### PR TITLE
fix #45: only locate files that fully match the link name

### DIFF
--- a/src/automators/onFileModifyAutomators/kanbanHelper.ts
+++ b/src/automators/onFileModifyAutomators/kanbanHelper.ts
@@ -32,7 +32,7 @@ export class KanbanHelper extends OnFileModifyAutomator {
 
     private getLinkFile(link: LinkCache): TFile {
         const markdownFiles: TFile[] = this.app.vault.getMarkdownFiles();
-        return markdownFiles.find(f => f.path.includes(`\/${link.link}.md`));
+        return markdownFiles.find(f => f.path.endsWith(`/${link.link}.md`) || f.path === `${link.link}.md`);
     }
 
     private async updateFilesInBoard(links: LinkCache[], board: KanbanProperty, kanbanBoardFileContent: string) {

--- a/src/automators/onFileModifyAutomators/kanbanHelper.ts
+++ b/src/automators/onFileModifyAutomators/kanbanHelper.ts
@@ -32,7 +32,7 @@ export class KanbanHelper extends OnFileModifyAutomator {
 
     private getLinkFile(link: LinkCache): TFile {
         const markdownFiles: TFile[] = this.app.vault.getMarkdownFiles();
-        return markdownFiles.find(f => f.path.includes(`${link.link}.md`));
+        return markdownFiles.find(f => f.path.includes(`\/${link.link}.md`));
     }
 
     private async updateFilesInBoard(links: LinkCache[], board: KanbanProperty, kanbanBoardFileContent: string) {


### PR DESCRIPTION
Proposed fix for matching all files containing the string of the link. I've only lightly tested it in my own vault as I don't know how to properly do that in the repo.