### PR TITLE
feat(api): expand public integration surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This is an asynchronous function, so you should `await` it.
 
 `update` changes an existing property. If you want to create the property when it is missing, use `addOrUpdateProperty`.
 
+When updating inline Dataview fields, non-string values are stringified. YAML frontmatter properties can preserve richer YAML values such as numbers, booleans, arrays, and objects.
+
 ### `createYamlProperty(propertyName: string, propertyValue: unknown, file: TFile | string)`
 Creates a YAML frontmatter property in the given file.
 
@@ -64,11 +66,6 @@ This is an asynchronous function, so you should `await` it.
 
 ### `addOrUpdateProperty(propertyName: string, propertyValue: unknown, file: TFile | string)`
 Updates an existing property with the given name, or creates a YAML frontmatter property when the property does not exist.
-
-This is an asynchronous function, so you should `await` it.
-
-### `deleteProperty(propertyName: string, file: TFile | string)`
-Deletes the first matching YAML frontmatter property or inline Dataview field with the given name.
 
 This is an asynchronous function, so you should `await` it.
 
@@ -95,7 +92,7 @@ The returned array is a copy, so mutating it will not change MetaEdit settings. 
 ### `setAutoProperties(autoProperties: AutoProperty[])`
 Replaces MetaEdit's configured Auto Properties and saves settings.
 
-Each Auto Property must have a unique non-empty `name` and a `choices` array of strings.
+Each Auto Property must have a string `name` and a `choices` array of strings.
 
 This is an asynchronous function, so you should `await` it.
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,29 @@ Returns the selected value. If no value was selected, or if the property was not
 
 This is an asynchronous function, so you should `await` it.
 
-### `update(propertyName: string, propertyValue: string, file: TFile | string)`
+### `update(propertyName: string, propertyValue: unknown, file: TFile | string)`
 Updates a property with the given name to the given value in the given file.
 
 If the file is a string, it should be the file path. Otherwise, a `TFile` is fine.
+
+This is an asynchronous function, so you should `await` it.
+
+`update` changes an existing property. If you want to create the property when it is missing, use `addOrUpdateProperty`.
+
+### `createYamlProperty(propertyName: string, propertyValue: unknown, file: TFile | string)`
+Creates a YAML frontmatter property in the given file.
+
+If the file already has a property with the same name, MetaEdit leaves it unchanged.
+
+This is an asynchronous function, so you should `await` it.
+
+### `addOrUpdateProperty(propertyName: string, propertyValue: unknown, file: TFile | string)`
+Updates an existing property with the given name, or creates a YAML frontmatter property when the property does not exist.
+
+This is an asynchronous function, so you should `await` it.
+
+### `deleteProperty(propertyName: string, file: TFile | string)`
+Deletes the first matching YAML frontmatter property or inline Dataview field with the given name.
 
 This is an asynchronous function, so you should `await` it.
 
@@ -59,6 +78,43 @@ Gets the value of the given property in the given file.
 If the file is a string, it should be the file path. Otherwise, a `TFile` is fine.
 
 This is an asynchronous function, so you should `await` it.
+
+### `getPropertiesInFile(file: TFile | string)`
+Gets all metadata properties MetaEdit can read from the given file, including tags, YAML frontmatter properties, and inline Dataview fields.
+
+This is an asynchronous function, so you should `await` it.
+
+### `getFilesWithProperty(propertyName: string)`
+Gets all markdown files with a YAML frontmatter property matching the given name.
+
+### `getAutoProperties()`
+Gets a copy of MetaEdit's configured Auto Properties.
+
+The returned array is a copy, so mutating it will not change MetaEdit settings. Use `setAutoProperties` to save changes.
+
+### `setAutoProperties(autoProperties: AutoProperty[])`
+Replaces MetaEdit's configured Auto Properties and saves settings.
+
+Each Auto Property must have a unique non-empty `name` and a `choices` array of strings.
+
+This is an asynchronous function, so you should `await` it.
+
+### `onMetadataChange(callback)`
+Registers a metadata-change listener and returns an unsubscribe function.
+
+The callback receives `{ file, data, cache, properties, previousProperties }`. `properties` contains the current properties parsed by MetaEdit for the file. `previousProperties` contains the last property snapshot emitted by this subscription for that file, or `null` when no previous snapshot is available.
+
+MetaEdit does not classify changes as add, rename, value change, or remove, because Obsidian's metadata event does not provide a stable semantic diff. Compare `previousProperties` and `properties` in your callback when you need that detail.
+
+Call the returned function when your plugin unloads, or register it with Obsidian's cleanup system:
+
+```js
+const unsubscribe = app.plugins.plugins["metaedit"].api.onMetadataChange((change) => {
+    console.log(change.file.path, change.properties);
+});
+
+this.register(unsubscribe);
+```
 
 ### API Examples
 #### New Task template (requires [Templater](https://github.com/SilentVoid13/Templater))

--- a/src/IMetaEditApi.ts
+++ b/src/IMetaEditApi.ts
@@ -1,12 +1,15 @@
 import type {TFile} from "obsidian";
 import type {Property} from "./parser";
 
+export type MetaEditPropertyValue = unknown;
+
 export interface IMetaEditApi {
-    autoprop: (propertyName: string) => void;
-    update: (propertyName: string, propertyValue: string, file: TFile | string) => Promise<void>;
+    autoprop: (propertyName: string) => Promise<string | null>;
+    update: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
     getPropertyValue: (propertyName: string, file: (TFile | string)) => Promise<any>;
     getFilesWithProperty: (propertyName: string) => TFile[];
-    createYamlProperty: (propertyName: string, propertyValue: string, file: TFile | string) => Promise<void>;
+    createYamlProperty: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
+    addOrUpdateProperty: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
+    deleteProperty: (propertyName: string, file: TFile | string) => Promise<void>;
     getPropertiesInFile: (file: TFile | string) => Promise<Property[]>;
 }
