### PR TITLE
Fix update method duplicating square brackets with links

### DIFF
--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -337,7 +337,7 @@ export default class MetaController {
         let newLine: string;
         switch (property.type) {
             case MetaType.Dataview:
-                const propertyRegex = new RegExp(`([\\(\\[]?)${this.escapeSpecialCharacters(property.key)}::[ ]*[^\\)\\]\n\r]*([\\]\\)]?)`, 'g');
+                const propertyRegex = new RegExp(`([\\(\\[]?)${this.escapeSpecialCharacters(property.key)}::[ ]*[^\\)\\]\n\r]*(?:\\]\])?([\\]\\)]?)`, 'g');
                 newLine = line.replace(propertyRegex, `$1${property.key}:: ${newValue}$2`);
                 break;
             case MetaType.YAML:


### PR DESCRIPTION
Added small fix to regex, have only tested for my use case on local vault.

Addresses issue #95 