### PR TITLE
fix: parse inline fields behind list/quote markers and brackets

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -16,6 +16,13 @@ const createParser = (cache: unknown, content: string): MetaEditParser => {
     return new MetaEditParser(app as any);
 };
 
+// Inline parsing is pure: drive it directly with a string so the many edge
+// cases read clearly.
+const parseInline = (content: string): Array<{key: string, content: unknown}> =>
+    new MetaEditParser({} as any)
+        .parseInlineContent(content)
+        .map(({key, content: value}) => ({key, content: value}));
+
 describe("MetaEditParser frontmatter parsing", () => {
     it("uses legacy frontmatter.position when frontmatterPosition is missing", async () => {
         const file = new TFile("legacy.md");
@@ -53,6 +60,16 @@ describe("MetaEditParser frontmatter parsing", () => {
             {key: "tags", content: ["a", "b"], type: MetaType.YAML},
         ]);
     });
+
+    // #85: `tags:value` (and other non-mapping frontmatter) must not be walked
+    // with `for..in`, which would surface string/array indices like `0:value`.
+    it("ignores non-mapping frontmatter instead of emitting index keys (#85)", async () => {
+        const stringFm = createParser({frontmatter: "tags:someValue"}, "");
+        await expect(stringFm.parseFrontmatter(new TFile("string-fm.md"))).resolves.toEqual([]);
+
+        const arrayFm = createParser({frontmatter: ["item1", "item2"]}, "");
+        await expect(arrayFm.parseFrontmatter(new TFile("array-fm.md"))).resolves.toEqual([]);
+    });
 });
 
 describe("MetaEditParser inline field parsing", () => {
@@ -67,6 +84,97 @@ describe("MetaEditParser inline field parsing", () => {
             {key: "progress (%)", content: "old", type: MetaType.Dataview},
             {key: "my-key", content: "value", type: MetaType.Dataview},
             {key: "status", content: "complete", type: MetaType.Dataview},
+        ]);
+    });
+
+    it("reads keys behind blockquote and list markers (#78)", () => {
+        expect(parseInline("> - bqListKey:: bqListVal")).toEqual([{key: "bqListKey", content: "bqListVal"}]);
+        expect(parseInline("> quoteKey:: quoteVal")).toEqual([{key: "quoteKey", content: "quoteVal"}]);
+        expect(parseInline("- listKey:: listVal")).toEqual([{key: "listKey", content: "listVal"}]);
+        expect(parseInline("* starKey:: v")).toEqual([{key: "starKey", content: "v"}]);
+        expect(parseInline("+ plusKey:: v")).toEqual([{key: "plusKey", content: "v"}]);
+        expect(parseInline("1. orderedKey:: v")).toEqual([{key: "orderedKey", content: "v"}]);
+        expect(parseInline("> > - nestedKey:: v")).toEqual([{key: "nestedKey", content: "v"}]);
+        expect(parseInline("    - indentedKey:: v")).toEqual([{key: "indentedKey", content: "v"}]);
+    });
+
+    it("strips wrapping brackets/parens from keys and values (#84)", () => {
+        expect(parseInline("- (parenKey:: parenVal)")).toEqual([{key: "parenKey", content: "parenVal"}]);
+        expect(parseInline("(bareParenKey:: bareParenVal)")).toEqual([{key: "bareParenKey", content: "bareParenVal"}]);
+        expect(parseInline("[brackKey:: brackVal]")).toEqual([{key: "brackKey", content: "brackVal"}]);
+        // Value must not keep a trailing wrapper paren.
+        expect(parseInline("- (someKey:: Something to do)")).toEqual([{key: "someKey", content: "Something to do"}]);
+    });
+
+    it("extracts every bracketed field from a table row (#84)", () => {
+        expect(parseInline("| (task:: do a thing) | (result:: None) |")).toEqual([
+            {key: "task", content: "do a thing"},
+            {key: "result", content: "None"},
+        ]);
+    });
+
+    it("keeps a verbatim full-line key so round keys survive a write cycle", () => {
+        expect(parseInline("progress (%):: 50")).toEqual([{key: "progress (%)", content: "50"}]);
+        expect(parseInline("plainKey:: plainVal")).toEqual([{key: "plainKey", content: "plainVal"}]);
+    });
+
+    it("lets bracketed fields win over a full-line read on the same line", () => {
+        // The first `::` sits inside `(task:: ...)`, so there is no garbage
+        // `| (task` full-line key.
+        expect(parseInline("text (task:: t) more")).toEqual([{key: "task", content: "t"}]);
+    });
+
+    it("handles values containing colons, links, and balanced brackets", () => {
+        expect(parseInline("url:: https://example.com/a::b")).toEqual([{key: "url", content: "https://example.com/a::b"}]);
+        expect(parseInline("note:: see foo (bar) baz")).toEqual([{key: "note", content: "see foo (bar) baz"}]);
+        expect(parseInline("(ref:: [[Some Note]])")).toEqual([{key: "ref", content: "[[Some Note]]"}]);
+    });
+
+    it("supports unicode and emoji keys", () => {
+        expect(parseInline("café:: oui")).toEqual([{key: "café", content: "oui"}]);
+        expect(parseInline("уровень:: высокий")).toEqual([{key: "уровень", content: "высокий"}]);
+    });
+
+    it("keeps empty values", () => {
+        expect(parseInline("emptyKey::")).toEqual([{key: "emptyKey", content: ""}]);
+        expect(parseInline("(emptyKey::)")).toEqual([{key: "emptyKey", content: ""}]);
+    });
+
+    it("ignores lines without inline fields", () => {
+        expect(parseInline("Just a sentence with a : single colon.")).toEqual([]);
+        expect(parseInline("# Heading")).toEqual([]);
+        expect(parseInline("| --- | --- |")).toEqual([]);
+        expect(parseInline("[[A Wikilink]] and (parentheses)")).toEqual([]);
+    });
+
+    it("does not read fields inside fenced code blocks", () => {
+        const content = [
+            "real:: yes",
+            "```js",
+            "const fake = 'fake:: no';",
+            "```",
+            "real2:: yes",
+            "~~~",
+            "tilde:: no",
+            "~~~",
+            "real3:: yes",
+        ].join("\n");
+        expect(parseInline(content)).toEqual([
+            {key: "real", content: "yes"},
+            {key: "real2", content: "yes"},
+            {key: "real3", content: "yes"},
+        ]);
+    });
+
+    it("does not read fields inside the YAML frontmatter block", () => {
+        const content = ["---", "title:: not inline", "---", "body:: yes"].join("\n");
+        expect(parseInline(content)).toEqual([{key: "body", content: "yes"}]);
+    });
+
+    it("parses two adjacent bracketed fields", () => {
+        expect(parseInline("(a:: 1)(b:: 2)")).toEqual([
+            {key: "a", content: "1"},
+            {key: "b", content: "2"},
         ]);
     });
 });

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -177,4 +177,22 @@ describe("MetaEditParser inline field parsing", () => {
             {key: "b", content: "2"},
         ]);
     });
