### PR TITLE
fix: harden frontmatter metadata writes

### DIFF
--- a/src/automators/onFileModifyAutomatorManager.ts
+++ b/src/automators/onFileModifyAutomatorManager.ts
@@ -59,8 +59,8 @@ export class OnFileModifyAutomatorManager implements IAutomatorManager {
 
         // Return on Excalidraw files to prevent conflict with its auto-save feature.
         const metadata = await this.app.metadataCache.getFileCache(outfile);
-        if (metadata.frontmatter != null) {  // Don't try to use frontmatter if it doesn't exist.
-            const keys = Object.keys(metadata?.frontmatter);
+        if (metadata?.frontmatter != null) {  // Don't try to use frontmatter if it doesn't exist.
+            const keys = Object.keys(metadata.frontmatter);
             if (keys && keys.some(key => key.toLowerCase().contains("excalidraw"))) {
                 return;
             }

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -9,8 +9,10 @@ import {ADD_FIRST_ELEMENT, ADD_TO_BEGINNING, ADD_TO_END} from "./constants";
 import type {ProgressProperty} from "./Types/progressProperty";
 import {ProgressPropertyOptions} from "./Types/progressPropertyOptions";
 import {MetaType} from "./Types/metaType";
-import {Notice, stringifyYaml} from "obsidian";
+import {Notice, normalizePath} from "obsidian";
 import {log} from "./logger/logManager";
+
+const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
 
 export default class MetaController {
     private parser: MetaEditParser;
@@ -35,34 +37,28 @@ export default class MetaController {
         return [...tags, ...yaml, ...inlineFields];
     }
 
-    public async addYamlProp(propName: string, propValue: string, file: TFile): Promise<void> {
-        const fileContent: string = await this.app.vault.read(file);
-        const frontmatter: Property[] = await this.parser.parseFrontmatter(file);
-        const isYamlEmpty: boolean = ((!frontmatter || frontmatter.length === 0) && !fileContent.match(/^-{3}\s*\n*\r*-{3}/));
-
-        if (frontmatter.some(value => value.key === propName)) {
-            new Notice(`Frontmatter in file '${file.name}' already has property '${propName}. Will not add.'`);
-            return;
-        }
-
+    public async addYamlProp(propName: string, propValue: unknown, file: TFile): Promise<void> {
         const settings = this.plugin.settings;
         if (settings.EditMode.mode === EditMode.AllMulti ||
             (settings.EditMode.mode === EditMode.SomeMulti && settings.EditMode.properties.contains(propName))) {
-            propValue = `[${propValue}]`;
+            propValue = [propValue];
         }
 
-        const splitContent = fileContent.split("\n");
-        if (isYamlEmpty) {
-            splitContent.unshift("---");
-            splitContent.unshift(`${propName}: ${propValue}`);
-            splitContent.unshift("---");
-        }
-        else {
-            splitContent.splice(1, 0, `${propName}: ${propValue}`);
-        }
+        let propertyExists = false;
+        await this.enqueueFileWrite(file, async () => {
+            await this.processFrontMatter(file, (frontmatter) => {
+                if (Object.prototype.hasOwnProperty.call(frontmatter, propName)) {
+                    propertyExists = true;
+                    return;
+                }
 
-        const newFileContent = splitContent.join("\n");
-        await this.app.vault.modify(file, newFileContent);
+                frontmatter[propName] = propValue;
+            });
+        });
+
+        if (propertyExists) {
+            new Notice(`Frontmatter in file '${file.name}' already has property '${propName}. Will not add.'`);
+        }
     }
 
     public async addDataviewField(propName: string, propValue: string, file: TFile): Promise<void> {
@@ -99,7 +95,7 @@ export default class MetaController {
         const splitTag: string[] = property.key.split("/");
         const allButLast: string = splitTag.slice(0, splitTag.length - 1).join("/");
         const trackerPluginMethod = "Use Tracker", metaEditMethod = "Use MetaEdit", choices = [trackerPluginMethod, metaEditMethod];
-        let newValue: string;
+        let newValue: string | string[];
         let method: string = metaEditMethod;
 
         if (this.hasTrackerPlugin)
@@ -215,7 +211,7 @@ export default class MetaController {
 
     private async multiValueMode(property: Property, file: TFile): Promise<boolean> {
         const settings: MetaEditSettings = this.plugin.settings;
-        let newValue: string;
+        let newValue: string | string[];
 
 
         if (settings.EditMode.mode == EditMode.SomeMulti && !settings.EditMode.properties.includes(property.key)) {
@@ -224,18 +220,7 @@ export default class MetaController {
         }
 
         let selectedOption: string, tempValue: string, splitValues: string[];
-        let currentPropValue: string = property.content;
-
-        if (currentPropValue !== null)
-            currentPropValue = currentPropValue.toString();
-        else
-            currentPropValue = "";
-
-        if (property.type === MetaType.YAML) {
-            splitValues = currentPropValue.split('').filter(c => !c.includes("[]")).join('').split(",");
-        } else {
-            splitValues = currentPropValue.split(",").map(prop => prop.trim());
-        }
+        splitValues = this.splitMultiValue(property);
 
         if (splitValues.length == 0 || (splitValues.length == 1 && splitValues[0] == "")) {
             const options = ["Add new value"];
@@ -274,16 +259,16 @@ export default class MetaController {
                 newValue = `${[...splitValues, tempValue].join(", ")}`;
                 break;
             default:
-                if (selectedIndex)
+                if (selectedIndex !== -1)
                     splitValues[selectedIndex] = tempValue;
                 else
                     splitValues = [tempValue];
-                newValue = `${splitValues.join(", ")}`;
+                newValue = splitValues.join(", ");
                 break;
         }
 
         if (property.type === MetaType.YAML)
-            newValue = `[${newValue}]`;
+            newValue = this.splitMultiValue({...property, content: newValue});
 
         if (newValue) {
             await this.updatePropertyInFile(property, newValue, file);
@@ -304,41 +289,29 @@ export default class MetaController {
         return null;
     }
 
-    private updateYamlProperty(property: Partial<Property>, newValue: string, file: TFile): string {
-        const fileCache = this.app.metadataCache.getFileCache(file);
-        const frontMatter = fileCache.frontmatter;
-        frontMatter[property.key] = newValue;
-        return stringifyYaml(frontMatter);
-    }
+    public async updatePropertyInFile(property: Partial<Property>, newValue: unknown, file: TFile): Promise<void> {
+        if (!property.key) return;
 
-    public async updatePropertyInFile(property: Partial<Property>, newValue: string, file: TFile): Promise<void> {
-        // I'm aware this is hacky. Didn't want to spend a bunch of time rewriting old logic.
-        // This uses the new frontmatter API to update the frontmatter. Later TODO: rewrite old logic to just do this & clean.
-        if (property.type === MetaType.YAML) {
-            const updatedMetaData = `---\n${this.updateYamlProperty(property, newValue, file)}\n---`;
-            const frontmatterPosition = this.app.metadataCache.getFileCache(file).frontmatterPosition;
-            const fileContents = await this.app.vault.read(file);
-
-            const deleteFrom = frontmatterPosition.start.offset;
-            const deleteTo = frontmatterPosition.end.offset;
-
-            const newFileContents = fileContents.substring(0, deleteFrom) + updatedMetaData + fileContents.substring(deleteTo);
-
-            await this.app.vault.modify(file, newFileContents);
-            return;
-        }
-
-        const fileContent = await this.app.vault.read(file);
-
-        const newFileContent = fileContent.split("\n").map(line => {
-            if (this.lineMatch(property, line)) {
-                return this.updatePropertyLine(property, newValue, line);
+        await this.enqueueFileWrite(file, async () => {
+            if (property.type === MetaType.YAML) {
+                await this.processFrontMatter(file, (frontmatter) => {
+                    frontmatter[property.key] = newValue;
+                });
+                return;
             }
 
-            return line;
-        }).join("\n");
+            const fileContent = await this.app.vault.read(file);
 
-        await this.app.vault.modify(file, newFileContent);
+            const newFileContent = fileContent.split("\n").map(line => {
+                if (this.lineMatch(property, line)) {
+                    return this.updatePropertyLine(property, newValue, line);
+                }
+
+                return line;
+            }).join("\n");
+
+            await this.app.vault.modify(file, newFileContent);
+        });
     }
 
     private escapeSpecialCharacters(text: string): string{
@@ -346,22 +319,29 @@ export default class MetaController {
     }
 
     private lineMatch(property: Partial<Property>, line: string): boolean {
-        const propertyRegex = new RegExp(`${this.escapeSpecialCharacters(property.key)}\:{1,2}`);
+        if (!property.key) return false;
+
         const tagRegex = new RegExp(`^\s*${this.escapeSpecialCharacters(property.key)}`);
 
         if (property.key.contains('#')) {
             return tagRegex.test(line);
         }
 
+        if (property.type === MetaType.Dataview) {
+            return this.dataviewPropertyRegex(property.key).test(line);
+        }
+
+        const propertyRegex = new RegExp(`^\\s*${this.escapeSpecialCharacters(property.key)}\\s*:`);
         return propertyRegex.test(line);
     }
 
-    private updatePropertyLine(property: Partial<Property>, newValue: string, line: string) {
+    private updatePropertyLine(property: Partial<Property>, newValue: unknown, line: string) {
+        if (!property.key) return line;
+
         let newLine: string;
         switch (property.type) {
             case MetaType.Dataview:
-                const propertyRegex = new RegExp(`([\\(\\[]?)${this.escapeSpecialCharacters(property.key)}::[ ]*[^\\)\\]\n\r]*(?:\\]\])?([\\]\\)]?)`, 'g');
-                newLine = line.replace(propertyRegex, `$1${property.key}:: ${newValue}$2`);
+                newLine = line.replace(this.dataviewPropertyRegex(property.key), `$1${property.key}:: ${newValue}$4`);
                 break;
             case MetaType.YAML:
                 newLine = `${property.key}: ${newValue}`;
@@ -389,20 +369,77 @@ export default class MetaController {
     }
 
     private async updateMultipleInFile(properties: Property[], file: TFile): Promise<void> {
-        let fileContent = (await this.app.vault.read(file)).split("\n");
+        await this.enqueueFileWrite(file, async () => {
+            const yamlProperties = properties.filter(prop => prop.type === MetaType.YAML);
+            const textProperties = properties.filter(prop => prop.type !== MetaType.YAML);
 
-        for (const prop of properties) {
-            fileContent = fileContent.map(line => {
+            if (yamlProperties.length > 0) {
+                await this.processFrontMatter(file, (frontmatter) => {
+                    for (const prop of yamlProperties) {
+                        frontmatter[prop.key] = prop.content;
+                    }
+                });
+            }
 
-                if (this.lineMatch(prop, line)) {
-                    return this.updatePropertyLine(prop, prop.content, line)
-                }
+            if (textProperties.length === 0) return;
 
-                return line;
-            });
+            let fileContent = (await this.app.vault.read(file)).split("\n");
+
+            for (const prop of textProperties) {
+                fileContent = fileContent.map(line => {
+
+                    if (this.lineMatch(prop, line)) {
+                        return this.updatePropertyLine(prop, prop.content, line)
+                    }
+
+                    return line;
+                });
+            }
+            const newFileContent = fileContent.join("\n");
+
+            await this.app.vault.modify(file, newFileContent);
+        });
+    }
+
+    private dataviewPropertyRegex(propertyKey: string): RegExp {
+        return new RegExp(`(^|[\\s\\[\\(])(${this.escapeSpecialCharacters(propertyKey)})::[ ]*([^\\)\\]\\n\\r]*)(\\]\\]|[\\]\\)]?)`, "g");
+    }
+
+    private splitMultiValue(property: Partial<Property>): string[] {
+        const content = property.content;
+
+        if (Array.isArray(content)) {
+            return content.map(prop => prop?.toString().trim() ?? "").filter(Boolean);
         }
-        const newFileContent = fileContent.join("\n");
 
-        await this.app.vault.modify(file, newFileContent);
+        if (content === null || content === undefined) return [];
+
+        return content.toString()
+            .replace(/^\s*\[/, "")
+            .replace(/\]\s*$/, "")
+            .split(",")
+            .map(prop => prop.trim())
+            .filter(Boolean);
+    }
+
+    private async processFrontMatter(file: TFile, update: (frontmatter: Record<string, unknown>) => void): Promise<void> {
+        await this.app.fileManager.processFrontMatter(file, update);
+    }
+
+    private async enqueueFileWrite<T>(file: TFile, task: () => Promise<T>): Promise<T> {
+        const key = normalizePath(file.path);
+        const previous = fileWriteQueues.get(key) ?? Promise.resolve();
+        const queued = previous.catch(() => undefined).then(task);
+
+        fileWriteQueues.set(key, queued);
+
+        try {
+            return await queued;
+        }
+        finally {
+            if (fileWriteQueues.get(key) === queued) {
+                fileWriteQueues.delete(key);
+            }
+        }
     }
 }

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it, vi} from "vitest";
+import {TFile} from "obsidian";
+import MetaEditParser from "./parser";
+import {MetaType} from "./Types/metaType";
+
+const createParser = (cache: unknown, content: string): MetaEditParser => {
+    const app = {
+        metadataCache: {
+            getFileCache: vi.fn().mockReturnValue(cache),
+        },
+        vault: {
+            cachedRead: vi.fn().mockResolvedValue(content),
+        },
+    };
+
+    return new MetaEditParser(app as any);
+};
+
+describe("MetaEditParser frontmatter parsing", () => {
+    it("uses legacy frontmatter.position when frontmatterPosition is missing", async () => {
+        const file = new TFile("legacy.md");
+        const parser = createParser(
+            {
+                frontmatter: {
+                    position: {
+                        start: {line: 0, col: 0, offset: 0},
+                        end: {line: 2, col: 3, offset: 18},
+                    },
+                },
+            },
+            "---\nstatus: live\n---\nBody\n",
+        );
+
+        await expect(parser.parseFrontmatter(file)).resolves.toEqual([
+            {key: "status", content: "live", type: MetaType.YAML},
+        ]);
+    });
+
+    it("falls back to cached frontmatter entries when no position metadata exists", async () => {
+        const file = new TFile("cache-only.md");
+        const parser = createParser(
+            {
+                frontmatter: {
+                    status: "cached",
+                    tags: ["a", "b"],
+                },
+            },
+            "",
+        );
+
+        await expect(parser.parseFrontmatter(file)).resolves.toEqual([
+            {key: "status", content: "cached", type: MetaType.YAML},
+            {key: "tags", content: ["a", "b"], type: MetaType.YAML},
+        ]);
+    });
+});
+
+describe("MetaEditParser inline field parsing", () => {
+    it("parses exact inline keys that contain regex metacharacters", async () => {
+        const file = new TFile("inline.md");
+        const parser = createParser(
+            {},
+            "progress (%):: old\n[[my-key:: value]]\n(status:: complete)\n",
+        );
+
+        await expect(parser.parseInlineFields(file)).resolves.toEqual([
+            {key: "progress (%)", content: "old", type: MetaType.Dataview},
+            {key: "my-key", content: "value", type: MetaType.Dataview},
+            {key: "status", content: "complete", type: MetaType.Dataview},
+        ]);
+    });
+});

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,8 +1,9 @@
-import type {App, TFile} from "obsidian";
+import type {App, CachedMetadata, Loc, TFile} from "obsidian";
 import {parseYaml} from "obsidian";
 import {MetaType} from "./Types/metaType";
 
 export type Property = {key: string, content: any, type: MetaType};
+type FrontmatterPosition = {start: Loc, end: Loc};
 
 export default class MetaEditParser {
     private app: App;
@@ -27,15 +28,53 @@ export default class MetaEditParser {
         const frontmatter = fileCache?.frontmatter;
         if (!frontmatter) return [];
 
-        const {start, end} = fileCache?.frontmatterPosition;
-        const filecontent = await this.app.vault.cachedRead(file);
+        const frontmatterPosition = this.getFrontmatterPosition(fileCache);
+        if (!frontmatterPosition) {
+            return this.objectToYamlProperties(frontmatter, true);
+        }
 
+        const {start, end} = frontmatterPosition;
+        const filecontent = await this.app.vault.cachedRead(file);
         const yamlContent: string = filecontent.split("\n").slice(start.line, end.line).join("\n");
         const parsedYaml = parseYaml(yamlContent);
+
+        return this.objectToYamlProperties(parsedYaml);
+    }
+
+    private getFrontmatterPosition(fileCache: CachedMetadata): FrontmatterPosition | null {
+        const frontmatterPosition = fileCache.frontmatterPosition;
+        if (this.isFrontmatterPosition(frontmatterPosition)) return frontmatterPosition;
+
+        const legacyPosition = fileCache.frontmatter?.position;
+        if (this.isFrontmatterPosition(legacyPosition)) return legacyPosition;
+
+        return null;
+    }
+
+    private isFrontmatterPosition(position: unknown): position is FrontmatterPosition {
+        if (!position || typeof position !== "object") return false;
+
+        const candidate = position as Partial<FrontmatterPosition>;
+        return this.isPosition(candidate.start) && this.isPosition(candidate.end);
+    }
+
+    private isPosition(position: unknown): position is Loc {
+        if (!position || typeof position !== "object") return false;
+
+        const candidate = position as Partial<Loc>;
+        return typeof candidate.line === "number" &&
+            typeof candidate.col === "number" &&
+            typeof candidate.offset === "number";
+    }
+
+    private objectToYamlProperties(parsedYaml: Record<string, unknown>, omitInternalPosition: boolean = false): Property[] {
+        if (!parsedYaml) return [];
 
         const metaYaml: Property[] = [];
 
         for (const key in parsedYaml) {
+            if (omitInternalPosition && key === "position" && this.isFrontmatterPosition(parsedYaml[key])) continue;
+
             metaYaml.push({key, content: parsedYaml[key], type: MetaType.YAML});
         }
 
@@ -44,7 +83,7 @@ export default class MetaEditParser {
 
     public async parseInlineFields(file: TFile): Promise<Property[]> {
         const content = await this.app.vault.cachedRead(file);
-        const regex = /[\[\(]?([^\n\r\(\[]*)::[ ]*([^\)\]\n\r]*)[\]\)]?/g;
+        const regex = /(?:\[\[|[\[\(]|^)([^\n\r\[\]]*?)::[ ]*([^\)\]\n\r]*)(?:\]\]|[\]\)])?/gm;
         const properties: Property[] = [];
 
         let match;

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -41,10 +41,7 @@ describe("MetaEdit runtime", () => {
 		const { obsidian, sandbox } = getContext();
 
 		const notePath = sandbox.path("note.md");
-		await sandbox.write("note.md", "# Note\n\nBody text.\n", {
-			waitForContent: true,
-			waitOptions: WAIT_OPTS,
-		});
+		await writeLiveFile(obsidian, notePath, "# Note\n\nBody text.\n");
 
 		// createYamlProperty adds a brand-new frontmatter key to the file.
 		await callApi(obsidian, "createYamlProperty", [
@@ -86,6 +83,208 @@ describe("MetaEdit runtime", () => {
 
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
+
+	test("updates YAML frontmatter through sequential API calls without corrupting fences", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("sequential-frontmatter.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nstatus: backlog\nstarted: old\nlastRead: old\nupdated: old\n---\n# Book\n",
+		);
+
+		await callApi(obsidian, "update", ["status", "reading", notePath]);
+		await callApi(obsidian, "update", ["started", "2026-06-27", notePath]);
+		await callApi(obsidian, "update", [
+			"lastRead",
+			"2026-06-27T12:00:00",
+			notePath,
+		]);
+		await callApi(obsidian, "update", [
+			"updated",
+			"2026-06-27T12:00:00",
+			notePath,
+		]);
+
+		const content = await sandbox.waitForContent(
+			"sequential-frontmatter.md",
+			(value) =>
+				value.includes("status: reading") &&
+				value.includes("started: 2026-06-27") &&
+				value.includes("lastRead: 2026-06-27T12:00:00") &&
+				value.includes("updated: 2026-06-27T12:00:00"),
+			WAIT_OPTS,
+		);
+
+		expect(content).toContain("---\n# Book");
+		expect(content).not.toContain("----");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("serializes concurrent YAML property creation for one file", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("concurrent-create.md");
+		await writeLiveFile(obsidian, notePath, "Note Content\n");
+
+		await evalJsonAsync<void>(
+			obsidian,
+			`
+			(async () => {
+				const api = app.plugins.plugins.${PLUGIN_ID}?.api;
+				if (!api) throw new Error("MetaEdit API is not available.");
+				const notePath = ${JSON.stringify(notePath)};
+				await Promise.all([
+					api.createYamlProperty("AB", "1", notePath),
+					api.createYamlProperty("BB", "1", notePath),
+					api.createYamlProperty("CB", "1", notePath),
+				]);
+			})()
+		`,
+		);
+
+		const content = await sandbox.waitForContent(
+			"concurrent-create.md",
+			(value) =>
+				value.includes("AB:") &&
+				value.includes("BB:") &&
+				value.includes("CB:"),
+			WAIT_OPTS,
+		);
+
+		expect(content.match(/^---$/gm)).toHaveLength(2);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("updates only the exact inline field key", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("inline-substring.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"airingstatus:: airing\nstatus:: backlog\nmy-key:: old\nprogress (%):: old\n",
+		);
+
+		await callApi(obsidian, "update", ["status", "complete", notePath]);
+		await callApi(obsidian, "update", ["my-key", "new", notePath]);
+		await callApi(obsidian, "update", ["progress (%)", "done", notePath]);
+
+		const content = await sandbox.waitForContent(
+			"inline-substring.md",
+			(value) =>
+				value.includes("status:: complete") &&
+				value.includes("my-key:: new") &&
+				value.includes("progress (%):: done"),
+			WAIT_OPTS,
+		);
+
+		expect(content).toContain("airingstatus:: airing");
+		expect(content).toContain("status:: complete");
+		expect(content).toContain("my-key:: new");
+		expect(content).toContain("progress (%):: done");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("preserves the rest of an inline multi-value list when editing the first item", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("first-inline-item.md");
+		await writeLiveFile(obsidian, notePath, "Tags:: #a, #B, #c, #d\n");
+
+		const content = await evalJsonAsync<string>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+				const originalMode = plugin.settings.EditMode.mode;
+				plugin.settings.EditMode.mode = "All Multi";
+
+				try {
+					const props = await plugin.controller.getPropertiesInFile(file);
+					const property = props.find((prop) => prop.key === "Tags");
+					if (!property) throw new Error("Tags property was not parsed.");
+
+					const editPromise = plugin.controller.multiValueMode(property, file);
+					const waitFor = async (selector, predicate = () => true) => {
+						const start = Date.now();
+						while (Date.now() - start < 5000) {
+							const found = Array.from(document.querySelectorAll(selector)).find(predicate);
+							if (found) return found;
+							await sleep(100);
+						}
+						throw new Error("Timed out waiting for " + selector);
+					};
+
+					const firstItem = await waitFor(
+						".suggestion-item",
+						(el) => el.textContent?.trim() === "#a",
+					);
+					firstItem.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+					firstItem.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+					firstItem.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+					const input = await waitFor(".metaEditPromptInput");
+					input.value = "#A";
+					input.dispatchEvent(new Event("input", { bubbles: true }));
+					input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+					await editPromise;
+					await sleep(300);
+
+					return await app.vault.read(file);
+				}
+				finally {
+					plugin.settings.EditMode.mode = originalMode;
+				}
+			})()
+		`,
+		);
+
+		expect(content).toBe("Tags:: #A, #B, #c, #d\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("progress properties update YAML without rewriting matching body text", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("progress-body.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nreadProgress: 0\n---\n# Tasks\n- [ ] one\n- [x] two\nBody line should stay literal: readProgress: 0\n",
+		);
+
+		const content = await evalJsonAsync<string>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				plugin.settings.ProgressProperties.enabled = true;
+				plugin.settings.ProgressProperties.properties = [{ name: "readProgress", type: "Total Tasks" }];
+				const props = await plugin.controller.getPropertiesInFile(file);
+
+				try {
+					await plugin.controller.handleProgressProps(props, file);
+					await new Promise((resolve) => setTimeout(resolve, 300));
+					return await app.vault.read(file);
+				}
+				finally {
+					plugin.settings.ProgressProperties.enabled = false;
+					plugin.settings.ProgressProperties.properties = [];
+				}
+			})()
+		`,
+		);
+
+		expect(content).toMatch(/readProgress: "?2"?/);
+		expect(content).toContain("Body line should stay literal: readProgress: 0");
+		expect(content).not.toContain("Body line should stay literal: readProgress: 2");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
 });
 
 // Invoke a MetaEdit public-API method inside the running app and return its
@@ -102,6 +301,35 @@ async function callApi<T = unknown>(
 			const api = app.plugins.plugins.${PLUGIN_ID}?.api;
 			if (!api) throw new Error("MetaEdit API is not available.");
 			return await api[${JSON.stringify(method)}](...${JSON.stringify(args)});
+		})()
+	`,
+	);
+}
+
+async function writeLiveFile(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	path: string,
+	content: string,
+): Promise<void> {
+	await evalJsonAsync<void>(
+		obsidian,
+		`
+		(async () => {
+			const path = ${JSON.stringify(path)};
+			const content = ${JSON.stringify(content)};
+			const parts = path.split("/");
+			let current = "";
+			for (const part of parts.slice(0, -1)) {
+				current = current ? current + "/" + part : part;
+				if (!app.vault.getAbstractFileByPath(current)) {
+					await app.vault.createFolder(current);
+				}
+			}
+
+			const existing = app.vault.getAbstractFileByPath(path);
+			if (existing) await app.vault.delete(existing);
+			await app.vault.create(path, content);
+			await new Promise((resolve) => setTimeout(resolve, 500));
 		})()
 	`,
 	);

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -61,3 +61,33 @@ export function getLinkpath(linktext: string): string {
 
   return cutIndex === -1 ? linktext : linktext.slice(0, cutIndex);
 }
+
+export function parseYaml(yaml: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const lines = yaml.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed === "---") continue;
+
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const rawValue = trimmed.slice(separatorIndex + 1).trim();
+    if (!key) continue;
+
+    if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+      result[key] = rawValue
+        .slice(1, -1)
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+      continue;
+    }
+
+    result[key] = rawValue;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Replace MetaEdit's frontmatter write path with Obsidian's `app.fileManager.processFrontMatter` and serialize metadata writes per file. This removes the raw `frontmatterPosition` substring replacement path that could corrupt fences, drop sequential updates, and bypass Obsidian's frontmatter/cache invalidation behavior.

What changed:
- YAML add/update/update-multiple operations now mutate frontmatter through `processFrontMatter` behind a shared per-file write queue.
- Inline `key:: value` updates still use text editing, but now match exact Dataview keys so `status` no longer updates `airingstatus`; keys with characters like `progress (%)` are covered.
- Multi-value editing now handles index `0` correctly and writes YAML multi-values as arrays instead of bracket-shaped strings.
- Frontmatter parsing accepts both `frontmatterPosition` and legacy `frontmatter.position`, carrying forward the compatibility intent from #100 without keeping the raw write path.
- The modify automator now ignores null metadata cache entries instead of throwing on ordinary file changes.

Tradeoff: `processFrontMatter` lets Obsidian own YAML serialization. That is the right robustness/cache-invalidation boundary, but it can normalize YAML formatting, quoting, flow-vs-block style, and comments in the frontmatter block. This PR chooses safe Obsidian-managed writes over preserving the previous hand-spliced formatting behavior.

This supersedes #100. Credit to @xt0rted for the original frontmatter-position compatibility investigation; this keeps that parsing compatibility but replaces the write strategy entirely.

Validation performed in this worktree's isolated vault (`metaedit-89-frontmatter-core`):
- Reproduced current failures before the fix: sequential YAML updates corrupted the closing fence and dropped later properties (#83), inline `status` changed `airingstatus` (#98), concurrent `createYamlProperty` lost writes (#73), first inline multi-value item edit collapsed the list (#81), Progress Properties rewrote matching body text (#108), and no-frontmatter modifies emitted the #72/#88 TypeError.
- After the fix, live validation passed for #89, #72, #83, #98, #88, #36, #42, #81, #108, #73, and the Kanban helper/cache path from #114. `dev:errors` reported no errors after validation.

Commands run:
- `pnpm install`
- `pnpm run lint` (passes with existing warnings outside this change)
- `pnpm run build`
- `pnpm run test`
- `pnpm run test:e2e` against the isolated Obsidian instance
- `pnpm run obsidian:e2e -- ...` live repro/proof scripts in the isolated vault

Fixes #89.
Refs #72, #83, #98, #88, #36, #42, #81, #108, #73, #114.
Supersedes #100.