### PR TITLE
feat(auto-properties): description, multi-select, and learn-as-you-go values

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 ## Features
 - Add or update Yaml properties and Dataview fields easily
 - Ignore properties to hide them from the menu
-- Auto Properties that have customizable, pre-defined values selectable through a suggester
+- Auto Properties that have customizable, pre-defined values selectable through a prompt
+  - Add an optional description shown when you pick a value
+  - Choose a Single or Multi (multi-select) type per property
+  - Type a value that is not in the list to use it once, or save it as a new choice
 - Multi-Value Mode that allows you to detect and vectorize/create arrays from your values
 - Progress Properties that automatically update properties/fields
   - Works with total task, completed task, and incomplete task counts. Mark a task as completed (from anywhere), and the file will be updated with the new count.
@@ -40,9 +43,9 @@ const {autoprop} = this.app.plugins.plugins["metaedit"].api;
 ```
 
 ### `autoprop(propertyName: string)`
-Takes a string containing a property name. Looks for the property in user settings and will open a suggester with possible values for that property.
+Takes a string containing a property name. Looks for the property in user settings and will open a prompt with the possible values for that property (and its description, if set).
 
-Returns the selected value. If no value was selected, or if the property was not found in settings, it returns `null`.
+Returns the selected value: a `string` for a Single property, or a `string[]` for a Multi property. If nothing was selected, or the property was not found / Auto Properties are disabled, it returns `null`.
 
 This is an asynchronous function, so you should `await` it.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Takes a string containing a property name. Looks for the property in user settin
 
 Returns the selected value: a `string` for a Single property, or a `string[]` for a Multi property. If nothing was selected, or the property was not found / Auto Properties are disabled, it returns `null`.
 
+For a Multi property used in a template, join the array yourself, e.g.
+`<% (await autoprop("Tags"))?.join(", ") %>`.
+
 This is an asynchronous function, so you should `await` it.
 
 ### `update(propertyName: string, propertyValue: unknown, file: TFile | string)`

--- a/src/IMetaEditApi.ts
+++ b/src/IMetaEditApi.ts
@@ -16,7 +16,7 @@ export interface MetaEditMetadataChange {
 export type MetaEditMetadataChangeCallback = (change: MetaEditMetadataChange) => void | Promise<void>;
 
 export interface IMetaEditApi {
-    autoprop: (propertyName: string) => Promise<string | null>;
+    autoprop: (propertyName: string) => Promise<string | string[] | null>;
     update: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
     getPropertyValue: (propertyName: string, file: (TFile | string)) => Promise<any>;
     getFilesWithProperty: (propertyName: string) => TFile[];

--- a/src/Modals/AutoPropertiesSettingModal/AutoPropertiesModalContent.svelte
+++ b/src/Modals/AutoPropertiesSettingModal/AutoPropertiesModalContent.svelte
@@ -1,102 +1,222 @@
 <script lang="ts">
-    import type {AutoProperty} from "../../Types/autoProperty";
+    import {setIcon} from "obsidian";
+    import type {AutoProperty, AutoPropertyType} from "../../Types/autoProperty";
 
     export let save: (autoProperties: AutoProperty[]) => void;
     export let autoProperties: AutoProperty[] = [];
 
+    const types: AutoPropertyType[] = ["Single", "Multi"];
+
+    // Svelte action: render a lucide icon into an element via Obsidian's setIcon.
+    function icon(node: HTMLElement, name: string) {
+        const render = (n: string) => {
+            node.textContent = "";
+            setIcon(node, n);
+        };
+        render(name);
+        return {update: render};
+    }
+
+    function asList(): AutoProperty[] {
+        return Array.isArray(autoProperties) ? autoProperties : [];
+    }
+
     function addNewProperty() {
-        let newProp: AutoProperty = {name: "", choices: [""]};
-
-        if (typeof autoProperties[Symbol.iterator] !== 'function')
-            autoProperties = [newProp];
-        else
-            autoProperties = [...autoProperties, newProp];
-
+        autoProperties = [...asList(), {name: "", choices: [""], type: "Single"}];
         save(autoProperties);
     }
 
     function removeProperty(property: AutoProperty) {
-        autoProperties = autoProperties.filter(ac => ac !== property);
+        autoProperties = asList().filter(ac => ac !== property);
         save(autoProperties);
     }
 
     function removeChoice(property: AutoProperty, i: number) {
         property.choices.splice(i, 1);
-        autoProperties = autoProperties; // Svelte
+        autoProperties = autoProperties; // notify Svelte
         save(autoProperties);
     }
 
     function addChoice(property: AutoProperty) {
-        autoProperties = autoProperties.map(prop => {
-            if (prop === property) {
-                prop.choices.push("");
-            }
-            return prop;
-        })
+        property.choices = [...property.choices, ""];
+        autoProperties = autoProperties; // notify Svelte
+        save(autoProperties);
+    }
+
+    function setType(property: AutoProperty, value: string) {
+        property.type = value as AutoPropertyType;
         save(autoProperties);
     }
 </script>
 
-<div class="centerSettingContent">
-    <table>
-        <thead>
-        <tr>
-            <th></th>
-            <th>Name</th>
-            <th>Values</th>
-        </tr>
-        </thead>
-        {#each autoProperties as property}
-            <tr>
-                <td>
-                    <input type="button" value="❌" class="not-a-button" on:click={() => removeProperty(property)}/>
-                </td>
-                <td>
-                    <input on:change={() => save(autoProperties)} type="text" placeholder="Property name" bind:value={property.name}>
-                </td>
-                <td>
-                    {#each property.choices as choice, i}
-                        <div style="display: block">
-                            <input on:change={() => save(autoProperties)} type="text" bind:value={choice} />
-                            <input class="not-a-button" type="button" value="❌" on:click={() => removeChoice(property, i)}>
-                        </div>
-                    {/each}
-                </td>
-                <td>
-                    <div style="width: 50%; text-align: center; margin: 5px auto auto;">
-                        <input class="not-a-button" type="button" value="➕" on:click={() => addChoice(property)}>
-                    </div>
-                </td>
-            </tr>
-            <br>
-        {/each}
-    </table>
+<div class="metaedit-auto-properties">
+    {#if asList().length === 0}
+        <p class="metaedit-empty">
+            No auto properties yet. Add one to define a reusable set of values for a property.
+        </p>
+    {/if}
 
-    <div class="buttonContainer">
-        <button on:click={addNewProperty} class="mod-cta">Add</button>
+    {#each asList() as property (property)}
+        <div class="metaedit-ap-card">
+            <div class="metaedit-ap-header">
+                <input
+                    class="metaedit-ap-name"
+                    type="text"
+                    placeholder="Property name"
+                    bind:value={property.name}
+                    on:change={() => save(autoProperties)}
+                />
+                <select
+                    class="dropdown metaedit-ap-type"
+                    on:change={(e) => setType(property, e.currentTarget.value)}
+                    aria-label="How many values this property holds"
+                >
+                    {#each types as t}
+                        <option value={t} selected={(property.type ?? "Single") === t}>{t}</option>
+                    {/each}
+                </select>
+                <button
+                    class="clickable-icon metaedit-ap-icon"
+                    aria-label="Remove this auto property"
+                    on:click={() => removeProperty(property)}
+                >
+                    <span use:icon={"trash-2"}></span>
+                </button>
+            </div>
+
+            <input
+                class="metaedit-ap-description"
+                type="text"
+                placeholder="Description (shown when you pick a value) - optional"
+                bind:value={property.description}
+                on:change={() => save(autoProperties)}
+            />
+
+            <div class="metaedit-ap-values">
+                <span class="metaedit-ap-label">Values</span>
+                {#each property.choices as choice, i}
+                    <div class="metaedit-ap-choice">
+                        <input
+                            type="text"
+                            placeholder="Value"
+                            bind:value={choice}
+                            on:change={() => save(autoProperties)}
+                        />
+                        <button
+                            class="clickable-icon metaedit-ap-icon"
+                            aria-label="Remove value"
+                            on:click={() => removeChoice(property, i)}
+                        >
+                            <span use:icon={"x"}></span>
+                        </button>
+                    </div>
+                {/each}
+                <button class="metaedit-ap-add-value" on:click={() => addChoice(property)}>
+                    <span use:icon={"plus"}></span>
+                    Add value
+                </button>
+            </div>
+        </div>
+    {/each}
+
+    <div class="metaedit-ap-footer">
+        <button on:click={addNewProperty} class="mod-cta">Add auto property</button>
     </div>
 </div>
 
 <style>
-    .buttonContainer {
+    .metaedit-auto-properties {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-top: 0.5rem;
+    }
+
+    .metaedit-empty {
+        color: var(--text-muted);
+        text-align: center;
+        margin: 0.5rem 0;
+    }
+
+    .metaedit-ap-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 0.75rem;
+        border: 1px solid var(--background-modifier-border);
+        border-radius: var(--radius-m, 8px);
+        background-color: var(--background-secondary);
+    }
+
+    .metaedit-ap-header {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+    }
+
+    .metaedit-ap-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        font-weight: var(--font-semibold, 600);
+    }
+
+    .metaedit-ap-type {
+        flex: 0 0 auto;
+    }
+
+    .metaedit-ap-description {
+        width: 100%;
+    }
+
+    .metaedit-ap-values {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+    }
+
+    .metaedit-ap-label {
+        color: var(--text-muted);
+        font-size: var(--font-ui-smaller, 0.8em);
+    }
+
+    .metaedit-ap-choice {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+    }
+
+    .metaedit-ap-choice input {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    .metaedit-ap-icon {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+    }
+
+    .metaedit-ap-add-value {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        align-self: flex-start;
+        background: transparent;
+        box-shadow: none;
+        color: var(--text-muted);
+        padding: 0.25rem 0.4rem;
+        cursor: pointer;
+    }
+
+    .metaedit-ap-add-value:hover {
+        color: var(--text-normal);
+    }
+
+    .metaedit-ap-footer {
         display: flex;
         justify-content: center;
-        margin-top: 1rem;
-    }
-
-    select {
-        border-radius: 4px;
-        width: 100%;
-        height: 30px;
-        border: 1px solid #dbdbdc;
-        color: #383a42;
-        background-color: #fff;
-        padding: 3px;
-    }
-
-    button {
-        margin-left: 5px;
-        margin-right: 5px;
-        font-size: 15px;
+        margin-top: 0.25rem;
     }
 </style>

--- a/src/Modals/AutoPropertyValueModal/AutoPropertyValueModal.ts
+++ b/src/Modals/AutoPropertyValueModal/AutoPropertyValueModal.ts
@@ -1,0 +1,64 @@
+import {type App, Modal} from "obsidian";
+import AutoPropertyValueModalContent from "./AutoPropertyValueModalContent.svelte";
+import type {AutoProperty} from "../../Types/autoProperty";
+
+export interface AutoPropertyValueModalOptions {
+    isMulti: boolean;
+    currentValue?: unknown;
+    /** Persist new values into the auto property's choice list (issue #43). */
+    onSaveChoices: (values: string[]) => void | Promise<void>;
+}
+
+/**
+ * The value-entry experience for an Auto Property. Returns a string for a Single
+ * property, a string[] for a Multi property, or null when the user cancels.
+ *
+ * This is deliberately its own modal (rather than the generic prompt/suggester)
+ * so Auto Properties own their selection UX end to end: description display
+ * (#59), pick-or-create with explicit "save as choice" (#43), multi-select
+ * (#40), placeholder text and single-Enter confirm (#30).
+ */
+export default class AutoPropertyValueModal extends Modal {
+    private content: AutoPropertyValueModalContent;
+    private resolvePromise: (value: string | string[] | null) => void;
+    private result: string | string[] | null = null;
+    private didSubmit = false;
+    public readonly waitForClose: Promise<string | string[] | null>;
+
+    public static Show(
+        app: App,
+        autoProperty: AutoProperty,
+        options: AutoPropertyValueModalOptions,
+    ): Promise<string | string[] | null> {
+        return new AutoPropertyValueModal(app, autoProperty, options).waitForClose;
+    }
+
+    private constructor(app: App, autoProperty: AutoProperty, options: AutoPropertyValueModalOptions) {
+        super(app);
+
+        this.waitForClose = new Promise((resolve) => (this.resolvePromise = resolve));
+
+        this.content = new AutoPropertyValueModalContent({
+            target: this.contentEl,
+            props: {
+                autoProperty,
+                isMulti: options.isMulti,
+                currentValue: options.currentValue ?? null,
+                onSaveChoices: options.onSaveChoices,
+                onSubmit: (value: string | string[]) => {
+                    this.result = value;
+                    this.didSubmit = true;
+                    this.close();
+                },
+            },
+        });
+
+        this.open();
+    }
+
+    onClose() {
+        super.onClose();
+        this.content.$destroy();
+        this.resolvePromise(this.didSubmit ? this.result : null);
+    }
+}

--- a/src/Modals/AutoPropertyValueModal/AutoPropertyValueModal.ts
+++ b/src/Modals/AutoPropertyValueModal/AutoPropertyValueModal.ts
@@ -16,7 +16,9 @@ export interface AutoPropertyValueModalOptions {
  * This is deliberately its own modal (rather than the generic prompt/suggester)
  * so Auto Properties own their selection UX end to end: description display
  * (#59), pick-or-create with explicit "save as choice" (#43), multi-select
- * (#40), placeholder text and single-Enter confirm (#30).
+ * (#40), placeholder text and single-Enter confirm (#30). The small amount of
+ * filter/keyboard logic is intentionally self-contained here rather than reusing
+ * the generic suggester, whose concerns (free-text autocomplete) differ.
  */
 export default class AutoPropertyValueModal extends Modal {
     private content: AutoPropertyValueModalContent;

--- a/src/Modals/AutoPropertyValueModal/AutoPropertyValueModalContent.svelte
+++ b/src/Modals/AutoPropertyValueModal/AutoPropertyValueModalContent.svelte
@@ -45,10 +45,19 @@
         return items;
     }
 
-    function chooseSingle(item: SingleItem) {
+    async function persistChoices(values: string[]) {
+        try {
+            await onSaveChoices(values);
+        } catch (e) {
+            // The chosen value is still valid; persistence is best-effort.
+            console.error("MetaEdit: failed to save new auto property choice", e);
+        }
+    }
+
+    async function chooseSingle(item: SingleItem) {
         if (!item) return;
         if (item.kind === "save") {
-            void onSaveChoices([item.value]);
+            await persistChoices([item.value]);
         }
         onSubmit(item.value);
     }
@@ -99,7 +108,7 @@
     async function confirmMulti() {
         const result = options.filter((o) => checked.has(o));
         if (saveNew && newCheckedValues.length > 0) {
-            await onSaveChoices(newCheckedValues);
+            await persistChoices(newCheckedValues);
         }
         onSubmit(result);
     }

--- a/src/Modals/AutoPropertyValueModal/AutoPropertyValueModalContent.svelte
+++ b/src/Modals/AutoPropertyValueModal/AutoPropertyValueModalContent.svelte
@@ -1,0 +1,290 @@
+<script lang="ts">
+    import {onMount} from "svelte";
+    import {setIcon} from "obsidian";
+    import type {AutoProperty} from "../../Types/autoProperty";
+    import {multiSelectOptions, normalizeChoices, toValueArray} from "../../autoProperties";
+
+    export let autoProperty: AutoProperty;
+    export let isMulti: boolean = false;
+    export let currentValue: unknown = null;
+    export let onSubmit: (value: string | string[]) => void;
+    export let onSaveChoices: (values: string[]) => void | Promise<void>;
+
+    interface SingleItem {
+        kind: "choice" | "use" | "save";
+        value: string;
+        label: string;
+    }
+
+    const choices = normalizeChoices(autoProperty.choices);
+
+    let inputEl: HTMLInputElement;
+    let query = "";
+    let highlight = 0;
+
+    // Svelte action for a lucide icon via Obsidian's setIcon.
+    function icon(node: HTMLElement, name: string) {
+        node.textContent = "";
+        setIcon(node, name);
+        return {};
+    }
+
+    // --- Single mode ---------------------------------------------------------
+    $: trimmedQuery = query.trim();
+    $: filtered = choices.filter((c) => c.toLowerCase().includes(trimmedQuery.toLowerCase()));
+    $: exactMatch = choices.some((c) => c.toLowerCase() === trimmedQuery.toLowerCase());
+    $: singleItems = buildSingleItems(filtered, trimmedQuery, exactMatch);
+    $: if (highlight > singleItems.length - 1) highlight = Math.max(0, singleItems.length - 1);
+
+    function buildSingleItems(matches: string[], q: string, exact: boolean): SingleItem[] {
+        const items: SingleItem[] = matches.map((c) => ({kind: "choice", value: c, label: c}));
+        if (q !== "" && !exact) {
+            items.push({kind: "use", value: q, label: `Use "${q}"`});
+            items.push({kind: "save", value: q, label: `Save "${q}" as a choice`});
+        }
+        return items;
+    }
+
+    function chooseSingle(item: SingleItem) {
+        if (!item) return;
+        if (item.kind === "save") {
+            void onSaveChoices([item.value]);
+        }
+        onSubmit(item.value);
+    }
+
+    function onSingleKeydown(e: KeyboardEvent) {
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            highlight = Math.min(highlight + 1, singleItems.length - 1);
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            highlight = Math.max(highlight - 1, 0);
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            if (singleItems.length > 0) chooseSingle(singleItems[highlight]);
+            else if (trimmedQuery !== "") onSubmit(trimmedQuery);
+        }
+    }
+
+    // --- Multi mode ----------------------------------------------------------
+    let options: string[] = isMulti ? multiSelectOptions(autoProperty, currentValue) : [];
+    let checked: Set<string> = new Set(toValueArray(currentValue));
+    let saveNew = false;
+
+    $: newCheckedValues = options.filter((o) => checked.has(o) && !choices.includes(o));
+
+    function toggleCheck(value: string) {
+        if (checked.has(value)) checked.delete(value);
+        else checked.add(value);
+        checked = checked; // notify Svelte
+    }
+
+    function addMultiValue() {
+        const value = query.trim();
+        if (value === "") return;
+        if (!options.includes(value)) options = [...options, value];
+        checked.add(value);
+        checked = checked;
+        query = "";
+    }
+
+    function onMultiAddKeydown(e: KeyboardEvent) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            addMultiValue();
+        }
+    }
+
+    async function confirmMulti() {
+        const result = options.filter((o) => checked.has(o));
+        if (saveNew && newCheckedValues.length > 0) {
+            await onSaveChoices(newCheckedValues);
+        }
+        onSubmit(result);
+    }
+
+    onMount(() => inputEl?.focus());
+</script>
+
+<div class="metaedit-ap-prompt">
+    <div class="metaedit-ap-prompt-head">
+        <div class="metaedit-ap-prompt-title">{autoProperty.name}</div>
+        {#if autoProperty.description}
+            <div class="metaedit-ap-prompt-desc">{autoProperty.description}</div>
+        {/if}
+    </div>
+
+    {#if isMulti}
+        <input
+            bind:this={inputEl}
+            class="metaedit-ap-prompt-input"
+            type="text"
+            placeholder="Type a value and press Enter to add it"
+            bind:value={query}
+            on:keydown={onMultiAddKeydown}
+        />
+        <div class="metaedit-ap-prompt-list" role="listbox" aria-multiselectable="true">
+            {#each options as option (option)}
+                <label class="metaedit-ap-prompt-row metaedit-ap-prompt-check">
+                    <input type="checkbox" checked={checked.has(option)} on:change={() => toggleCheck(option)} />
+                    <span class="metaedit-ap-prompt-row-label">{option}</span>
+                    {#if !choices.includes(option)}
+                        <span class="metaedit-ap-prompt-tag">new</span>
+                    {/if}
+                </label>
+            {:else}
+                <div class="metaedit-ap-prompt-empty">No values yet - type one above and press Enter.</div>
+            {/each}
+        </div>
+        {#if newCheckedValues.length > 0}
+            <label class="metaedit-ap-prompt-savenew">
+                <input type="checkbox" bind:checked={saveNew} />
+                Also add new values to this property's choice list
+            </label>
+        {/if}
+        <div class="metaedit-ap-prompt-actions">
+            <button class="mod-cta" on:click={confirmMulti}>Confirm</button>
+        </div>
+    {:else}
+        <input
+            bind:this={inputEl}
+            class="metaedit-ap-prompt-input"
+            type="text"
+            placeholder="Pick a value, or type a new one"
+            bind:value={query}
+            on:keydown={onSingleKeydown}
+        />
+        <div class="metaedit-ap-prompt-list" role="listbox">
+            {#each singleItems as item, i (item.kind + item.value)}
+                <button
+                    class="metaedit-ap-prompt-row"
+                    class:is-selected={i === highlight}
+                    class:metaedit-ap-prompt-action={item.kind !== "choice"}
+                    on:click={() => chooseSingle(item)}
+                    on:mouseenter={() => (highlight = i)}
+                >
+                    {#if item.kind === "save"}
+                        <span class="metaedit-ap-prompt-row-icon" use:icon={"plus"}></span>
+                    {:else if item.kind === "use"}
+                        <span class="metaedit-ap-prompt-row-icon" use:icon={"corner-down-left"}></span>
+                    {/if}
+                    <span class="metaedit-ap-prompt-row-label">{item.label}</span>
+                </button>
+            {:else}
+                <div class="metaedit-ap-prompt-empty">No choices defined - type a value and press Enter.</div>
+            {/each}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .metaedit-ap-prompt {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+    }
+
+    .metaedit-ap-prompt-head {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+    }
+
+    .metaedit-ap-prompt-title {
+        font-size: var(--font-ui-large, 1.1em);
+        font-weight: var(--font-semibold, 600);
+        color: var(--text-normal);
+    }
+
+    .metaedit-ap-prompt-desc {
+        color: var(--text-muted);
+        font-size: var(--font-ui-small, 0.85em);
+        line-height: 1.4;
+    }
+
+    .metaedit-ap-prompt-input {
+        width: 100%;
+    }
+
+    .metaedit-ap-prompt-list {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        max-height: 16rem;
+        overflow-y: auto;
+    }
+
+    .metaedit-ap-prompt-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        width: 100%;
+        text-align: left;
+        padding: 0.4rem 0.55rem;
+        border-radius: var(--radius-s, 4px);
+        background: transparent;
+        box-shadow: none;
+        color: var(--text-normal);
+        cursor: pointer;
+        font-size: var(--font-ui-medium, 1em);
+    }
+
+    .metaedit-ap-prompt-row.is-selected {
+        background-color: var(--background-modifier-hover);
+    }
+
+    .metaedit-ap-prompt-action {
+        color: var(--text-muted);
+    }
+
+    .metaedit-ap-prompt-check {
+        cursor: pointer;
+    }
+
+    .metaedit-ap-prompt-check input {
+        margin: 0;
+    }
+
+    .metaedit-ap-prompt-row-icon {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    .metaedit-ap-prompt-row-label {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .metaedit-ap-prompt-tag {
+        flex: 0 0 auto;
+        font-size: var(--font-ui-smaller, 0.75em);
+        color: var(--text-accent);
+        border: 1px solid var(--background-modifier-border);
+        border-radius: var(--radius-s, 4px);
+        padding: 0 0.3rem;
+    }
+
+    .metaedit-ap-prompt-empty {
+        color: var(--text-muted);
+        padding: 0.4rem 0.55rem;
+        font-size: var(--font-ui-small, 0.85em);
+    }
+
+    .metaedit-ap-prompt-savenew {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--text-muted);
+        font-size: var(--font-ui-small, 0.85em);
+        cursor: pointer;
+    }
+
+    .metaedit-ap-prompt-actions {
+        display: flex;
+        justify-content: flex-end;
+    }
+</style>

--- a/src/Types/autoProperty.ts
+++ b/src/Types/autoProperty.ts
@@ -1,4 +1,14 @@
+export type AutoPropertyType = "Single" | "Multi";
+
 export interface AutoProperty {
     name: string,
-    choices: string[]
+    choices: string[],
+    /** Optional, human-readable note shown in the value prompt (issue #59). */
+    description?: string,
+    /**
+     * Selection behaviour in the value prompt (issue #40).
+     * "Single" (default / undefined) lets you pick one value.
+     * "Multi" lets you pick several values, written as a list.
+     */
+    type?: AutoPropertyType,
 }

--- a/src/autoProperties.test.ts
+++ b/src/autoProperties.test.ts
@@ -12,7 +12,7 @@ import {
 import type {AutoProperty} from "./Types/autoProperty";
 import {EditMode} from "./Types/editMode";
 
-const single: AutoProperty = {name: "status", choices: ["todo", "done"]};
+const single: AutoProperty = {name: "status", choices: ["todo", "done"], type: "Single"};
 const multi: AutoProperty = {name: "tags", choices: ["a", "b"], type: "Multi"};
 
 describe("findAutoProperty", () => {
@@ -38,20 +38,28 @@ describe("isMultiAutoProperty", () => {
 
     it("is multi when the property declares type Multi, regardless of EditMode", () => {
         expect(isMultiAutoProperty(multi, allSingle, "tags")).toBe(true);
+        expect(isMultiAutoProperty(multi, {mode: EditMode.AllSingle, properties: []}, "tags")).toBe(true);
     });
 
-    it("is single for a Single property under AllSingle", () => {
+    it("is single for an explicit Single property under AllSingle", () => {
         expect(isMultiAutoProperty(single, allSingle, "status")).toBe(false);
     });
 
-    it("is multi when EditMode is AllMulti even for a Single property", () => {
-        expect(isMultiAutoProperty(single, {mode: EditMode.AllMulti, properties: []}, "status")).toBe(true);
+    it("an explicit Single property overrides AllMulti (type is authoritative)", () => {
+        expect(isMultiAutoProperty(single, {mode: EditMode.AllMulti, properties: []}, "status")).toBe(false);
     });
 
-    it("is multi under SomeMulti only when the property is listed", () => {
+    it("a type-less property inherits the global EditMode", () => {
+        const legacy: AutoProperty = {name: "status", choices: ["todo"]};
+        expect(isMultiAutoProperty(legacy, allSingle, "status")).toBe(false);
+        expect(isMultiAutoProperty(legacy, {mode: EditMode.AllMulti, properties: []}, "status")).toBe(true);
+    });
+
+    it("a type-less property under SomeMulti is multi only when listed", () => {
+        const legacy: AutoProperty = {name: "status", choices: ["todo"]};
         const some = {mode: EditMode.SomeMulti, properties: ["status"]};
-        expect(isMultiAutoProperty(single, some, "status")).toBe(true);
-        expect(isMultiAutoProperty(single, some, "other")).toBe(false);
+        expect(isMultiAutoProperty(legacy, some, "status")).toBe(true);
+        expect(isMultiAutoProperty(legacy, some, "other")).toBe(false);
     });
 });
 
@@ -85,12 +93,16 @@ describe("toValueArray", () => {
 });
 
 describe("multiSelectOptions", () => {
-    it("lists choices first then current values not already a choice", () => {
-        expect(multiSelectOptions(multi, ["b", "custom"])).toEqual(["a", "b", "custom"]);
+    it("lists current values first (preserving order) then remaining choices", () => {
+        expect(multiSelectOptions(multi, ["b", "custom"])).toEqual(["b", "custom", "a"]);
     });
 
     it("never drops a pre-existing value that is not a defined choice", () => {
         expect(multiSelectOptions({name: "x", choices: []}, ["kept"])).toEqual(["kept"]);
+    });
+
+    it("returns the defined choices when there is no current value", () => {
+        expect(multiSelectOptions(multi, null)).toEqual(["a", "b"]);
     });
 });
 

--- a/src/autoProperties.test.ts
+++ b/src/autoProperties.test.ts
@@ -1,0 +1,116 @@
+import {describe, expect, it} from "vitest";
+import {
+    autoPropertyType,
+    findAutoProperty,
+    isMultiAutoProperty,
+    isNewChoice,
+    multiSelectOptions,
+    normalizeChoices,
+    toValueArray,
+    withChoiceAdded,
+} from "./autoProperties";
+import type {AutoProperty} from "./Types/autoProperty";
+import {EditMode} from "./Types/editMode";
+
+const single: AutoProperty = {name: "status", choices: ["todo", "done"]};
+const multi: AutoProperty = {name: "tags", choices: ["a", "b"], type: "Multi"};
+
+describe("findAutoProperty", () => {
+    it("returns the first match by name", () => {
+        expect(findAutoProperty([single, multi], "tags")).toBe(multi);
+    });
+
+    it("returns undefined when absent or list missing", () => {
+        expect(findAutoProperty([single], "nope")).toBeUndefined();
+        expect(findAutoProperty(undefined, "status")).toBeUndefined();
+    });
+});
+
+describe("autoPropertyType", () => {
+    it("treats a missing type as Single (back-compat with old data.json)", () => {
+        expect(autoPropertyType({name: "x", choices: []})).toBe("Single");
+        expect(autoPropertyType(multi)).toBe("Multi");
+    });
+});
+
+describe("isMultiAutoProperty", () => {
+    const allSingle = {mode: EditMode.AllSingle, properties: []};
+
+    it("is multi when the property declares type Multi, regardless of EditMode", () => {
+        expect(isMultiAutoProperty(multi, allSingle, "tags")).toBe(true);
+    });
+
+    it("is single for a Single property under AllSingle", () => {
+        expect(isMultiAutoProperty(single, allSingle, "status")).toBe(false);
+    });
+
+    it("is multi when EditMode is AllMulti even for a Single property", () => {
+        expect(isMultiAutoProperty(single, {mode: EditMode.AllMulti, properties: []}, "status")).toBe(true);
+    });
+
+    it("is multi under SomeMulti only when the property is listed", () => {
+        const some = {mode: EditMode.SomeMulti, properties: ["status"]};
+        expect(isMultiAutoProperty(single, some, "status")).toBe(true);
+        expect(isMultiAutoProperty(single, some, "other")).toBe(false);
+    });
+});
+
+describe("normalizeChoices", () => {
+    it("trims, drops empties, and de-dupes while preserving order", () => {
+        expect(normalizeChoices([" todo ", "todo", "", "done", "  "])).toEqual(["todo", "done"]);
+    });
+
+    it("handles undefined", () => {
+        expect(normalizeChoices(undefined)).toEqual([]);
+    });
+});
+
+describe("toValueArray", () => {
+    it("returns [] for null/undefined", () => {
+        expect(toValueArray(null)).toEqual([]);
+        expect(toValueArray(undefined)).toEqual([]);
+    });
+
+    it("splits CSV strings", () => {
+        expect(toValueArray("a, b ,c")).toEqual(["a", "b", "c"]);
+    });
+
+    it("strips YAML inline-array brackets", () => {
+        expect(toValueArray("[a, b]")).toEqual(["a", "b"]);
+    });
+
+    it("passes through arrays", () => {
+        expect(toValueArray(["a", " b ", "", "c"])).toEqual(["a", "b", "c"]);
+    });
+});
+
+describe("multiSelectOptions", () => {
+    it("lists choices first then current values not already a choice", () => {
+        expect(multiSelectOptions(multi, ["b", "custom"])).toEqual(["a", "b", "custom"]);
+    });
+
+    it("never drops a pre-existing value that is not a defined choice", () => {
+        expect(multiSelectOptions({name: "x", choices: []}, ["kept"])).toEqual(["kept"]);
+    });
+});
+
+describe("isNewChoice / withChoiceAdded", () => {
+    it("detects values not already in choices (trim-insensitive)", () => {
+        expect(isNewChoice(single, "todo")).toBe(false);
+        expect(isNewChoice(single, " todo ")).toBe(false);
+        expect(isNewChoice(single, "blocked")).toBe(true);
+        expect(isNewChoice(single, "  ")).toBe(false);
+    });
+
+    it("appends a trimmed new choice immutably", () => {
+        const next = withChoiceAdded(single, " blocked ");
+        expect(next).not.toBe(single);
+        expect(next.choices).toEqual(["todo", "done", "blocked"]);
+        expect(single.choices).toEqual(["todo", "done"]);
+    });
+
+    it("returns the same reference when nothing is added", () => {
+        expect(withChoiceAdded(single, "todo")).toBe(single);
+        expect(withChoiceAdded(single, "  ")).toBe(single);
+    });
+});

--- a/src/autoProperties.ts
+++ b/src/autoProperties.ts
@@ -26,19 +26,22 @@ export function autoPropertyType(autoProp: AutoProperty): AutoPropertyType {
 }
 
 /**
- * Whether an auto property should offer multi-select. This is the UNION of two
- * independent signals, so the per-property declaration never fights the global
- * EditMode - the more permissive one wins:
- *   - the auto property is explicitly declared "Multi", or
- *   - EditMode already treats this property as multi (AllMulti, or SomeMulti and
- *     the property is in the list).
+ * Whether an auto property should offer multi-select.
+ *
+ * An explicit `type` is authoritative: "Multi" is always multi, "Single" is
+ * always single - so the per-property choice wins over the global EditMode in
+ * both directions. When `type` is absent (data from before this field existed)
+ * the property inherits the global EditMode (AllMulti, or SomeMulti and the
+ * property is in the list), preserving prior behaviour on upgrade.
  */
 export function isMultiAutoProperty(
     autoProp: AutoProperty,
     editMode: EditModeSettings,
     propertyName: string,
 ): boolean {
-    if (autoPropertyType(autoProp) === "Multi") return true;
+    if (autoProp.type === "Multi") return true;
+    if (autoProp.type === "Single") return false;
+    // No explicit type: inherit the global EditMode.
     if (editMode.mode === EditMode.AllMulti) return true;
     if (editMode.mode === EditMode.SomeMulti && editMode.properties.includes(propertyName)) {
         return true;
@@ -76,15 +79,16 @@ export function toValueArray(content: unknown): string[] {
 }
 
 /**
- * The pre-checked option list for a multi prompt: the defined choices first, then
- * any current values that are not already a choice (so editing never silently
- * drops a value the user already had).
+ * The option list for a multi prompt: the current values first, in their existing
+ * order, then the defined choices that are not already set. Current-first keeps a
+ * user's existing list order stable - newly checked choices append at the end
+ * rather than reshuffling what was already there - and never drops a value the
+ * user already had, even if it is not a defined choice.
  */
 export function multiSelectOptions(autoProp: AutoProperty, currentValue: unknown): string[] {
-    const choices = normalizeChoices(autoProp.choices);
-    const seen = new Set(choices);
-    const out = [...choices];
-    for (const value of toValueArray(currentValue)) {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const value of [...toValueArray(currentValue), ...normalizeChoices(autoProp.choices)]) {
         if (!seen.has(value)) {
             seen.add(value);
             out.push(value);

--- a/src/autoProperties.ts
+++ b/src/autoProperties.ts
@@ -1,0 +1,110 @@
+import type {AutoProperty, AutoPropertyType} from "./Types/autoProperty";
+import {EditMode} from "./Types/editMode";
+
+/**
+ * Pure, Obsidian-free helpers for the Auto Properties feature. Kept separate from
+ * `metaController` and the Svelte modals so the logic can be unit-tested in the
+ * jsdom-free `node` test environment.
+ */
+
+export interface EditModeSettings {
+    mode: EditMode;
+    properties: string[];
+}
+
+/** Find the auto property whose name matches `propertyName` (first match wins). */
+export function findAutoProperty(
+    properties: AutoProperty[] | undefined,
+    propertyName: string,
+): AutoProperty | undefined {
+    return properties?.find((a) => a.name === propertyName);
+}
+
+/** The effective selection type, treating a missing `type` as "Single". */
+export function autoPropertyType(autoProp: AutoProperty): AutoPropertyType {
+    return autoProp.type === "Multi" ? "Multi" : "Single";
+}
+
+/**
+ * Whether an auto property should offer multi-select. This is the UNION of two
+ * independent signals, so the per-property declaration never fights the global
+ * EditMode - the more permissive one wins:
+ *   - the auto property is explicitly declared "Multi", or
+ *   - EditMode already treats this property as multi (AllMulti, or SomeMulti and
+ *     the property is in the list).
+ */
+export function isMultiAutoProperty(
+    autoProp: AutoProperty,
+    editMode: EditModeSettings,
+    propertyName: string,
+): boolean {
+    if (autoPropertyType(autoProp) === "Multi") return true;
+    if (editMode.mode === EditMode.AllMulti) return true;
+    if (editMode.mode === EditMode.SomeMulti && editMode.properties.includes(propertyName)) {
+        return true;
+    }
+    return false;
+}
+
+/** Trimmed, de-duplicated, non-empty choices - what the prompt should display. */
+export function normalizeChoices(choices: string[] | undefined): string[] {
+    if (!choices) return [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const raw of choices) {
+        const choice = (raw ?? "").trim();
+        if (choice === "" || seen.has(choice)) continue;
+        seen.add(choice);
+        out.push(choice);
+    }
+    return out;
+}
+
+/** Coerce a stored property value (string, CSV, YAML array, or list) into values. */
+export function toValueArray(content: unknown): string[] {
+    if (content === null || content === undefined) return [];
+    if (Array.isArray(content)) {
+        return content.map((v) => (v ?? "").toString().trim()).filter(Boolean);
+    }
+    return content
+        .toString()
+        .replace(/^\s*\[/, "")
+        .replace(/\]\s*$/, "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+}
+
+/**
+ * The pre-checked option list for a multi prompt: the defined choices first, then
+ * any current values that are not already a choice (so editing never silently
+ * drops a value the user already had).
+ */
+export function multiSelectOptions(autoProp: AutoProperty, currentValue: unknown): string[] {
+    const choices = normalizeChoices(autoProp.choices);
+    const seen = new Set(choices);
+    const out = [...choices];
+    for (const value of toValueArray(currentValue)) {
+        if (!seen.has(value)) {
+            seen.add(value);
+            out.push(value);
+        }
+    }
+    return out;
+}
+
+/** True when `value` is a non-empty value not already among the defined choices. */
+export function isNewChoice(autoProp: AutoProperty, value: string): boolean {
+    const trimmed = value.trim();
+    if (trimmed === "") return false;
+    return !(autoProp.choices ?? []).some((c) => (c ?? "").trim() === trimmed);
+}
+
+/**
+ * Immutably append `value` to an auto property's choices, trimming and de-duping.
+ * Returns the same reference when nothing changes so callers can skip a save.
+ */
+export function withChoiceAdded(autoProp: AutoProperty, value: string): AutoProperty {
+    if (!isNewChoice(autoProp, value)) return autoProp;
+    return {...autoProp, choices: [...(autoProp.choices ?? []), value.trim()]};
+}

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -13,7 +13,7 @@ import {Notice, normalizePath} from "obsidian";
 import {log} from "./logger/logManager";
 import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoPropertyValueModal";
 import type {AutoProperty} from "./Types/autoProperty";
-import {findAutoProperty, isMultiAutoProperty, withChoiceAdded} from "./autoProperties";
+import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
 
@@ -42,8 +42,10 @@ export default class MetaController {
 
     public async addYamlProp(propName: string, propValue: unknown, file: TFile): Promise<void> {
         const settings = this.plugin.settings;
-        if (settings.EditMode.mode === EditMode.AllMulti ||
-            (settings.EditMode.mode === EditMode.SomeMulti && settings.EditMode.properties.contains(propName))) {
+        if (!Array.isArray(propValue) &&
+            (settings.EditMode.mode === EditMode.AllMulti ||
+            (settings.EditMode.mode === EditMode.SomeMulti && settings.EditMode.properties.contains(propName)))) {
+            // A Multi auto property already produced a list; don't nest it.
             propValue = [propValue];
         }
 
@@ -121,13 +123,14 @@ export default class MetaController {
             newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`)
             this.useTrackerPlugin = true;
         } else if (method === metaEditMethod) {
-            const autoProp = await this.handleAutoProperties(allButLast);
-
-            if (autoProp)
+            if (this.getActiveAutoProperty(allButLast)) {
+                const autoProp = await this.handleAutoProperties(allButLast);
+                if (autoProp === null) return; // user cancelled the auto property prompt
                 // A tag is a single token; collapse a multi result into one string.
                 newValue = Array.isArray(autoProp) ? autoProp.join(", ") : autoProp;
-            else
+            } else {
                 newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`);
+            }
         }
 
         if (newValue) {
@@ -161,16 +164,16 @@ export default class MetaController {
         if (!propName) return null;
 
         let propValue: string | string[];
-        const autoProp = await this.handleAutoProperties(propName);
-
-        if (autoProp !== null) {
+        if (this.getActiveAutoProperty(propName)) {
+            const autoProp = await this.handleAutoProperties(propName);
+            if (autoProp === null) return null; // user cancelled the auto property prompt
             propValue = autoProp;
         } else {
-            propValue = await GenericPrompt.Prompt(this.app, "Enter a property value", "Value")
+            const entered = await GenericPrompt.Prompt(this.app, "Enter a property value", "Value")
                 .catch(() => null);
+            if (entered === null) return null;
+            propValue = entered;
         }
-
-        if (propValue === null) return null;
 
         return {propName, propValue: typeof propValue === "string" ? propValue.trim() : propValue};
     }
@@ -322,17 +325,21 @@ export default class MetaController {
     }
 
     private async persistAutoPropertyChoices(autoProp: AutoProperty, values: string[]): Promise<void> {
-        let updated = autoProp;
+        const list = this.plugin.settings.AutoProperties.properties;
+        // Prefer the exact object, but fall back to name so we still resolve if the
+        // settings tab replaced the entry while the prompt was open.
+        const idx = list.indexOf(autoProp) !== -1 ? list.indexOf(autoProp) : list.findIndex(a => a.name === autoProp.name);
+        if (idx === -1) return;
+
+        // Append to the LIVE entry's current choices so a concurrent settings-tab
+        // edit is preserved rather than overwritten with a stale snapshot.
+        let updated = list[idx];
         for (const value of values) {
             updated = withChoiceAdded(updated, value);
         }
-        if (updated === autoProp) return; // nothing new
+        if (updated === list[idx]) return; // nothing new
 
-        const list = this.plugin.settings.AutoProperties.properties;
-        const idx = list.findIndex(a => a === autoProp || a.name === autoProp.name);
-        if (idx === -1) return;
-
-        list[idx] = {...list[idx], choices: updated.choices};
+        list[idx] = updated;
         await this.plugin.saveSettings();
     }
 
@@ -453,20 +460,7 @@ export default class MetaController {
     }
 
     private splitMultiValue(property: Partial<Property>): string[] {
-        const content = property.content;
-
-        if (Array.isArray(content)) {
-            return content.map(prop => prop?.toString().trim() ?? "").filter(Boolean);
-        }
-
-        if (content === null || content === undefined) return [];
-
-        return content.toString()
-            .replace(/^\s*\[/, "")
-            .replace(/\]\s*$/, "")
-            .split(",")
-            .map(prop => prop.trim())
-            .filter(Boolean);
+        return toValueArray(property.content);
     }
 
     private async processFrontMatter(file: TFile, update: (frontmatter: Record<string, unknown>) => void): Promise<void> {

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -11,6 +11,9 @@ import {ProgressPropertyOptions} from "./Types/progressPropertyOptions";
 import {MetaType} from "./Types/metaType";
 import {Notice, normalizePath} from "obsidian";
 import {log} from "./logger/logManager";
+import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoPropertyValueModal";
+import type {AutoProperty} from "./Types/autoProperty";
+import {findAutoProperty, isMultiAutoProperty, withChoiceAdded} from "./autoProperties";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
 
@@ -61,7 +64,8 @@ export default class MetaController {
         }
     }
 
-    public async addDataviewField(propName: string, propValue: string, file: TFile): Promise<void> {
+    public async addDataviewField(propName: string, propValue: unknown, file: TFile): Promise<void> {
+        const valueStr = Array.isArray(propValue) ? propValue.join(", ") : String(propValue);
         const fileContent: string = await this.app.vault.read(file);
         const lines = fileContent.split("\n").reduce((obj: {[key: string]: string}, line: string, idx: number) => {
             obj[idx] = !!line ? line : "";
@@ -73,7 +77,7 @@ export default class MetaController {
 
         const splitContent: string[] = fileContent.split("\n");
         if (typeof appendAfter === "number" || parseInt(appendAfter)) {
-            splitContent.splice(parseInt(appendAfter), 0, `${propName}:: ${propValue}`);
+            splitContent.splice(parseInt(appendAfter), 0, `${propName}:: ${valueStr}`);
         }
         const newFileContent = splitContent.join("\n");
 
@@ -83,9 +87,19 @@ export default class MetaController {
     public async editMetaElement(property: Property, meta: Property[], file: TFile): Promise<void> {
         const mode: EditMode = this.plugin.settings.EditMode.mode;
 
-        if (property.type === MetaType.Tag)
+        if (property.type === MetaType.Tag) {
             await this.editTag(property, file);
-        else if (mode === EditMode.AllMulti || mode === EditMode.SomeMulti)
+            return;
+        }
+
+        // Auto Properties own their value-entry UX (description, pick-or-create,
+        // single/multi). They take precedence over the global EditMode flow.
+        if (this.getActiveAutoProperty(property.key)) {
+            await this.editAutoProperty(property, file);
+            return;
+        }
+
+        if (mode === EditMode.AllMulti || mode === EditMode.SomeMulti)
             await this.multiValueMode(property, file);
         else
             await this.standardMode(property, file);
@@ -110,7 +124,8 @@ export default class MetaController {
             const autoProp = await this.handleAutoProperties(allButLast);
 
             if (autoProp)
-                newValue = autoProp;
+                // A tag is a single token; collapse a multi result into one string.
+                newValue = Array.isArray(autoProp) ? autoProp.join(", ") : autoProp;
             else
                 newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`);
         }