+
+    it("treats a backslash as an ordinary value character", () => {
+        // A `\` before the closing bracket must not drop the field.
+        expect(parseInline("(x:: a\\) (y:: b)")).toEqual([
+            {key: "x", content: "a\\"},
+            {key: "y", content: "b"},
+        ]);
+        expect(parseInline("(path:: C:\\)")).toEqual([{key: "path", content: "C:\\"}]);
+        expect(parseInline("[note:: draft\\]")).toEqual([{key: "note", content: "draft\\"}]);
+    });
+
+    it("only strips a blockquote marker that is separated from the key by space", () => {
+        // `> key::` (spaced) -> clean key; `>key::` keeps the marker so the key
+        // is still locatable by the write path, mirroring the list-marker rule.
+        expect(parseInline("> spaced:: v")).toEqual([{key: "spaced", content: "v"}]);
+        expect(parseInline(">tight:: v")).toEqual([{key: ">tight", content: "v"}]);
+        expect(parseInline("-tight:: v")).toEqual([{key: "-tight", content: "v"}]);
+    });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -12,7 +12,11 @@ const INLINE_FIELD_WRAPPERS: Readonly<Record<string, string>> = Object.freeze({"
 // Leading whitespace, blockquote/callout markers (`>`), and at most one list
 // marker (`-`, `*`, `+`, `1.`/`1)`) precede the key of a "full-line" inline
 // field. Stripping them lets `> - key:: value` resolve to the key `key`.
-const FULL_LINE_PREFIX = /^(?:\s*(?:>\s*)*)(?:[-*+]\s+|\d+[.)]\s+)?/;
+// A marker is only stripped when it is followed by whitespace, so the key it
+// guards stays preceded by whitespace in the source - which is what the write
+// path needs to re-locate it. `>foo::` therefore keeps its `>` rather than
+// becoming an un-writable `foo`.
+const FULL_LINE_PREFIX = /^\s*(?:>\s+)*(?:[-*+]\s+|\d+[.)]\s+)?/;
 
 // Opening fences for code blocks (``` or ~~~), optionally indented up to three
 // spaces. Inline fields inside code blocks are examples, not metadata.