-

--- a/src/IMetaEditApi.ts
+++ b/src/IMetaEditApi.ts
@@ -1,8 +1,19 @@
-import type {TFile} from "obsidian";
+import type {CachedMetadata, TFile} from "obsidian";
 import type {Property} from "./parser";
 import type {AutoProperty} from "./Types/autoProperty";
 
 export type MetaEditPropertyValue = unknown;
+export type MetaEditUnsubscribe = () => void;
+
+export interface MetaEditMetadataChange {
+    file: TFile;
+    data: string;
+    cache: CachedMetadata;
+    properties: Property[];
+    previousProperties: Property[] | null;
+}
+
+export type MetaEditMetadataChangeCallback = (change: MetaEditMetadataChange) => void | Promise<void>;
 
 export interface IMetaEditApi {
     autoprop: (propertyName: string) => Promise<string | null>;
@@ -15,4 +26,5 @@ export interface IMetaEditApi {
     getPropertiesInFile: (file: TFile | string) => Promise<Property[]>;
     getAutoProperties: () => AutoProperty[];
     setAutoProperties: (autoProperties: AutoProperty[]) => Promise<void>;
+    onMetadataChange: (callback: MetaEditMetadataChangeCallback) => MetaEditUnsubscribe;
 }

--- a/src/IMetaEditApi.ts
+++ b/src/IMetaEditApi.ts
@@ -1,5 +1,6 @@
 import type {TFile} from "obsidian";
 import type {Property} from "./parser";
+import type {AutoProperty} from "./Types/autoProperty";
 
 export type MetaEditPropertyValue = unknown;
 
@@ -12,4 +13,6 @@ export interface IMetaEditApi {
     addOrUpdateProperty: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
     deleteProperty: (propertyName: string, file: TFile | string) => Promise<void>;
     getPropertiesInFile: (file: TFile | string) => Promise<Property[]>;
+    getAutoProperties: () => AutoProperty[];
+    setAutoProperties: (autoProperties: AutoProperty[]) => Promise<void>;
 }

--- a/src/IMetaEditApi.ts
+++ b/src/IMetaEditApi.ts
@@ -22,7 +22,6 @@ export interface IMetaEditApi {
     getFilesWithProperty: (propertyName: string) => TFile[];
     createYamlProperty: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
     addOrUpdateProperty: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
-    deleteProperty: (propertyName: string, file: TFile | string) => Promise<void>;
     getPropertiesInFile: (file: TFile | string) => Promise<Property[]>;
     getAutoProperties: () => AutoProperty[];
     setAutoProperties: (autoProperties: AutoProperty[]) => Promise<void>;

--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -1,8 +1,8 @@
 import type MetaEdit from "./main";
-import MetaController from "./metaController";
-import type {IMetaEditApi} from "./IMetaEditApi";
+import type {IMetaEditApi, MetaEditPropertyValue} from "./IMetaEditApi";
 import type {Property} from "./parser";
 import {TFile} from "obsidian";
+import {MetaType} from "./Types/metaType";
 
 export class MetaEditApi {
     constructor(private plugin: MetaEdit) {
@@ -15,26 +15,25 @@ export class MetaEditApi {
             getPropertyValue: this.getGetPropertyValueFunction(),
             getFilesWithProperty: this.getGetFilesWithPropertyFunction(),
             createYamlProperty: this.getCreateYamlPropertyFunction(),
+            addOrUpdateProperty: this.getAddOrUpdatePropertyFunction(),
+            deleteProperty: this.getDeletePropertyFunction(),
             getPropertiesInFile: this.getGetPropertiesInFile(),
         };
     }
 
     private getAutopropFunction() {
-        return (propertyName: string) => new MetaController(this.plugin.app, this.plugin).handleAutoProperties(propertyName);
+        return (propertyName: string) => this.plugin.controller.handleAutoProperties(propertyName);
      }
 
-    private getUpdateFunction(): (propertyName: string, propertyValue: string, file: (TFile | string)) => Promise<undefined | void> {
-        return async (propertyName: string, propertyValue: string, file: TFile | string) => {
+    private getUpdateFunction(): (propertyName: string, propertyValue: MetaEditPropertyValue, file: (TFile | string)) => Promise<undefined | void> {
+        return async (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => {
             const targetFile = this.getFileFromTFileOrPath(file);
             if (!targetFile) return;
 
-            const controller: MetaController = new MetaController(this.plugin.app, this.plugin);
-            const propsInFile: Property[] = await controller.getPropertiesInFile(targetFile);
-
-            const targetProperty = propsInFile.find(prop => prop.key === propertyName);
+            const targetProperty = await this.getPropertyInFile(propertyName, targetFile);
             if (!targetProperty) return;
 
-            return controller.updatePropertyInFile(targetProperty, propertyValue, targetFile);
+            return this.plugin.controller.updatePropertyInFile(targetProperty, propertyValue, targetFile);
         }
     }
 
@@ -59,10 +58,7 @@ export class MetaEditApi {
             const targetFile = this.getFileFromTFileOrPath(file);
             if (!targetFile) return;
 
-            const controller: MetaController = new MetaController(this.plugin.app, this.plugin);
-            const propsInFile: Property[] = await controller.getPropertiesInFile(targetFile);
-
-            const targetProperty = propsInFile.find(prop => prop.key === propertyName);
+            const targetProperty = await this.getPropertyInFile(propertyName, targetFile);
             if (!targetProperty) return;
 
             return targetProperty.content;
@@ -76,12 +72,47 @@ export class MetaEditApi {
     }
 
     private getCreateYamlPropertyFunction() {
-        return async (propertyName: string, propertyValue: string, file: TFile | string) => {
+        return async (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => {
             const targetFile = this.getFileFromTFileOrPath(file);
             if (!targetFile) return;
 
-            const controller: MetaController = new MetaController(this.plugin.app, this.plugin);
-            await controller.addYamlProp(propertyName, propertyValue, targetFile);
+            await this.plugin.controller.addYamlProp(propertyName, propertyValue, targetFile);
+        }
+    }
+
+    private getAddOrUpdatePropertyFunction() {
+        return async (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => {
+            const targetFile = this.getFileFromTFileOrPath(file);
+            if (!targetFile) return;
+
+            const targetProperty = await this.getPropertyInFile(propertyName, targetFile);
+            if (targetProperty) {
+                await this.plugin.controller.updatePropertyInFile(targetProperty, propertyValue, targetFile);
+                return;
+            }
+
+            await this.plugin.controller.addYamlProp(propertyName, propertyValue, targetFile);
+        }
+    }
+
+    private getDeletePropertyFunction() {
+        return async (propertyName: string, file: TFile | string) => {
+            const targetFile = this.getFileFromTFileOrPath(file);
+            if (!targetFile) return;
+
+            const targetProperty = await this.getPropertyInFile(propertyName, targetFile);
+            if (!targetProperty) return;
+
+            if (targetProperty.type === MetaType.YAML) {
+                await this.plugin.app.fileManager.processFrontMatter(targetFile, (frontmatter) => {
+                    delete frontmatter[targetProperty.key];
+                });
+                return;
+            }
+
+            if (targetProperty.type === MetaType.Dataview) {
+                await this.deleteDataviewProperty(targetProperty, targetFile);
+            }
         }
     }
 
@@ -90,8 +121,41 @@ export class MetaEditApi {
             const targetFile = this.getFileFromTFileOrPath(file);
             if (!targetFile) return;
 
-            const controller: MetaController = new MetaController(this.plugin.app, this.plugin);
-            return await controller.getPropertiesInFile(targetFile);
+            return await this.plugin.controller.getPropertiesInFile(targetFile);
         }
+    }
+
+    private async getPropertyInFile(propertyName: string, file: TFile): Promise<Property | undefined> {
+        const propsInFile: Property[] = await this.plugin.controller.getPropertiesInFile(file);
+        return propsInFile.find(prop => prop.key === propertyName);
+    }
+
+    private async deleteDataviewProperty(property: Property, file: TFile): Promise<void> {
+        const fileContent = await this.plugin.app.vault.read(file);
+        let deleted = false;
+
+        const newFileContent = fileContent.split("\n")
+            .map(line => {
+                if (deleted) return line;
+
+                const updatedLine = this.removeDataviewPropertyFromLine(property.key, line);
+                if (updatedLine === line) return line;
+
+                deleted = true;
+                return updatedLine.trim().length === 0 ? null : updatedLine;
+            })
+            .filter((line): line is string => line !== null)
+            .join("\n");
+
+        await this.plugin.app.vault.modify(file, newFileContent);
+    }
+
+    private removeDataviewPropertyFromLine(propertyKey: string, line: string): string {
+        const propertyRegex = new RegExp(`(^|[\\s\\[\\(])${this.escapeSpecialCharacters(propertyKey)}::[ ]*[^\\)\\]\\n\\r]*(\\]\\]|[\\]\\)]?)?`);
+        return line.replace(propertyRegex, "").replace(/[ \t]{2,}/g, " ").trimEnd();
+    }
+
+    private escapeSpecialCharacters(text: string): string {
+        return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
     }
 }

--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -3,8 +3,11 @@ import type {IMetaEditApi, MetaEditPropertyValue} from "./IMetaEditApi";
 import type {Property} from "./parser";
 import {TFile} from "obsidian";
 import {MetaType} from "./Types/metaType";
+import type {AutoProperty} from "./Types/autoProperty";
 
 export class MetaEditApi {
+    private settingsWriteQueue: Promise<unknown> = Promise.resolve();
+
     constructor(private plugin: MetaEdit) {
     }
 
@@ -18,6 +21,8 @@ export class MetaEditApi {
             addOrUpdateProperty: this.getAddOrUpdatePropertyFunction(),
             deleteProperty: this.getDeletePropertyFunction(),
             getPropertiesInFile: this.getGetPropertiesInFile(),
+            getAutoProperties: this.getGetAutoPropertiesFunction(),
+            setAutoProperties: this.getSetAutoPropertiesFunction(),
         };
     }
 
@@ -125,6 +130,31 @@ export class MetaEditApi {
         }
     }
 
+    private getGetAutoPropertiesFunction() {
+        return (): AutoProperty[] => {
+            return this.cloneAutoProperties(this.plugin.settings.AutoProperties.properties);
+        }
+    }
+
+    private getSetAutoPropertiesFunction() {
+        return async (autoProperties: AutoProperty[]): Promise<void> => {
+            await this.enqueueSettingsWrite(async () => {
+                const nextAutoProperties = this.validateAutoProperties(autoProperties);
+                const previousAutoProperties = this.cloneAutoProperties(this.plugin.settings.AutoProperties.properties);
+
+                this.plugin.settings.AutoProperties.properties = nextAutoProperties;
+
+                try {
+                    await this.plugin.saveSettings();
+                }
+                catch (error) {
+                    this.plugin.settings.AutoProperties.properties = previousAutoProperties;
+                    throw error;
+                }
+            });
+        }
+    }
+
     private async getPropertyInFile(propertyName: string, file: TFile): Promise<Property | undefined> {
         const propsInFile: Property[] = await this.plugin.controller.getPropertiesInFile(file);
         return propsInFile.find(prop => prop.key === propertyName);
@@ -157,5 +187,51 @@ export class MetaEditApi {
 
     private escapeSpecialCharacters(text: string): string {
         return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+    }
+
+    private cloneAutoProperties(autoProperties: AutoProperty[]): AutoProperty[] {
+        return autoProperties.map(autoProperty => ({
+            name: autoProperty.name,
+            choices: [...autoProperty.choices],
+        }));
+    }
+
+    private validateAutoProperties(autoProperties: AutoProperty[]): AutoProperty[] {
+        if (!Array.isArray(autoProperties)) {
+            throw new TypeError("Auto Properties must be an array.");
+        }
+
+        const names = new Set<string>();
+
+        return autoProperties.map((autoProperty, index) => {
+            if (!autoProperty || typeof autoProperty !== "object") {
+                throw new TypeError(`Auto Property at index ${index} must be an object.`);
+            }
+
+            if (typeof autoProperty.name !== "string" || autoProperty.name.length === 0) {
+                throw new TypeError(`Auto Property at index ${index} must have a non-empty string name.`);
+            }
+
+            if (names.has(autoProperty.name)) {
+                throw new Error(`Duplicate Auto Property name: ${autoProperty.name}`);
+            }
+
+            names.add(autoProperty.name);
+
+            if (!Array.isArray(autoProperty.choices) || !autoProperty.choices.every(choice => typeof choice === "string")) {
+                throw new TypeError(`Auto Property '${autoProperty.name}' choices must be an array of strings.`);
+            }
+
+            return {
+                name: autoProperty.name,
+                choices: [...autoProperty.choices],
+            };
+        });
+    }
+
+    private enqueueSettingsWrite<T>(task: () => Promise<T>): Promise<T> {
+        const queued = this.settingsWriteQueue.catch(() => undefined).then(task);
+        this.settingsWriteQueue = queued.catch(() => undefined);
+        return queued;
     }
 }

--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -1,5 +1,10 @@
 import type MetaEdit from "./main";
-import type {IMetaEditApi, MetaEditPropertyValue} from "./IMetaEditApi";
+import type {
+    IMetaEditApi,
+    MetaEditMetadataChangeCallback,
+    MetaEditPropertyValue,
+    MetaEditUnsubscribe,
+} from "./IMetaEditApi";
 import type {Property} from "./parser";
 import {TFile} from "obsidian";
 import {MetaType} from "./Types/metaType";
@@ -23,6 +28,7 @@ export class MetaEditApi {
             getPropertiesInFile: this.getGetPropertiesInFile(),
             getAutoProperties: this.getGetAutoPropertiesFunction(),
             setAutoProperties: this.getSetAutoPropertiesFunction(),
+            onMetadataChange: this.getOnMetadataChangeFunction(),
         };
     }
 
@@ -155,6 +161,44 @@ export class MetaEditApi {
         }
     }
 
+    private getOnMetadataChangeFunction() {
+        return (callback: MetaEditMetadataChangeCallback): MetaEditUnsubscribe => {
+            let unsubscribed = false;
+            const previousPropertiesByPath = new Map<string, Property[]>();
+            const eventRef = this.plugin.app.metadataCache.on("changed", async (file, data, cache) => {
+                if (unsubscribed) return;
+
+                const previousProperties = previousPropertiesByPath.get(file.path) ?? null;
+                const properties = this.cloneProperties(await this.plugin.controller.getPropertiesInFile(file));
+
+                if (previousProperties && this.propertiesSignature(previousProperties) === this.propertiesSignature(properties)) {
+                    return;
+                }
+
+                previousPropertiesByPath.set(file.path, this.cloneProperties(properties));
+
+                await callback({
+                    file,
+                    data,
+                    cache,
+                    properties: this.cloneProperties(properties),
+                    previousProperties: previousProperties ? this.cloneProperties(previousProperties) : null,
+                });
+            });
+
+            const unsubscribe = () => {
+                if (unsubscribed) return;
+
+                unsubscribed = true;
+                previousPropertiesByPath.clear();
+                this.plugin.app.metadataCache.offref(eventRef);
+            };
+
+            this.plugin.register(unsubscribe);
+            return unsubscribe;
+        }
+    }
+
     private async getPropertyInFile(propertyName: string, file: TFile): Promise<Property | undefined> {
         const propsInFile: Property[] = await this.plugin.controller.getPropertiesInFile(file);
         return propsInFile.find(prop => prop.key === propertyName);
@@ -233,5 +277,40 @@ export class MetaEditApi {
         const queued = this.settingsWriteQueue.catch(() => undefined).then(task);
         this.settingsWriteQueue = queued.catch(() => undefined);
         return queued;
+    }
+
+    private cloneProperties(properties: Property[]): Property[] {
+        return properties.map(property => ({
+            key: property.key,
+            type: property.type,
+            content: this.cloneValue(property.content),
+        }));
+    }
+
+    private cloneValue(value: unknown): unknown {
+        if (value instanceof Date) {
+            return new Date(value.getTime());
+        }
+
+        if (Array.isArray(value)) {
+            return value.map(item => this.cloneValue(item));
+        }
+
+        if (value && typeof value === "object") {
+            return Object.entries(value as Record<string, unknown>).reduce((clone, [key, item]) => {
+                clone[key] = this.cloneValue(item);
+                return clone;
+            }, {} as Record<string, unknown>);
+        }
+
+        return value;
+    }
+
+    private propertiesSignature(properties: Property[]): string {
+        return JSON.stringify(properties.map(property => ({
+            key: property.key,
+            type: property.type,
+            content: property.content,
+        })));
     }
 }

--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -7,6 +7,7 @@ import type {
 } from "./IMetaEditApi";
 import type {Property} from "./parser";
 import {TFile} from "obsidian";
+import type {CachedMetadata} from "obsidian";
 import {MetaType} from "./Types/metaType";
 import type {AutoProperty} from "./Types/autoProperty";
 
@@ -24,7 +25,6 @@ export class MetaEditApi {
             getFilesWithProperty: this.getGetFilesWithPropertyFunction(),
             createYamlProperty: this.getCreateYamlPropertyFunction(),
             addOrUpdateProperty: this.getAddOrUpdatePropertyFunction(),
-            deleteProperty: this.getDeletePropertyFunction(),
             getPropertiesInFile: this.getGetPropertiesInFile(),
             getAutoProperties: this.getGetAutoPropertiesFunction(),
             setAutoProperties: this.getSetAutoPropertiesFunction(),
@@ -102,28 +102,10 @@ export class MetaEditApi {
                 return;
             }
 
-            await this.plugin.controller.addYamlProp(propertyName, propertyValue, targetFile);
-        }
-    }
-
-    private getDeletePropertyFunction() {
-        return async (propertyName: string, file: TFile | string) => {
-            const targetFile = this.getFileFromTFileOrPath(file);
-            if (!targetFile) return;
-
-            const targetProperty = await this.getPropertyInFile(propertyName, targetFile);
-            if (!targetProperty) return;
-
-            if (targetProperty.type === MetaType.YAML) {
-                await this.plugin.app.fileManager.processFrontMatter(targetFile, (frontmatter) => {
-                    delete frontmatter[targetProperty.key];
-                });
-                return;
-            }
-
-            if (targetProperty.type === MetaType.Dataview) {
-                await this.deleteDataviewProperty(targetProperty, targetFile);
-            }
+            await this.plugin.controller.updatePropertyInFile({
+                key: propertyName,
+                type: MetaType.YAML,
+            }, propertyValue, targetFile);
         }
     }
 
@@ -165,11 +147,13 @@ export class MetaEditApi {
         return (callback: MetaEditMetadataChangeCallback): MetaEditUnsubscribe => {
             let unsubscribed = false;
             const previousPropertiesByPath = new Map<string, Property[]>();
-            const eventRef = this.plugin.app.metadataCache.on("changed", async (file, data, cache) => {
+            const eventQueues = new Map<string, Promise<void>>();
+            const handleChange = async (file: TFile, data: string, cache: CachedMetadata) => {
                 if (unsubscribed) return;
 
                 const previousProperties = previousPropertiesByPath.get(file.path) ?? null;
                 const properties = this.cloneProperties(await this.plugin.controller.getPropertiesInFile(file));
+                if (unsubscribed) return;
 
                 if (previousProperties && this.propertiesSignature(previousProperties) === this.propertiesSignature(properties)) {
                     return;
@@ -177,13 +161,43 @@ export class MetaEditApi {
 
                 previousPropertiesByPath.set(file.path, this.cloneProperties(properties));
 
-                await callback({
-                    file,
-                    data,
-                    cache,
-                    properties: this.cloneProperties(properties),
-                    previousProperties: previousProperties ? this.cloneProperties(previousProperties) : null,
+                try {
+                    await callback({
+                        file,
+                        data,
+                        cache,
+                        properties: this.cloneProperties(properties),
+                        previousProperties: previousProperties ? this.cloneProperties(previousProperties) : null,
+                    });
+                }
+                catch (error) {
+                    console.error("MetaEdit metadata change callback failed.", error);
+                }
+            };
+            const eventRef = this.plugin.app.metadataCache.on("changed", (file, data, cache) => {
+                const previousTask = eventQueues.get(file.path) ?? Promise.resolve();
+                const queuedTask = previousTask.catch(() => undefined).then(() => handleChange(file, data, cache));
+
+                eventQueues.set(file.path, queuedTask);
+                void queuedTask.finally(() => {
+                    if (eventQueues.get(file.path) === queuedTask) {
+                        eventQueues.delete(file.path);
+                    }
                 });
+            });
+            const deletedEventRef = this.plugin.app.metadataCache.on("deleted", (file) => {
+                previousPropertiesByPath.delete(file.path);
+                eventQueues.delete(file.path);
+            });
+            const renameEventRef = this.plugin.app.vault.on("rename", (file, oldPath) => {
+                if (!(file instanceof TFile)) return;
+
+                const previousProperties = previousPropertiesByPath.get(oldPath);
+                previousPropertiesByPath.delete(oldPath);
+
+                if (previousProperties) {
+                    previousPropertiesByPath.set(file.path, previousProperties);
+                }
             });
 
             const unsubscribe = () => {
@@ -191,7 +205,10 @@ export class MetaEditApi {
 
                 unsubscribed = true;
                 previousPropertiesByPath.clear();
+                eventQueues.clear();
                 this.plugin.app.metadataCache.offref(eventRef);
+                this.plugin.app.metadataCache.offref(deletedEventRef);
+                this.plugin.app.vault.offref(renameEventRef);
             };
 
             this.plugin.register(unsubscribe);
@@ -202,35 +219,6 @@ export class MetaEditApi {
     private async getPropertyInFile(propertyName: string, file: TFile): Promise<Property | undefined> {
         const propsInFile: Property[] = await this.plugin.controller.getPropertiesInFile(file);
         return propsInFile.find(prop => prop.key === propertyName);
-    }
-
-    private async deleteDataviewProperty(property: Property, file: TFile): Promise<void> {
-        const fileContent = await this.plugin.app.vault.read(file);
-        let deleted = false;
-
-        const newFileContent = fileContent.split("\n")
-            .map(line => {
-                if (deleted) return line;
-
-                const updatedLine = this.removeDataviewPropertyFromLine(property.key, line);
-                if (updatedLine === line) return line;
-
-                deleted = true;
-                return updatedLine.trim().length === 0 ? null : updatedLine;
-            })
-            .filter((line): line is string => line !== null)
-            .join("\n");
-
-        await this.plugin.app.vault.modify(file, newFileContent);
-    }
-
-    private removeDataviewPropertyFromLine(propertyKey: string, line: string): string {
-        const propertyRegex = new RegExp(`(^|[\\s\\[\\(])${this.escapeSpecialCharacters(propertyKey)}::[ ]*[^\\)\\]\\n\\r]*(\\]\\]|[\\]\\)]?)?`);
-        return line.replace(propertyRegex, "").replace(/[ \t]{2,}/g, " ").trimEnd();
-    }
-
-    private escapeSpecialCharacters(text: string): string {
-        return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
     }
 
     private cloneAutoProperties(autoProperties: AutoProperty[]): AutoProperty[] {
@@ -245,25 +233,17 @@ export class MetaEditApi {
             throw new TypeError("Auto Properties must be an array.");
         }
 
-        const names = new Set<string>();
-
         return autoProperties.map((autoProperty, index) => {
             if (!autoProperty || typeof autoProperty !== "object") {
                 throw new TypeError(`Auto Property at index ${index} must be an object.`);
             }
 
-            if (typeof autoProperty.name !== "string" || autoProperty.name.length === 0) {
-                throw new TypeError(`Auto Property at index ${index} must have a non-empty string name.`);
-            }
-
-            if (names.has(autoProperty.name)) {
-                throw new Error(`Duplicate Auto Property name: ${autoProperty.name}`);
-            }
-
-            names.add(autoProperty.name);
-
             if (!Array.isArray(autoProperty.choices) || !autoProperty.choices.every(choice => typeof choice === "string")) {
-                throw new TypeError(`Auto Property '${autoProperty.name}' choices must be an array of strings.`);
+                throw new TypeError(`Auto Property at index ${index} choices must be an array of strings.`);
+            }
+
+            if (typeof autoProperty.name !== "string") {
+                throw new TypeError(`Auto Property at index ${index} must have a string name.`);
             }
 
             return {

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -27,8 +27,10 @@ describe("MetaEdit runtime", () => {
 
 		expect(state.hasRunCommand).toBe(true);
 		expect(state.apiMethods).toEqual([
+			"addOrUpdateProperty",
 			"autoprop",
 			"createYamlProperty",
+			"deleteProperty",
 			"getFilesWithProperty",
 			"getPropertiesInFile",
 			"getPropertyValue",
@@ -81,6 +83,68 @@ describe("MetaEdit runtime", () => {
 		]);
 		expect(String(updated)).toBe("published");
 
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("adds, updates, and deletes properties through the public API", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("property-helpers.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nstatus: draft\n---\nowner:: old\n\nBody text.\n",
+		);
+
+		await callApi(obsidian, "addOrUpdateProperty", [
+			"priority",
+			1,
+			notePath,
+		]);
+		await callApi(obsidian, "addOrUpdateProperty", [
+			"status",
+			"published",
+			notePath,
+		]);
+		await callApi(obsidian, "deleteProperty", ["owner", notePath]);
+
+		const content = await sandbox.waitForContent(
+			"property-helpers.md",
+			(value) =>
+				value.includes("priority: 1") &&
+				value.includes("status: published") &&
+				!value.includes("owner:: old"),
+			WAIT_OPTS,
+		);
+
+		expect(content).toContain("priority: 1");
+		expect(content).toContain("status: published");
+		expect(content).not.toContain("owner:: old");
+		expect(content).toContain("\n\nBody text.");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("updates one numeric YAML property without changing its sibling", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("numeric-frontmatter.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\noutdoor: 0\nreading: 0\n---\n# Baseline\n",
+		);
+
+		await callApi(obsidian, "update", ["outdoor", 1, notePath]);
+
+		const content = await sandbox.waitForContent(
+			"numeric-frontmatter.md",
+			(value) => value.includes("outdoor: 1") && value.includes("reading: 0"),
+			WAIT_OPTS,
+		);
+
+		expect(content).toContain("outdoor: 1");
+		expect(content).toContain("reading: 0");
+		expect(content).not.toContain("reading: 1");
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -30,7 +30,6 @@ describe("MetaEdit runtime", () => {
 			"addOrUpdateProperty",
 			"autoprop",
 			"createYamlProperty",
-			"deleteProperty",
 			"getAutoProperties",
 			"getFilesWithProperty",
 			"getPropertiesInFile",
@@ -89,7 +88,7 @@ describe("MetaEdit runtime", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
-	test("adds, updates, and deletes properties through the public API", async () => {
+	test("adds and updates properties through the public API", async () => {
 		const { obsidian, sandbox } = getContext();
 
 		const notePath = sandbox.path("property-helpers.md");
@@ -109,20 +108,18 @@ describe("MetaEdit runtime", () => {
 			"published",
 			notePath,
 		]);
-		await callApi(obsidian, "deleteProperty", ["owner", notePath]);
 
 		const content = await sandbox.waitForContent(
 			"property-helpers.md",
 			(value) =>
 				value.includes("priority: 1") &&
-				value.includes("status: published") &&
-				!value.includes("owner:: old"),
+				value.includes("status: published"),
 			WAIT_OPTS,
 		);
 
 		expect(content).toContain("priority: 1");
 		expect(content).toContain("status: published");
-		expect(content).not.toContain("owner:: old");
+		expect(content).toContain("owner:: old");
 		expect(content).toContain("\n\nBody text.");
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
@@ -157,8 +154,8 @@ describe("MetaEdit runtime", () => {
 		const state = await evalJsonAsync<{
 			returnedChoices: string[];
 			savedChoices: string[];
-			duplicateMessage: string;
-			settingsAfterDuplicate: { name: string; choices: string[] }[];
+			invalidMessage: string;
+			settingsAfterInvalid: { name: string; choices: string[] }[];
 		}>(
 			obsidian,
 			`
@@ -168,30 +165,31 @@ describe("MetaEdit runtime", () => {
 				if (!api) throw new Error("MetaEdit API is not available.");
 
 				await api.setAutoProperties([
+					{ name: "", choices: [""] },
 					{ name: "Status", choices: ["Draft", "Done"] },
+					{ name: "Status", choices: ["Duplicate"] },
 				]);
 
 				const returned = api.getAutoProperties();
-				returned[0].choices.push("Leaked");
+				returned[1].choices.push("Leaked");
 
-				let duplicateMessage = "";
+				let invalidMessage = "";
 				try {
 					await api.setAutoProperties([
-						{ name: "Status", choices: ["One"] },
-						{ name: "Status", choices: ["Two"] },
+						{ name: "Broken", choices: "not-an-array" },
 					]);
 				}
 				catch (error) {
-					duplicateMessage = error.message;
+					invalidMessage = error.message;
 				}
 
 				const saved = await plugin.loadData();
 
 				return {
-					returnedChoices: api.getAutoProperties()[0].choices,
-					savedChoices: saved.AutoProperties.properties[0].choices,
-					duplicateMessage,
-					settingsAfterDuplicate: plugin.settings.AutoProperties.properties,
+					returnedChoices: api.getAutoProperties()[1].choices,
+					savedChoices: saved.AutoProperties.properties[1].choices,
+					invalidMessage,
+					settingsAfterInvalid: plugin.settings.AutoProperties.properties,
 				};
 			})()
 		`,
@@ -199,9 +197,11 @@ describe("MetaEdit runtime", () => {
 
 		expect(state.returnedChoices).toEqual(["Draft", "Done"]);
 		expect(state.savedChoices).toEqual(["Draft", "Done"]);
-		expect(state.duplicateMessage).toContain("Duplicate Auto Property name: Status");
-		expect(state.settingsAfterDuplicate).toEqual([
+		expect(state.invalidMessage).toContain("choices must be an array of strings");
+		expect(state.settingsAfterInvalid).toEqual([
+			{ name: "", choices: [""] },
 			{ name: "Status", choices: ["Draft", "Done"] },
+			{ name: "Status", choices: ["Duplicate"] },
 		]);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -31,9 +31,11 @@ describe("MetaEdit runtime", () => {
 			"autoprop",
 			"createYamlProperty",
 			"deleteProperty",
+			"getAutoProperties",
 			"getFilesWithProperty",
 			"getPropertiesInFile",
 			"getPropertyValue",
+			"setAutoProperties",
 			"update",
 		]);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
@@ -145,6 +147,61 @@ describe("MetaEdit runtime", () => {
 		expect(content).toContain("outdoor: 1");
 		expect(content).toContain("reading: 0");
 		expect(content).not.toContain("reading: 1");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("sets Auto Properties through the public API without exposing mutable settings", async () => {
+		const { obsidian } = getContext();
+
+		const state = await evalJsonAsync<{
+			returnedChoices: string[];
+			savedChoices: string[];
+			duplicateMessage: string;
+			settingsAfterDuplicate: { name: string; choices: string[] }[];
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const api = plugin?.api;
+				if (!api) throw new Error("MetaEdit API is not available.");
+
+				await api.setAutoProperties([
+					{ name: "Status", choices: ["Draft", "Done"] },
+				]);
+
+				const returned = api.getAutoProperties();
+				returned[0].choices.push("Leaked");
+
+				let duplicateMessage = "";
+				try {
+					await api.setAutoProperties([
+						{ name: "Status", choices: ["One"] },
+						{ name: "Status", choices: ["Two"] },
+					]);
+				}
+				catch (error) {
+					duplicateMessage = error.message;
+				}
+
+				const saved = await plugin.loadData();
+
+				return {
+					returnedChoices: api.getAutoProperties()[0].choices,
+					savedChoices: saved.AutoProperties.properties[0].choices,
+					duplicateMessage,
+					settingsAfterDuplicate: plugin.settings.AutoProperties.properties,
+				};
+			})()
+		`,
+		);
+
+		expect(state.returnedChoices).toEqual(["Draft", "Done"]);
+		expect(state.savedChoices).toEqual(["Draft", "Done"]);
+		expect(state.duplicateMessage).toContain("Duplicate Auto Property name: Status");
+		expect(state.settingsAfterDuplicate).toEqual([
+			{ name: "Status", choices: ["Draft", "Done"] },
+		]);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
@@ -386,7 +443,14 @@ async function writeLiveFile(
 			for (const part of parts.slice(0, -1)) {
 				current = current ? current + "/" + part : part;
 				if (!app.vault.getAbstractFileByPath(current)) {
-					await app.vault.createFolder(current);
+					try {
+						await app.vault.createFolder(current);
+					}
+					catch (error) {
+						if (!String(error.message).includes("Folder already exists")) {
+							throw error;
+						}
+					}
 				}
 			}
 

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -35,6 +35,7 @@ describe("MetaEdit runtime", () => {
 			"getFilesWithProperty",
 			"getPropertiesInFile",
 			"getPropertyValue",
+			"onMetadataChange",
 			"setAutoProperties",
 			"update",
 		]);
@@ -202,6 +203,78 @@ describe("MetaEdit runtime", () => {
 		expect(state.settingsAfterDuplicate).toEqual([
 			{ name: "Status", choices: ["Draft", "Done"] },
 		]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("notifies metadata changes with parsed properties and cleans up subscriptions", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("metadata-listener.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nstatus: draft\n---\ninline:: one\n",
+		);
+
+		const state = await evalJsonAsync<{
+			events: {
+				status: unknown;
+				inline: unknown;
+				previousProperties: number | null;
+			}[];
+			countBeforeUnsubscribe: number;
+			countAfterUnsubscribe: number;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const api = plugin?.api;
+				if (!api) throw new Error("MetaEdit API is not available.");
+
+				const notePath = ${JSON.stringify(notePath)};
+				const file = app.vault.getAbstractFileByPath(notePath);
+				const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+				const waitFor = async (predicate) => {
+					const started = Date.now();
+					while (Date.now() - started < 5000) {
+						if (predicate()) return;
+						await sleep(100);
+					}
+					throw new Error("Timed out waiting for metadata listener.");
+				};
+				const events = [];
+				const unsubscribe = api.onMetadataChange((change) => {
+					if (change.file.path !== notePath) return;
+
+					const status = change.properties.find((property) => property.key === "status");
+					const inline = change.properties.find((property) => property.key === "inline");
+					events.push({
+						status: status?.content,
+						inline: inline?.content,
+						previousProperties: change.previousProperties?.length ?? null,
+					});
+				});
+
+				await api.update("status", "done", notePath);
+				await waitFor(() => events.some((event) => event.status === "done" && event.inline === "one"));
+
+				const countBeforeUnsubscribe = events.length;
+				unsubscribe();
+				await api.update("status", "closed", notePath);
+				await sleep(800);
+
+				return {
+					events,
+					countBeforeUnsubscribe,
+					countAfterUnsubscribe: events.length,
+				};
+			})()
+		`,
+		);
+
+		expect(state.events.some(event => event.status === "done" && event.inline === "one")).toBe(true);
+		expect(state.countAfterUnsubscribe).toBe(state.countBeforeUnsubscribe);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 


### PR DESCRIPTION
## Summary

Expand MetaEdit's public API with integration-focused additions that are safe for other plugins to depend on: add-or-update metadata writes, Auto Properties settings access, and metadata-change subscriptions backed by MetaEdit's parser.

This also documents the current API contract and the product decisions that came out of review. In particular, this PR does **not** publish a runtime npm package for #29 and does **not** expose `deleteProperty` yet: safe deletion needs a controller-owned, queued write path rather than API-local file surgery.

## Changes

- Adds `addOrUpdateProperty(propertyName, propertyValue, file)` for callers that need update-or-create semantics without silently no-oping when a property is absent.
- Widens public write value types from `string` to `unknown` so numeric YAML values, including the #101 repro, are represented honestly.
- Adds `getAutoProperties()` and `setAutoProperties(autoProperties)` with defensive cloning, shape validation, serialized API writes, and rollback on save failure.
- Adds `onMetadataChange(callback)` returning an idempotent unsubscribe function. The callback receives `{ file, data, cache, properties, previousProperties }`, where `properties` are parsed through MetaEdit. Events are serialized per file and subscriptions clean up on unsubscribe or MetaEdit unload.
- Updates README API docs, including inline-field stringification behavior and the metadata listener's snapshot-based contract.
- Adds live Obsidian E2E coverage for the new API methods and hardens the E2E file helper against repeated isolated-vault runs.

## Product decisions

#29 should not be implemented as a runtime npm package in this PR. The useful runtime behavior depends on a live Obsidian app, vault, metadata cache, and MetaEdit's plugin instance. A future types-only package could be useful after the public API contract settles, but flipping npm publishing now would freeze internal plugin shapes too early.

`deleteProperty` was left out after adversarial review. Implementing it only in `MetaEditApi.ts` would bypass the controller's per-file write queue from the recent frontmatter rewrite and would duplicate inline-field parsing. The right follow-up is a controller-owned delete path that can be exposed safely.

## Testing / validation

- `pnpm install --frozen-lockfile`
- `pnpm run lint` (0 errors; existing warnings remain in unrelated files)
- `pnpm run build`
- `pnpm run test` (58 tests)
- Isolated vault `metaedit-38-api`: `pnpm run test:e2e` with `HOME=$METAEDIT_E2E_OBSIDIAN_HOME` (11 live Obsidian tests)
- Direct isolated-vault proof through `app.plugins.plugins.metaedit.api.*`:
  - `update("reading", 1, notePath)` preserved sibling frontmatter and wrote numeric YAML.
  - `addOrUpdateProperty("priority", "high", notePath)` created YAML frontmatter through MetaEdit's controller.
  - `setAutoProperties([{ name: "Status", choices: ["draft", "done"] }])` saved and read back via `getAutoProperties()`.
  - `onMetadataChange(...)` emitted parsed YAML and inline properties, then stopped after unsubscribe.
- `pnpm run obsidian:e2e -- dev:errors` after runtime proof: no errors captured.
- Adversarial design review before implementation and adversarial diff review after implementation. Accepted findings removed unsafe API-local delete support, relaxed Auto Properties validation to round-trip UI-created settings, and serialized metadata listener events per file.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
      — it becomes the squash-merge commit and drives the released version.
- [x] Linked any related issue(s).
- [x] Noted release/migration impact, if any.

Fixes #38.
Fixes #97.
Fixes #102.
Fixes #101.
Refs #29.