@@ -145,10 +160,10 @@ export default class MetaController {
         const propName = await GenericPrompt.Prompt(this.app, "Enter a property name", "Property", "", suggestValues);
         if (!propName) return null;
 
-        let propValue: string;
+        let propValue: string | string[];
         const autoProp = await this.handleAutoProperties(propName);
 
-        if (autoProp) {
+        if (autoProp !== null) {
             propValue = autoProp;
         } else {
             propValue = await GenericPrompt.Prompt(this.app, "Enter a property value", "Value")
@@ -157,7 +172,7 @@ export default class MetaController {
 
         if (propValue === null) return null;
 
-        return {propName, propValue: propValue.trim()};
+        return {propName, propValue: typeof propValue === "string" ? propValue.trim() : propValue};
     }
 
     public async deleteProperty(property: Property, file: TFile): Promise<void> {
@@ -196,13 +211,9 @@ export default class MetaController {
     }
 
     private async standardMode(property: Property, file: TFile): Promise<void> {
-        const autoProp = await this.handleAutoProperties(property.key);
-        let newValue;
-
-        if (autoProp)
-            newValue = autoProp;
-        else
-            newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`, property.content, property.content);
+        // Auto Properties are intercepted in editMetaElement, so this path only
+        // handles free-text values.
+        const newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`, property.content, property.content);
 
         if (newValue) {
             await this.updatePropertyInFile(property, newValue, file);
@@ -237,10 +248,8 @@ export default class MetaController {
         if (!selectedOption) return;
         let selectedIndex;
 
-        const autoProp = await this.handleAutoProperties(property.key);
-        if (autoProp) {
-            tempValue = autoProp;
-        } else if (selectedOption.includes("cmd")) {
+        // Auto Properties are intercepted in editMetaElement; this path is free-text.
+        if (selectedOption.includes("cmd")) {
             tempValue = await GenericPrompt.Prompt(this.app, "Enter a new value");
         } else {
             selectedIndex = splitValues.findIndex(el => el == selectedOption);
@@ -278,15 +287,53 @@ export default class MetaController {
         return false;
     }
 
-    public async handleAutoProperties(propertyName: string): Promise<string> {
-        const autoProp = this.plugin.settings.AutoProperties.properties.find(a => a.name === propertyName);
+    private getActiveAutoProperty(propertyName: string): AutoProperty | undefined {
+        if (!this.plugin.settings.AutoProperties.enabled) return undefined;
+        return findAutoProperty(this.plugin.settings.AutoProperties.properties, propertyName);
+    }
 
-        if (this.plugin.settings.AutoProperties.enabled && autoProp) {
-            const options = autoProp.choices;
-            return await GenericPrompt.Prompt(this.app, `Enter a new value for ${propertyName}`, '', '', options);
+    /**
+     * Open the Auto Property value prompt for `propertyName`, if one is defined and
+     * enabled. Returns a string for a Single property, a string[] for a Multi
+     * property, or null when there is no auto property or the user cancels.
+     */
+    public async handleAutoProperties(propertyName: string, currentValue?: unknown): Promise<string | string[] | null> {
+        const autoProp = this.getActiveAutoProperty(propertyName);
+        if (!autoProp) return null;
+
+        const isMulti = isMultiAutoProperty(autoProp, this.plugin.settings.EditMode, propertyName);
+
+        return await AutoPropertyValueModal.Show(this.app, autoProp, {
+            isMulti,
+            currentValue,
+            onSaveChoices: (values: string[]) => this.persistAutoPropertyChoices(autoProp, values),
+        });
+    }
+
+    private async editAutoProperty(property: Property, file: TFile): Promise<void> {
+        const result = await this.handleAutoProperties(property.key, property.content);
+        if (result === null || result === undefined) return;
+
+        // YAML keeps a real list; inline/tag fields store a comma-joined string.
+        const newValue: unknown =
+            Array.isArray(result) && property.type !== MetaType.YAML ? result.join(", ") : result;
+
+        await this.updatePropertyInFile(property, newValue, file);
+    }
+
+    private async persistAutoPropertyChoices(autoProp: AutoProperty, values: string[]): Promise<void> {
+        let updated = autoProp;
+        for (const value of values) {
+            updated = withChoiceAdded(updated, value);
         }
+        if (updated === autoProp) return; // nothing new
 
-        return null;
+        const list = this.plugin.settings.AutoProperties.properties;
+        const idx = list.findIndex(a => a === autoProp || a.name === autoProp.name);
+        if (idx === -1) return;
+
+        list[idx] = {...list[idx], choices: updated.choices};
+        await this.plugin.saveSettings();
     }
 
     public async updatePropertyInFile(property: Partial<Property>, newValue: unknown, file: TFile): Promise<void> {

--- a/tests/e2e/auto-properties.test.ts
+++ b/tests/e2e/auto-properties.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from "vitest";
+import {
+	createMetaEditE2EHarness,
+	evalJsonAsync,
+	PLUGIN_ID,
+} from "./harness";
+import type { AutoProperty } from "../../src/Types/autoProperty";
+
+const getContext = createMetaEditE2EHarness("metaedit-auto-properties");
+
+// Drive a real Auto Property edit through plugin.controller.editMetaElement and
+// the AutoPropertyValueModal, manipulating the modal DOM exactly as a user would.
+// Returns the file contents after the edit plus the persisted choices, so each
+// test can assert on real on-disk results.
+async function runAutoPropertyEdit(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	opts: {
+		notePath: string;
+		noteBody: string;
+		property: string;
+		autoProperties: AutoProperty[];
+		editMode?: string;
+		// A function body (string) run with `dom` helpers + `modal` element in scope
+		// to interact with the modal. Must leave the modal on a path to close.
+		interact: string;
+	},
+): Promise<{ content: string; choices: string[] | undefined }> {
+	return await evalJsonAsync(
+		obsidian,
+		`
+		(async () => {
+			const plugin = app.plugins.plugins.${PLUGIN_ID};
+			const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+			const waitFor = async (sel, pred = () => true) => {
+				const start = Date.now();
+				while (Date.now() - start < 5000) {
+					const el = Array.from(document.querySelectorAll(sel)).find(pred);
+					if (el) return el;
+					await sleep(80);
+				}
+				throw new Error("Timed out waiting for " + sel);
+			};
+			const dom = { sleep, waitFor };
+
+			const snapshot = {
+				auto: JSON.parse(JSON.stringify(plugin.settings.AutoProperties)),
+				mode: plugin.settings.EditMode.mode,
+			};
+			plugin.settings.AutoProperties.enabled = true;
+			plugin.settings.AutoProperties.properties = ${JSON.stringify(opts.autoProperties)};
+			plugin.settings.EditMode.mode = ${JSON.stringify(opts.editMode ?? "All Single")};
+			await plugin.saveSettings();
+
+			const path = ${JSON.stringify(opts.notePath)};
+			const existing = app.vault.getAbstractFileByPath(path);
+			if (existing) await app.vault.delete(existing);
+			const file = await app.vault.create(path, ${JSON.stringify(opts.noteBody)});
+			await sleep(300);
+
+			try {
+				const props = await plugin.controller.getPropertiesInFile(file);
+				const property = props.find((p) => p.key === ${JSON.stringify(opts.property)});
+				if (!property) throw new Error("Property not parsed: ${opts.property}");
+
+				const editPromise = plugin.controller.editMetaElement(property, props, file);
+				const modal = await waitFor(".metaedit-ap-prompt");
+
+				await (async () => { ${opts.interact} })();
+
+				await Promise.race([editPromise, sleep(4000)]);
+				await sleep(300);
+
+				const content = await app.vault.read(file);
+				const saved = plugin.settings.AutoProperties.properties.find(
+					(a) => a.name === ${JSON.stringify(opts.property)},
+				);
+				return { content, choices: saved ? saved.choices : undefined };
+			} finally {
+				// Make sure no modal is left open to leak into the next test.
+				document.querySelectorAll(".modal-close-button").forEach((b) => b.click());
+				plugin.settings.AutoProperties = snapshot.auto;
+				plugin.settings.EditMode.mode = snapshot.mode;
+				await plugin.saveSettings();
+			}
+		})()
+	`,
+	);
+}
+
+describe("Auto Properties value prompt", () => {
+	test("shows the description and writes the picked value (single, #59)", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const result = await runAutoPropertyEdit(obsidian, {
+			notePath: sandbox.path("ap-single.md"),
+			noteBody: "---\nstatus: todo\n---\n# Note\n",
+			property: "status",
+			autoProperties: [
+				{
+					name: "status",
+					choices: ["todo", "in-progress", "done"],
+					description: "The workflow state of this note",
+					type: "Single",
+				},
+			],
+			interact: `
+				const desc = modal.querySelector(".metaedit-ap-prompt-desc");
+				if (desc.textContent !== "The workflow state of this note") {
+					throw new Error("Description not shown: " + desc.textContent);
+				}
+				const done = await dom.waitFor(".metaedit-ap-prompt-row", (el) => el.textContent.trim() === "done");
+				done.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			`,
+		});
+
+		expect(result.content).toContain("status: done");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("saves a typed value as a new choice when chosen explicitly (#43)", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const result = await runAutoPropertyEdit(obsidian, {
+			notePath: sandbox.path("ap-save.md"),
+			noteBody: "---\nstatus: todo\n---\n",
+			property: "status",
+			autoProperties: [{ name: "status", choices: ["todo", "done"], type: "Single" }],
+			interact: `
+				const input = modal.querySelector(".metaedit-ap-prompt-input");
+				input.value = "blocked";
+				input.dispatchEvent(new Event("input", { bubbles: true }));
+				const save = await dom.waitFor(
+					".metaedit-ap-prompt-row",
+					(el) => el.textContent.includes("Save") && el.textContent.includes("blocked"),
+				);
+				save.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			`,
+		});
+
+		expect(result.content).toContain("status: blocked");
+		expect(result.choices).toEqual(["todo", "done", "blocked"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("uses a typed value once without polluting the choice list (#43)", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const result = await runAutoPropertyEdit(obsidian, {
+			notePath: sandbox.path("ap-once.md"),
+			noteBody: "---\nstatus: todo\n---\n",
+			property: "status",
+			autoProperties: [{ name: "status", choices: ["todo", "done"], type: "Single" }],
+			interact: `
+				const input = modal.querySelector(".metaedit-ap-prompt-input");
+				input.value = "scratch";
+				input.dispatchEvent(new Event("input", { bubbles: true }));
+				const use = await dom.waitFor(
+					".metaedit-ap-prompt-row",
+					(el) => el.textContent.includes('Use "scratch"'),
+				);
+				use.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			`,
+		});
+
+		expect(result.content).toContain("status: scratch");
+		expect(result.choices).toEqual(["todo", "done"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("multi type writes a YAML list and overrides AllSingle EditMode (#40)", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const result = await runAutoPropertyEdit(obsidian, {
+			notePath: sandbox.path("ap-multi.md"),
+			noteBody: "---\ntags: [work]\n---\n",
+			property: "tags",
+			editMode: "All Single",
+			autoProperties: [
+				{ name: "tags", choices: ["work", "personal", "urgent"], type: "Multi" },
+			],
+			interact: `
+				const checks = Array.from(modal.querySelectorAll(".metaedit-ap-prompt-check"));
+				const work = checks.find((c) => c.querySelector(".metaedit-ap-prompt-row-label").textContent === "work");
+				if (!work.querySelector("input").checked) throw new Error("current value not pre-checked");
+				const urgent = checks.find((c) => c.querySelector(".metaedit-ap-prompt-row-label").textContent === "urgent");
+				urgent.querySelector("input").click();
+				const confirm = await dom.waitFor("button.mod-cta", (el) => el.textContent.trim() === "Confirm");
+				confirm.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			`,
+		});
+
+		expect(result.content).toContain("work");
+		expect(result.content).toContain("urgent");
+		// A real YAML list, not a comma string.
+		expect(result.content).toMatch(/tags:\n\s*-\s*work\n\s*-\s*urgent/);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("treats an entry without a type as single (back-compat)", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const result = await runAutoPropertyEdit(obsidian, {
+			notePath: sandbox.path("ap-legacy.md"),
+			noteBody: "---\nkind: a\n---\n",
+			property: "kind",
+			autoProperties: [{ name: "kind", choices: ["a", "b"] }],
+			interact: `
+				if (modal.querySelectorAll(".metaedit-ap-prompt-check").length !== 0) {
+					throw new Error("legacy entry rendered as multi");
+				}
+				const b = await dom.waitFor(".metaedit-ap-prompt-row", (el) => el.textContent.trim() === "b");
+				b.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			`,
+		});
+
+		expect(result.content).toContain("kind: b");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+});

--- a/tests/e2e/auto-properties.test.ts
+++ b/tests/e2e/auto-properties.test.ts
@@ -196,6 +196,43 @@ describe("Auto Properties value prompt", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("does not nest a Multi value into a list-of-lists under AllMulti (#40)", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		// A Multi auto property yields a string[]; addYamlProp must not wrap it
+		// again when the global EditMode is AllMulti, or it becomes [[...]].
+		const notePath = sandbox.path("ap-nested.md");
+		const result = await evalJsonAsync<{ content: string; tags: unknown }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+				const snapshot = plugin.settings.EditMode.mode;
+				plugin.settings.EditMode.mode = "All Multi";
+				const path = ${JSON.stringify(notePath)};
+				const existing = app.vault.getAbstractFileByPath(path);
+				if (existing) await app.vault.delete(existing);
+				const file = await app.vault.create(path, "Body\\n");
+				await sleep(300);
+				try {
+					await plugin.controller.addYamlProp("tags", ["work", "urgent"], file);
+					await sleep(300);
+					const content = await app.vault.read(file);
+					const tags = app.metadataCache.getFileCache(file)?.frontmatter?.tags;
+					return { content, tags };
+				} finally {
+					plugin.settings.EditMode.mode = snapshot;
+				}
+			})()
+		`,
+		);
+
+		expect(result.tags).toEqual(["work", "urgent"]);
+		expect(result.content).not.toContain("- - ");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("treats an entry without a type as single (back-compat)", async () => {
 		const { obsidian, sandbox } = getContext();
 


### PR DESCRIPTION
## Summary

Makes Auto Properties genuinely useful and pleasant, end to end - both where you
**define** them (settings) and where you **use** them (the value prompt).

Closes #59, closes #43, closes #40, and addresses the Auto Properties items in #30.

| Issue | Underlying problem (reframed) | What ships |
|-------|------------------------------|------------|
| **#59** | The value prompt gives no context about what you're filling in | An optional per-property **description**, shown above the choices in the prompt |
| **#43** | The choice list must be hand-maintained; it should learn | Typing a value not in the list offers **Use "x"** (one-off) and an explicit **Save "x" as a choice** (persists) - learns without silently collecting typos |
| **#40** | Some properties are multi-valued, but the picker only picked one | A per-property **Single / Multi** type; Multi pre-checks current values and writes a real list |
| **#30** | Entry friction: empty placeholder, double-Enter | A dedicated prompt with a real placeholder and **single-Enter** confirm |

## Why this shape

Each issue title is a proposed solution; the table above restates the problem
behind it. A few deliberate design decisions:

- **A dedicated `AutoPropertyValueModal`.** All four asks live in the value-entry
  experience, which previously reused the generic text prompt and so couldn't
  show a description, learn values, or multi-select. Auto Properties now own that
  UX in one cohesive, self-contained component. `editMetaElement` routes active
  auto properties to it before the EditMode single/multi split, so the
  single-vs-multi decision lives in exactly one place.
- **`type` is authoritative, and composes with EditMode instead of fighting it.**
  Explicit `Single`/`Multi` overrides the global Edit Mode in both directions; an
  entry with no `type` (data from before this PR) inherits Edit Mode, preserving
  prior behaviour on upgrade. This avoids the "two sources of truth" trap while
  still letting you make one property multi without touching global settings.
- **#43 learns explicitly, never silently.** Auto-persisting every typed value
  would fill the list with typos and casing variants and would give the public
  `autoprop()` API a hidden write side effect. Instead, persisting is a distinct,
  labelled action shown only when the value is new.
- **Settings editor redesign.** The editor is rebuilt as themed property cards
  with native Obsidian icons (replacing the emoji buttons and the
  `<br>`-in-`<table>` spacing hack) and uses theme CSS variables, so it renders
  correctly in dark mode (the old hardcoded light colors did not). Adds the
  Description field and Type dropdown.

## Scope decisions

- **#30's "hotkey to change the value on the hovered line"** is intentionally
  **not** in this PR: it concerns the property-list suggester, not Auto
  Properties, and belongs with the suggester work (#61). The other #30 items
  (placeholder, single-Enter) are delivered.
- Built on top of the merged #89 frontmatter-transaction writes, which is what
  lets a Multi property serialize as a real YAML list rather than a comma string.

## Validation

All checks green locally (CI runs test + build + lint):

- `pnpm run test` - 78 unit tests (new pure-logic suite in `src/autoProperties.test.ts`).
- `pnpm run build`, `pnpm run lint` - clean (no new warnings).
- `pnpm run test:e2e` - **13 live Obsidian E2E tests pass**, including 6 new
  Auto Properties tests driving the real modal via the DOM and asserting on-disk
  results + an empty runtime-error baseline:
  - description shown + picked value written (#59)
  - typed value saved as a new choice and persisted (#43)
  - typed value used once **without** polluting the choice list (#43)
  - Multi writes a real YAML list and overrides `All Single` (#40)
  - new Multi value is **not** nested into `[[...]]` under `All Multi` (#40 regression)
  - a type-less entry behaves as Single (back-compat)
- Manually verified live in the isolated vault: single-Enter, cancel writes
  nothing, and the settings editor persists name/description/type/add/remove to
  `data.json`.

The design and the implementation diff each went through an adversarial review on
the opposite model (3 design reviewers, 2 implementation reviewers). Their
high/medium findings were folded in - notably the nested-array fix, the
cancel-vs-no-match `null` disambiguation, authoritative `type` semantics,
order-preserving multi options, and appending learned choices to the live
settings entry so a concurrent settings-tab edit isn't overwritten.

> Note: `dev:screenshot` in the isolated E2E harness returns a frozen frame for
> modal overlays (the same limitation affected the pre-existing settings UI), so
> visual proof here is DOM-structure assertions + the E2E suite rather than
> pixel screenshots.

## Migration / compatibility

- `AutoProperty` gains optional `description?` and `type?` - existing `data.json`
  upgrades with no migration code (missing `type` inherits Edit Mode; missing
  `description` shows nothing).
- The public `autoprop()` API now returns `string | string[] | null` (a Multi
  property returns an array; it returned only strings before). README updated.