### PR TITLE
Support new and old frontmatter api

### DIFF
--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -316,8 +316,9 @@ export default class MetaController {
         // This uses the new frontmatter API to update the frontmatter. Later TODO: rewrite old logic to just do this & clean.
         if (property.type === MetaType.YAML) {
             const updatedMetaData = `---\n${this.updateYamlProperty(property, newValue, file)}\n---`;
+            const fileCache = this.app.metadataCache.getFileCache(file);
             //@ts-ignore
-            const frontmatterPosition = this.app.metadataCache.getFileCache(file).frontmatterPosition;
+            const frontmatterPosition = fileCache.frontmatterPosition ?? fileCache.frontmatter.position;
             const fileContents = await this.app.vault.read(file);
 
             const deleteFrom = frontmatterPosition.start.offset;

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -314,11 +314,11 @@ export default class MetaController {
     public async updatePropertyInFile(property: Partial<Property>, newValue: string, file: TFile): Promise<void> {
         // I'm aware this is hacky. Didn't want to spend a bunch of time rewriting old logic.
         // This uses the new frontmatter API to update the frontmatter. Later TODO: rewrite old logic to just do this & clean.
-        if (property.type === MetaType.YAML) {
+        //@ts-ignore
+        const frontmatterPosition = this.app.metadataCache.getFileCache(file).frontmatterPosition;
+
+        if (property.type === MetaType.YAML && frontmatterPosition) {
             const updatedMetaData = `---\n${this.updateYamlProperty(property, newValue, file)}\n---`;
-            const fileCache = this.app.metadataCache.getFileCache(file);
-            //@ts-ignore
-            const frontmatterPosition = fileCache.frontmatterPosition ?? fileCache.frontmatter.position;
             const fileContents = await this.app.vault.read(file);
 
             const deleteFrom = frontmatterPosition.start.offset;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -28,7 +28,7 @@ export default class MetaEditParser {
         if (!frontmatter) return [];
 
         //@ts-ignore - this is part of the new Obsidian API as of v1.4.1
-        const {start, end} = fileCache?.frontmatterPosition;
+        const {start, end} = fileCache?.frontmatterPosition ?? fileCache?.frontmatter?.position;
         const filecontent = await this.app.vault.cachedRead(file);
 
         const yamlContent: string = filecontent.split("\n").slice(start.line, end.line).join("\n");


### PR DESCRIPTION
The current implementation works fine in the desktop app, but the mobile app still uses the old api. I patched my local copy and this seems to work on both now.

Fixes #99