### PR TITLE
Adds error notification, prevent unneeded changes

### DIFF
--- a/src/automators/onFileModifyAutomators/kanbanHelper.ts
+++ b/src/automators/onFileModifyAutomators/kanbanHelper.ts
@@ -1,4 +1,4 @@
-import type {CachedMetadata, LinkCache, TFile} from "obsidian";
+import {CachedMetadata, LinkCache, Notice, TFile} from "obsidian";
 import type MetaEdit from "../../main";
 import type {KanbanProperty} from "../../Types/kanbanProperty";
 import {abstractFileToMarkdownTFile} from "../../utility";
@@ -64,11 +64,16 @@ export class KanbanHelper extends OnFileModifyAutomator {
         }
         const targetProperty = fileProperties.find(prop => prop.key === board.property);
         if (!targetProperty) {
-            log.logWarning(`'${board.property} not found in ${board.boardName}'`)
+            log.logWarning(`'${board.property} not found in ${board.boardName} for file "${linkFile.name}".'`);
+            new Notice(`'${board.property} not found in ${board.boardName} for file "${linkFile.name}".'`); // This notice will help users debug "Property not found in board" errors.
             return;
         }
 
-        await this.plugin.controller.updatePropertyInFile(targetProperty, heading, linkFile);
+        const propertyHasChanged = (targetProperty.content != heading); // Kanban Helper will check if the file's property is different from its current heading in the kanban and will only make changes to the file if there's a difference
+        if (propertyHasChanged) {
+            console.debug("Updating " + targetProperty.key + " of file " + linkFile.name + " to " + heading);
+            await this.plugin.controller.updatePropertyInFile(targetProperty, heading, linkFile);
+        }
     }
 
     private getTaskHeading(targetTaskContent: string, fileContent: string): string | null {


### PR DESCRIPTION
This PR does two things:
1. Re: issue #45, this PR adds a user-facing notification to help users see which files are missing the YAML metadata property Kanban Helper is looking for.

2. Previously, if Kanban Helper was operating on a board, when a user changed a card, Kanban Helper would rewrite the metadata of every card on the board, even if there was no change to a linked file's metadata. This led to every file e.g., getting a new `date modified` on the file system. I've added a check, `const propertyHasChanged = (targetProperty.content != heading);`, which returns `true` if the linked file's metadata property has a value that is different from the one the user has changed it to. Kanban helper will therefore only run `updatePropertyInFile` if `propertyHasChanged` is true.

Thanks for a fantastic plugin! 