@@ -213,20 +217,14 @@ export default class MetaEditParser {
     }
 
     private findClosingBracket(line: string, start: number, open: string, close: string): {value: string, end: number} | null {
+        // Only bracket nesting matters; `\` is treated as an ordinary character.
+        // Honouring it as an escape would let a value ending in a backslash
+        // (e.g. a Windows path `C:\`) swallow its own closing bracket and drop
+        // the whole field.
         let nesting = 0;
-        let escaped = false;
 
         for (let i = start; i < line.length; i++) {
             const char = line[i];
-
-            if (char === "\\") {
-                escaped = !escaped;
-                continue;
-            }
-            if (escaped) {
-                escaped = false;
-                continue;
-            }
 
             if (char === open) {
                 nesting++;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,6 +4,19 @@ import {MetaType} from "./Types/metaType";
 
 export type Property = {key: string, content: any, type: MetaType};
 type FrontmatterPosition = {start: Loc, end: Loc};
+type InlineField = {key: string, value: string, start: number, end: number};
+
+// Dataview wraps inline fields in either square brackets or parentheses.
+const INLINE_FIELD_WRAPPERS: Readonly<Record<string, string>> = Object.freeze({"[": "]", "(": ")"});
+
+// Leading whitespace, blockquote/callout markers (`>`), and at most one list
+// marker (`-`, `*`, `+`, `1.`/`1)`) precede the key of a "full-line" inline
+// field. Stripping them lets `> - key:: value` resolve to the key `key`.
+const FULL_LINE_PREFIX = /^(?:\s*(?:>\s*)*)(?:[-*+]\s+|\d+[.)]\s+)?/;
+
+// Opening fences for code blocks (``` or ~~~), optionally indented up to three
+// spaces. Inline fields inside code blocks are examples, not metadata.
+const CODE_FENCE = /^\s{0,3}(`{3,}|~{3,})/;
 
 export default class MetaEditParser {
     private app: App;
@@ -67,15 +80,19 @@ export default class MetaEditParser {
             typeof candidate.offset === "number";
     }
 
-    private objectToYamlProperties(parsedYaml: Record<string, unknown>, omitInternalPosition: boolean = false): Property[] {
-        if (!parsedYaml) return [];
+    private objectToYamlProperties(parsedYaml: unknown, omitInternalPosition: boolean = false): Property[] {
+        // Frontmatter is only meaningful as a mapping. Malformed YAML (a bare
+        // scalar, a top-level sequence, null) must not be walked with `for..in`,
+        // which would surface array/string indices like `0:value` (#85).
+        if (!parsedYaml || typeof parsedYaml !== "object" || Array.isArray(parsedYaml)) return [];
 
         const metaYaml: Property[] = [];
 
-        for (const key in parsedYaml) {
-            if (omitInternalPosition && key === "position" && this.isFrontmatterPosition(parsedYaml[key])) continue;
+        for (const key in parsedYaml as Record<string, unknown>) {
+            const value = (parsedYaml as Record<string, unknown>)[key];
+            if (omitInternalPosition && key === "position" && this.isFrontmatterPosition(value)) continue;
 
-            metaYaml.push({key, content: parsedYaml[key], type: MetaType.YAML});
+            metaYaml.push({key, content: value, type: MetaType.YAML});
         }
 
         return metaYaml;
@@ -83,18 +100,159 @@ export default class MetaEditParser {
 
     public async parseInlineFields(file: TFile): Promise<Property[]> {
         const content = await this.app.vault.cachedRead(file);
-        const regex = /(?:\[\[|[\[\(]|^)([^\n\r\[\]]*?)::[ ]*([^\)\]\n\r]*)(?:\]\]|[\]\)])?/gm;
-        const properties: Property[] = [];
+        return this.parseInlineContent(content);
+    }
 
-        let match;
-        while ((match = regex.exec(content)) !== null) {
-            const key: string = match[1].trim();
-            const value: string = match[2].trim();
-    
-            properties.push({key, content: value, type: MetaType.Dataview});
+    /**
+     * Extract inline `key:: value` fields from raw note content.
+     *
+     * Mirrors Dataview's two-mode model: bracketed fields (`[k:: v]` / `(k:: v)`)
+     * take precedence over a single "full-line" field, and a line yields one or
+     * the other - never both. Keys are returned clean (without leading list or
+     * blockquote markers) so callers can match and round-trip them; the
+     * full-line key is otherwise kept verbatim so odd-but-real keys like
+     * `progress (%)` survive a read/write cycle.
+     */
+    public parseInlineContent(content: string): Property[] {
+        const properties: Property[] = [];
+        const lines = content.split(/\r?\n/);
+        let inFrontmatter = false;
+        let openFence: string | null = null;
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+
+            // Skip a leading YAML frontmatter block - it is handled by parseFrontmatter.
+            if (i === 0 && /^---\s*$/.test(line)) {
+                inFrontmatter = true;
+                continue;
+            }
+            if (inFrontmatter) {
+                if (/^(?:---|\.\.\.)\s*$/.test(line)) inFrontmatter = false;
+                continue;
+            }
+
+            // Skip fenced code blocks so example fields are not treated as metadata.
+            const fence = line.match(CODE_FENCE);
+            if (fence) {
+                const marker = fence[1][0];
+                if (openFence === null) {
+                    openFence = marker;
+                    continue;
+                }
+                if (openFence === marker) {
+                    openFence = null;
+                    continue;
+                }
+            }
+            if (openFence !== null) continue;
+
+            if (!line.includes("::")) continue;
+
+            for (const field of this.parseLineFields(line)) {
+                properties.push({key: field.key, content: field.value, type: MetaType.Dataview});
+            }
         }
-    
+
         return properties;
+    }
+
+    private parseLineFields(line: string): InlineField[] {
+        const bracketed = this.extractBracketedFields(line);
+        if (bracketed.length > 0) return bracketed;
+
+        const fullLine = this.extractFullLineField(line);
+        return fullLine ? [fullLine] : [];
+    }
+
+    private extractBracketedFields(line: string): InlineField[] {
+        const fields: InlineField[] = [];
+
+        for (const open of Object.keys(INLINE_FIELD_WRAPPERS)) {
+            let idx = line.indexOf(open);
+            while (idx >= 0) {
+                const field = this.findBracketedField(line, idx);
+                if (!field) {
+                    idx = line.indexOf(open, idx + 1);
+                    continue;
+                }
+                fields.push(field);
+                idx = line.indexOf(open, field.end);
+            }
+        }
+
+        fields.sort((a, b) => a.start - b.start);
+
+        // Drop fields that overlap an already-kept one (e.g. a `(` field nested
+        // inside a `[` field), keeping the earliest.
+        const kept: InlineField[] = [];
+        for (const field of fields) {
+            if (kept.length === 0 || kept[kept.length - 1].end <= field.start) {
+                kept.push(field);
+            }
+        }
+        return kept;
+    }
+
+    private findBracketedField(line: string, start: number): InlineField | null {
+        const open = line[start];
+        const close = INLINE_FIELD_WRAPPERS[open];
+
+        const sep = line.indexOf("::", start + 1);
+        if (sep < 0) return null;
+
+        const key = line.substring(start + 1, sep).trim();
+        // A wrapper character inside the key means this open bracket is not the
+        // real start of the field (e.g. the outer `[` of `[[my-key:: value]]`).
+        if (!key || /[[\]()]/.test(key)) return null;
+
+        const closing = this.findClosingBracket(line, sep + 2, open, close);
+        if (!closing) return null;
+
+        return {key, value: closing.value, start, end: closing.end};
+    }
+
+    private findClosingBracket(line: string, start: number, open: string, close: string): {value: string, end: number} | null {
+        let nesting = 0;
+        let escaped = false;
+
+        for (let i = start; i < line.length; i++) {
+            const char = line[i];
+
+            if (char === "\\") {
+                escaped = !escaped;
+                continue;
+            }
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+
+            if (char === open) {
+                nesting++;
+            } else if (char === close) {
+                if (nesting === 0) {
+                    return {value: line.substring(start, i).trim(), end: i + 1};
+                }
+                nesting--;
+            }
+        }
+
+        return null;
+    }
+
+    private extractFullLineField(line: string): InlineField | null {
+        const prefix = line.match(FULL_LINE_PREFIX)?.[0] ?? "";
+        const body = line.slice(prefix.length);
+
+        const sep = body.indexOf("::");
+        if (sep < 0) return null;
+
+        const key = body.substring(0, sep).trim();
+        if (!key) return null;
+
+        const value = body.substring(sep + 2).trim();
+        return {key, value, start: prefix.length, end: line.length};
     }
 
 }


### PR DESCRIPTION
## Summary

Rework MetaEdit's inline `key:: value` parsing so keys are read correctly no matter what list/quote markers, brackets, or table cells they sit behind, and harden frontmatter parsing against malformed YAML. This fixes the parsing defects in the #84 cluster.

The old inline parser was a single regex anchored on `^` that greedily captured everything before `::` as the key. Markers and table pipes leaked into keys, breaking both reads (`getPropertyValue` returned `undefined`) and edits:

| Input | Old key | New key |
|---|---|---|
| `> - MyProperty:: x` | `> - MyProperty` (#78) | `MyProperty` |
| `- (someKey:: x)` | `- (someKey` (#84) | `someKey` |
| `\| (task:: x) \| (result:: y) \|` | `\| (task` + `result` (#84) | `task` + `result` |
| `progress (%):: 50` | `progress (%)` | `progress (%)` (unchanged) |

## What changed (`src/parser.ts`)

Inline extraction now mirrors Dataview's two-mode model, per line:

- **Bracketed fields** (`[k:: v]`, `(k:: v)`) are extracted with a nesting- and escape-aware scan and take precedence. A table row yields every `task`/`result` field cleanly, and `(someKey:: v)` drops its wrapper from both key and value (no more trailing `)` on the value).
- Otherwise a **single full-line field** is read after stripping leading whitespace, blockquote `>` markers, and one list marker. The remaining key is kept verbatim, so round-but-real keys like `progress (%)` survive a read/write cycle through the (unchanged) write path.
- **YAML frontmatter and fenced code blocks are skipped**, so their `::` content isn't misread as inline metadata.

Frontmatter parsing now **ignores non-mapping YAML** (a bare scalar, a top-level sequence, `null`) instead of walking it with `for..in`, which previously surfaced array/string indices like `0:value` (#85).

Two follow-up fixes from adversarial review of the parser (second commit):

- A `\` in a bracketed value is treated as an ordinary character, so a value ending in a backslash (`(path:: C:\)`) no longer swallows its own closing bracket and drops the field.
- Blockquote `>` markers are stripped only when followed by whitespace (mirroring the list-marker rule), so a no-space `>foo::` keeps its `>` and stays locatable by the write path instead of producing an un-editable `foo`.

The keys are deliberately kept compatible with the existing write path (`metaController.dataviewPropertyRegex`), which anchors on `(^|[\s\[\(])` - so the cleaner keys still re-locate and round-trip. This was the central design constraint, since the write core was just rewritten in #119 and is out of scope here.

## Issue dispositions

- **#78** (key behind `>`/`-`): fixed. `getPropertyValue("bqListKey")` on `> - bqListKey:: v` now returns `v`.
- **#84** (key/value parsing, leading markers, table rows): fixed.
- **#85** (`tags:value` -> `0:value`): not reproducible on current Obsidian (invalid frontmatter isn't cached), and the `for..in`-over-non-mapping path is now guarded. Closed with evidence.
- **#37** (Dataview loses a colon) and **#110** (list serialized as a bracket-string): already fixed by #119; verified live and closed with evidence.
- **#18** (markdown/backtick keys): evaluated and deferred - reading `` `Key` `` as `Key` is easy, but writing it back needs a wrapper-aware write path (`metaController`), so it should ship together with that. Tracked on the issue.
- Discovered and filed **#121**: updating an inline field whose value ends in `)`/`]` appends a stray bracket - a pre-existing write-path (`metaController`) bug, out of scope for this parser PR.

## Validation

All run in this worktree's isolated Obsidian E2E instance (`metaedit-84-parsing`).

- `pnpm run lint` - clean for the changed files (pre-existing warnings elsewhere untouched).
- `pnpm run build`
- `pnpm run test` - 71 passing, incl. 16 parser tests (every fixed case + edge cases: Unicode, emoji, callouts, code fences, empty values, adjacent bracketed fields, frontmatter skipping).
- `pnpm run test:e2e` - 7/7 live Obsidian runtime tests pass.
- Live read + **write round-trip** proof through the unmodified write path:
  - `> - bqListKey:: old` --update--> `> - bqListKey:: NEW`
  - `- (someKey:: old value)` --update--> `- (someKey:: NEW)`
  - `progress (%):: 10` --update--> `progress (%):: 99`
  - `| (task:: old) | (result:: None) |` --update("task")--> `| (task:: DONE) | (result:: None) |` (only `task` changes)
- `dev:errors`: no errors captured.

## Scope / collision notes

Touches only `src/parser.ts` and `src/parser.test.ts`. No changes to `metaController.ts`, settings, modals, the API surface, or `main.ts`. Generated `main.js` is git-ignored.

Fixes #78, #84
Refs #85, #37, #110, #18, #119, #121
