### PR TITLE
Changes to accept every Dataview metadata format

### DIFF
--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -309,7 +309,7 @@ export default class MetaController {
 
         const newFileContent = fileContent.split("\n").map(line => {
             if (this.lineMatch(property, line)) {
-                return this.updatePropertyLine(property, newValue);
+                return this.updatePropertyLine(property, newValue, line);
             }
 
             return line;
@@ -319,7 +319,7 @@ export default class MetaController {
     }
 
     private lineMatch(property: Partial<Property>, line: string): boolean {
-        const propertyRegex = new RegExp(`^\s*${property.key}\:{1,2}`);
+        const propertyRegex = new RegExp(`\s*${property.key}\:{1,2}`);
         const tagRegex = new RegExp(`^\s*${property.key}`);
 
         if (property.key.contains('#')) {
@@ -329,11 +329,12 @@ export default class MetaController {
         return propertyRegex.test(line);
     }
 
-    private updatePropertyLine(property: Partial<Property>, newValue: string) {
+    private updatePropertyLine(property: Partial<Property>, newValue: string, line: string) {
         let newLine: string;
         switch (property.type) {
             case MetaType.Dataview:
-                newLine = `${property.key}:: ${newValue}`;
+                const propertyRegex = new RegExp(`${property.key}::\\s*([^\\)\\]\n\r]*)`, 'g');
+                newLine = line.replace(propertyRegex, `${property.key}:: ${newValue}`);
                 break;
             case MetaType.YAML:
                 newLine = `${property.key}: ${newValue}`;
@@ -367,7 +368,7 @@ export default class MetaController {
             fileContent = fileContent.map(line => {
 
                 if (this.lineMatch(prop, line)) {
-                    return this.updatePropertyLine(prop, prop.content)
+                    return this.updatePropertyLine(prop, prop.content, line)
                 }
 
                 return line;

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -318,9 +318,13 @@ export default class MetaController {
         await this.app.vault.modify(file, newFileContent);
     }
 
+    private escapeSpecialCharacters(text: string): string{
+        return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+    }
+
     private lineMatch(property: Partial<Property>, line: string): boolean {
-        const propertyRegex = new RegExp(`\s*${property.key}\:{1,2}`);
-        const tagRegex = new RegExp(`^\s*${property.key}`);
+        const propertyRegex = new RegExp(`${this.escapeSpecialCharacters(property.key)}\:{1,2}`);
+        const tagRegex = new RegExp(`^\s*${this.escapeSpecialCharacters(property.key)}`);
 
         if (property.key.contains('#')) {
             return tagRegex.test(line);
@@ -333,8 +337,8 @@ export default class MetaController {
         let newLine: string;
         switch (property.type) {
             case MetaType.Dataview:
-                const propertyRegex = new RegExp(`${property.key}::\\s*([^\\)\\]\n\r]*)`, 'g');
-                newLine = line.replace(propertyRegex, `${property.key}:: ${newValue}`);
+                const propertyRegex = new RegExp(`([\\(\\[]?)${this.escapeSpecialCharacters(property.key)}::[ ]*[^\\)\\]\n\r]*([\\]\\)]?)`, 'g');
+                newLine = line.replace(propertyRegex, `$1${property.key}:: ${newValue}$2`);
                 break;
             case MetaType.YAML:
                 newLine = `${property.key}: ${newValue}`;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -42,9 +42,9 @@ export default class MetaEditParser {
 
     public async parseInlineFields(file: TFile): Promise<Property[]> {
         const content = await this.app.vault.cachedRead(file);
-        const regex = /([^\n\r\(\[]*)::\s?([^\)\]\n\r]*)/g;
+        const regex = /[\[\(]?([^\n\r\(\[]*)::[ ]*([^\)\]\n\r]*)[\]\)]?/g;
         const properties: Property[] = [];
-    
+
         let match;
         while ((match = regex.exec(content)) !== null) {
             const key: string = match[1].trim();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -42,20 +42,18 @@ export default class MetaEditParser {
 
     public async parseInlineFields(file: TFile): Promise<Property[]> {
         const content = await this.app.vault.cachedRead(file);
-
-        return content.split("\n").reduce((obj: Property[], str: string) => {
-            let parts = str.split("::");
-
-            if (parts[0] && parts[1]) {
-                obj.push({key: parts[0], content: parts[1].trim(), type: MetaType.Dataview});
-            }
-            else if (str.includes("::")) {
-                const key: string = str.replace("::",'');
-                obj.push({key, content: "", type: MetaType.Dataview});
-            }
-
-            return obj;
-        },  []);
+        const regex = /([^\n\r\(\[]*)::\s?([^\)\]\n\r]*)/g;
+        const properties: Property[] = [];
+    
+        let match;
+        while ((match = regex.exec(content)) !== null) {
+            const key: string = match[1].trim();
+            const value: string = match[2].trim();
+    
+            properties.push({key, content: value, type: MetaType.Dataview});
+        }
+    
+        return properties;
     }
 
 }


### PR DESCRIPTION
Changes to also parse for "(field:: value)" and "[field:: value]",
as opposed to only "field:: value".