### PR TITLE
feat: bulk edit metadata across folders and selected notes

### DIFF
--- a/src/Modals/LinkMenu.ts
+++ b/src/Modals/LinkMenu.ts
@@ -39,7 +39,7 @@ export class LinkMenu {
                 this.targetFile = file;
                 this.addFileOptions(menu);
             }
-            if (file instanceof TFolder && file.children && file.children.some(f => f instanceof TFile && f.extension === "md")) {
+            if (file instanceof TFolder && this.folderHasMarkdown(file)) {
                 this.targetFolder = file;
                 this.addFolderOptions(menu);
             }
@@ -52,7 +52,7 @@ export class LinkMenu {
 
         const hasMarkdown = files.some(f =>
             (f instanceof TFile && f.extension === "md") ||
-            (f instanceof TFolder && f.children?.some(c => c instanceof TFile && c.extension === "md")));
+            (f instanceof TFolder && this.folderHasMarkdown(f)));
         if (!hasMarkdown) return;
 
         menu.addItem(item => {
@@ -62,6 +62,14 @@ export class LinkMenu {
                 await this.plugin.runBulkEditForSelection(files);
             });
         });
+    }
+
+    // The bulk flow recurses into subfolders, so the menu must appear whenever a
+    // folder contains markdown at any depth - not only as a direct child.
+    private folderHasMarkdown(folder: TFolder): boolean {
+        return folder.children?.some(child =>
+            (child instanceof TFile && child.extension === "md") ||
+            (child instanceof TFolder && this.folderHasMarkdown(child))) ?? false;
     }
 
     private addFileOptions(menu: Menu) {

--- a/src/Modals/LinkMenu.ts
+++ b/src/Modals/LinkMenu.ts
@@ -5,6 +5,7 @@ export class LinkMenu {
     private targetFile: TFile;
     private targetFolder: TFolder;
     private eventRef: EventRef;
+    private filesEventRef: EventRef;
 
     constructor(private plugin: MetaEdit) {}
 
@@ -12,11 +13,19 @@ export class LinkMenu {
         this.eventRef = this.plugin.app.workspace.on('file-menu',
             (menu, file, source) => this.onMenuOpenCallback(menu, file, source));
         this.plugin.registerEvent(this.eventRef);
+
+        // 'files-menu' fires for a multi-selection in the file explorer.
+        this.filesEventRef = this.plugin.app.workspace.on('files-menu',
+            (menu, files, source) => this.onFilesMenuOpenCallback(menu, files, source));
+        this.plugin.registerEvent(this.filesEventRef);
     }
 
     public unregisterEvent(): void {
         if (this.eventRef){
             this.plugin.app.workspace.offref(this.eventRef);
+        }
+        if (this.filesEventRef){
+            this.plugin.app.workspace.offref(this.filesEventRef);
         }
     }
 
@@ -37,11 +46,29 @@ export class LinkMenu {
         }
     }
 
+    private onFilesMenuOpenCallback(menu: Menu, files: TAbstractFile[], source: string) {
+        if (source !== "file-explorer-context-menu") return;
+        if (!Array.isArray(files) || files.length === 0) return;
+
+        const hasMarkdown = files.some(f =>
+            (f instanceof TFile && f.extension === "md") ||
+            (f instanceof TFolder && f.children?.some(c => c instanceof TFile && c.extension === "md")));
+        if (!hasMarkdown) return;
+
+        menu.addItem(item => {
+            item.setIcon('pencil');
+            item.setTitle("Bulk edit metadata in selected notes");
+            item.onClick(async () => {
+                await this.plugin.runBulkEditForSelection(files);
+            });
+        });
+    }
+
     private addFileOptions(menu: Menu) {
         menu.addItem(item => {
             item.setIcon('pencil');
             item.setTitle("Edit Meta");
-            item.onClick(async evt => {
+            item.onClick(async () => {
                 await this.plugin.runMetaEditForFile(this.targetFile);
             })
         })
@@ -50,8 +77,8 @@ export class LinkMenu {
     private addFolderOptions(menu: Menu) {
         menu.addItem(item => {
             item.setIcon('pencil');
-            item.setTitle("Add YAML property to all files in this folder (and subfolders)");
-            item.onClick(async evt => {
+            item.setTitle("Bulk edit metadata in this folder (and subfolders)");
+            item.onClick(async () => {
                 await this.plugin.runMetaEditForFolder(this.targetFolder);
             })
         })

--- a/src/Types/obsidian-augmentations.d.ts
+++ b/src/Types/obsidian-augmentations.d.ts
@@ -1,0 +1,19 @@
+import "obsidian";
+
+// The bundled obsidian@1.4.4 typings predate the multi-select `files-menu`
+// workspace event (present at runtime since Obsidian 0.15). Declare it here so
+// the bulk multi-select entry point is typed rather than cast through `any`.
+declare module "obsidian" {
+	interface Workspace {
+		on(
+			name: "files-menu",
+			callback: (
+				menu: Menu,
+				files: TAbstractFile[],
+				source: string,
+				leaf?: WorkspaceLeaf,
+			) => unknown,
+			ctx?: unknown,
+		): EventRef;
+	}
+}

--- a/src/bulk/BulkOptionModal.ts
+++ b/src/bulk/BulkOptionModal.ts
@@ -1,0 +1,77 @@
+import { type App, Modal } from "obsidian";
+
+export interface BulkOption {
+	/** Stable value returned when this option is chosen. */
+	key: string;
+	label: string;
+	description?: string;
+}
+
+export interface BulkChoiceConfig {
+	title: string;
+	description?: string;
+	options: BulkOption[];
+	/** Render the options as warning-styled buttons for destructive choices. */
+	danger?: boolean;
+}
+
+/**
+ * A small button-list modal for picking a bulk conflict policy or confirming a
+ * destructive action. Unlike the shared GenericSuggester, it resolves to `null`
+ * when dismissed (Escape / click-away), so callers can cleanly abort instead of
+ * hanging on a never-settled promise.
+ */
+export class BulkOptionModal extends Modal {
+	private resolvePromise!: (value: string | null) => void;
+	private didChoose = false;
+
+	private constructor(app: App, private config: BulkChoiceConfig) {
+		super(app);
+	}
+
+	public static Choose(app: App, config: BulkChoiceConfig): Promise<string | null> {
+		const modal = new BulkOptionModal(app, config);
+		const promise = new Promise<string | null>((resolve) => {
+			modal.resolvePromise = resolve;
+		});
+		modal.open();
+		return promise;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.addClass("metaedit-bulk-modal");
+		contentEl.createEl("h3", { text: this.config.title });
+
+		if (this.config.description) {
+			contentEl.createEl("p", {
+				text: this.config.description,
+				cls: "metaedit-bulk-modal-description",
+			});
+		}
+
+		const list = contentEl.createDiv({ cls: "metaedit-bulk-options" });
+		for (const option of this.config.options) {
+			const button = list.createEl("button", { cls: "metaedit-bulk-option" });
+			if (this.config.danger) button.addClass("mod-warning");
+
+			button.createDiv({ cls: "metaedit-bulk-option-label", text: option.label });
+			if (option.description) {
+				button.createDiv({ cls: "metaedit-bulk-option-description", text: option.description });
+			}
+
+			button.addEventListener("click", () => this.choose(option.key));
+		}
+	}
+
+	private choose(key: string): void {
+		this.didChoose = true;
+		this.resolvePromise(key);
+		this.close();
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+		if (!this.didChoose) this.resolvePromise(null);
+	}
+}

--- a/src/bulk/bulkMetadata.test.ts
+++ b/src/bulk/bulkMetadata.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+	type BulkSummary,
+	type ConflictPolicy,
+	decideBulkWrite,
+	emptySummary,
+	formatSummary,
+	recordOutcome,
+	toArray,
+	uniqueConcat,
+	valuesEqual,
+} from "./bulkMetadata";
+
+const decide = (over: Partial<Parameters<typeof decideBulkWrite>[0]>) =>
+	decideBulkWrite({
+		exists: false,
+		currentValue: undefined,
+		rawValue: "v",
+		policy: "skip",
+		wrapInArray: false,
+		...over,
+	});
+
+describe("decideBulkWrite - add (key missing)", () => {
+	it("adds a scalar when the key is missing, regardless of policy", () => {
+		for (const policy of ["skip", "overwrite", "merge"] as ConflictPolicy[]) {
+			expect(decide({ exists: false, rawValue: "draft", policy })).toEqual({
+				action: "write",
+				value: "draft",
+				outcome: "added",
+			});
+		}
+	});
+
+	it("wraps the added value in a list when EditMode requests multi-value", () => {
+		expect(decide({ exists: false, rawValue: "draft", wrapInArray: true })).toEqual({
+			action: "write",
+			value: ["draft"],
+			outcome: "added",
+		});
+	});
+});
+
+describe("decideBulkWrite - skip policy", () => {
+	it("never touches a note that already has the key", () => {
+		expect(decide({ exists: true, currentValue: "old", rawValue: "new", policy: "skip" })).toEqual({
+			action: "skip",
+			outcome: "skipped",
+		});
+	});
+});
+
+describe("decideBulkWrite - overwrite policy", () => {
+	it("replaces a differing scalar value", () => {
+		expect(
+			decide({ exists: true, currentValue: "draft", rawValue: "published", policy: "overwrite" }),
+		).toEqual({ action: "write", value: "published", outcome: "overwritten" });
+	});
+
+	it("is idempotent: an already-equal value is reported unchanged, no write", () => {
+		expect(
+			decide({ exists: true, currentValue: "published", rawValue: "published", policy: "overwrite" }),
+		).toEqual({ action: "skip", outcome: "unchanged" });
+	});
+
+	it("treats wrapped scalars as equal under multi-value EditMode", () => {
+		expect(
+			decide({
+				exists: true,
+				currentValue: ["published"],
+				rawValue: "published",
+				policy: "overwrite",
+				wrapInArray: true,
+			}),
+		).toEqual({ action: "skip", outcome: "unchanged" });
+	});
+
+	it("flattens an existing list to the new scalar (caller confirms this destructive path)", () => {
+		expect(
+			decide({ exists: true, currentValue: ["a", "b", "c"], rawValue: "x", policy: "overwrite" }),
+		).toEqual({ action: "write", value: "x", outcome: "overwritten" });
+	});
+});
+
+describe("decideBulkWrite - merge policy", () => {
+	it("appends a new value to an existing list without duplicating", () => {
+		expect(
+			decide({ exists: true, currentValue: ["a", "b"], rawValue: "c", policy: "merge" }),
+		).toEqual({ action: "write", value: ["a", "b", "c"], outcome: "merged" });
+	});
+
+	it("is idempotent: appending a value already present reports unchanged, no write", () => {
+		expect(
+			decide({ exists: true, currentValue: ["a", "b"], rawValue: "b", policy: "merge" }),
+		).toEqual({ action: "skip", outcome: "unchanged" });
+	});
+
+	it("normalizes an existing scalar into a list when merging", () => {
+		expect(
+			decide({ exists: true, currentValue: "a", rawValue: "b", policy: "merge" }),
+		).toEqual({ action: "write", value: ["a", "b"], outcome: "merged" });
+	});
+
+	it("dedupes across types: numeric 5 and string '5' are the same value", () => {
+		expect(
+			decide({ exists: true, currentValue: [5], rawValue: "5", policy: "merge" }),
+		).toEqual({ action: "skip", outcome: "unchanged" });
+	});
+
+	it("leaves map-valued properties untouched (cannot append a scalar into a map)", () => {
+		expect(
+			decide({ exists: true, currentValue: { nested: true }, rawValue: "x", policy: "merge" }),
+		).toEqual({ action: "skip", outcome: "skipped" });
+	});
+
+	it("preserves existing object elements while appending the new scalar", () => {
+		const current = [{ id: 1 }];
+		expect(
+			decide({ exists: true, currentValue: current, rawValue: "x", policy: "merge" }),
+		).toEqual({ action: "write", value: [{ id: 1 }, "x"], outcome: "merged" });
+	});
+});
+
+describe("idempotency across a re-run", () => {
+	// Feeds the decision's written value back in as the next run's current value
+	// and asserts the second run is a no-op for every conflict policy.
+	const reRunIsNoop = (policy: ConflictPolicy, currentValue: unknown, rawValue: string) => {
+		const first = decideBulkWrite({ exists: true, currentValue, rawValue, policy, wrapInArray: false });
+		const nextValue = first.action === "write" ? first.value : currentValue;
+		const second = decideBulkWrite({ exists: true, currentValue: nextValue, rawValue, policy, wrapInArray: false });
+		return second;
+	};
+
+	it("merge converges after one run", () => {
+		expect(reRunIsNoop("merge", "a", "b")).toEqual({ action: "skip", outcome: "unchanged" });
+	});
+
+	it("overwrite converges after one run", () => {
+		expect(reRunIsNoop("overwrite", "old", "new")).toEqual({ action: "skip", outcome: "unchanged" });
+	});
+});
+
+describe("value helpers", () => {
+	it("toArray wraps scalars, copies arrays, and empties nullish", () => {
+		expect(toArray("a")).toEqual(["a"]);
+		expect(toArray(["a", "b"])).toEqual(["a", "b"]);
+		expect(toArray(null)).toEqual([]);
+		expect(toArray(undefined)).toEqual([]);
+	});
+
+	it("uniqueConcat keeps order and drops duplicates by stable value", () => {
+		expect(uniqueConcat(["a"], ["a", "b", "b"])).toEqual(["a", "b"]);
+		expect(uniqueConcat([{ a: 1 }], [{ a: 1 }])).toEqual([{ a: 1 }]);
+	});
+
+	it("valuesEqual compares structurally regardless of key order", () => {
+		expect(valuesEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+		expect(valuesEqual(["a"], ["a"])).toBe(true);
+		expect(valuesEqual("a", ["a"])).toBe(false);
+	});
+});
+
+describe("formatSummary", () => {
+	const withCounts = (over: Partial<BulkSummary>): BulkSummary => ({
+		...emptySummary(over.total ?? 1),
+		...over,
+	});
+
+	it("lists only non-zero buckets", () => {
+		const summary = withCounts({ total: 5, added: 3, skipped: 2 });
+		expect(formatSummary(summary, "status")).toBe(
+			'MetaEdit bulk "status": 3 added, 2 skipped across 5 notes.',
+		);
+	});
+
+	it("calls out failures and points at the console", () => {
+		const summary = withCounts({ total: 2, added: 1, failed: 1, failures: [{ path: "x.md", error: "boom" }] });
+		expect(formatSummary(summary, "k")).toContain("1 failed");
+		expect(formatSummary(summary, "k")).toContain("see console");
+	});
+
+	it("uses singular note wording and a no-changes phrase", () => {
+		const summary = withCounts({ total: 1, skipped: 1 });
+		expect(formatSummary(summary, "k")).toBe('MetaEdit bulk "k": 1 skipped across 1 note.');
+		const noop = withCounts({ total: 3 });
+		expect(formatSummary(noop, "k")).toBe('MetaEdit bulk "k": no changes across 3 notes.');
+	});
+
+	it("recordOutcome increments the matching bucket", () => {
+		const summary = emptySummary(2);
+		recordOutcome(summary, "added");
+		recordOutcome(summary, "merged");
+		expect(summary.added).toBe(1);
+		expect(summary.merged).toBe(1);
+	});
+});

--- a/src/bulk/bulkMetadata.test.ts
+++ b/src/bulk/bulkMetadata.test.ts
@@ -22,14 +22,22 @@ const decide = (over: Partial<Parameters<typeof decideBulkWrite>[0]>) =>
 	});
 
 describe("decideBulkWrite - add (key missing)", () => {
-	it("adds a scalar when the key is missing, regardless of policy", () => {
-		for (const policy of ["skip", "overwrite", "merge"] as ConflictPolicy[]) {
+	it("adds a scalar when the key is missing under skip/overwrite", () => {
+		for (const policy of ["skip", "overwrite"] as ConflictPolicy[]) {
 			expect(decide({ exists: false, rawValue: "draft", policy })).toEqual({
 				action: "write",
 				value: "draft",
 				outcome: "added",
 			});
 		}
+	});
+
+	it("seeds a list when the key is missing under merge (list-shaped result)", () => {
+		expect(decide({ exists: false, rawValue: "draft", policy: "merge" })).toEqual({
+			action: "write",
+			value: ["draft"],
+			outcome: "added",
+		});
 	});
 
 	it("wraps the added value in a list when EditMode requests multi-value", () => {

--- a/src/bulk/bulkMetadata.ts
+++ b/src/bulk/bulkMetadata.ts
@@ -1,0 +1,200 @@
+/**
+ * Pure decision logic for applying a single YAML frontmatter property across a
+ * set of notes. This module is intentionally free of any Obsidian dependency so
+ * it can be unit-tested in the jsdom-free node environment, and so the
+ * read-decide-write step can run atomically inside
+ * `app.fileManager.processFrontMatter` (the same safe frontmatter primitive the
+ * controller write path uses) - never against the eventually-consistent
+ * metadata cache.
+ */
+
+/** How to treat notes that already define the target property. */
+export type ConflictPolicy = "skip" | "overwrite" | "merge";
+
+/** What happened to a single note during a bulk apply. */
+export type BulkOutcome =
+	| "added"
+	| "merged"
+	| "overwritten"
+	| "skipped"
+	| "unchanged"
+	| "failed";
+
+export type BulkDecision =
+	| { action: "write"; value: unknown; outcome: "added" | "merged" | "overwritten" }
+	| { action: "skip"; outcome: "skipped" | "unchanged" };
+
+export interface DecideArgs {
+	/** Whether the property key already exists in the note's frontmatter. */
+	exists: boolean;
+	/** The note's current value for the key (only meaningful when `exists`). */
+	currentValue: unknown;
+	/** The raw value entered by the user (always a string). */
+	rawValue: string;
+	/** Conflict policy chosen for notes that already have the key. */
+	policy: ConflictPolicy;
+	/**
+	 * Whether a freshly-added/overwritten scalar should be wrapped in a list,
+	 * mirroring the controller's EditMode (AllMulti / SomeMulti) wrapping so the
+	 * bulk path produces the same YAML shape as a single-note add.
+	 */
+	wrapInArray: boolean;
+}
+
+/**
+ * Decide what to write (if anything) for one note. Pure and deterministic:
+ * given the same inputs it always returns the same decision, which is what
+ * makes a bulk apply idempotent on re-run.
+ */
+export function decideBulkWrite(args: DecideArgs): BulkDecision {
+	const { exists, currentValue, rawValue, policy, wrapInArray } = args;
+
+	if (!exists) {
+		return { action: "write", value: wrapScalar(rawValue, wrapInArray), outcome: "added" };
+	}
+
+	switch (policy) {
+		case "skip":
+			return { action: "skip", outcome: "skipped" };
+
+		case "overwrite": {
+			const next = wrapScalar(rawValue, wrapInArray);
+			if (valuesEqual(currentValue, next)) {
+				return { action: "skip", outcome: "unchanged" };
+			}
+			return { action: "write", value: next, outcome: "overwritten" };
+		}
+
+		case "merge": {
+			// Merging a scalar into a map is undefined; leave the note untouched
+			// rather than clobber structured data.
+			if (isPlainObject(currentValue)) {
+				return { action: "skip", outcome: "skipped" };
+			}
+
+			const merged = uniqueConcat(toArray(currentValue), [rawValue]);
+			if (valuesEqual(currentValue, merged)) {
+				return { action: "skip", outcome: "unchanged" };
+			}
+			return { action: "write", value: merged, outcome: "merged" };
+		}
+
+		default:
+			return { action: "skip", outcome: "skipped" };
+	}
+}
+
+export interface BulkSummary {
+	total: number;
+	added: number;
+	merged: number;
+	overwritten: number;
+	skipped: number;
+	unchanged: number;
+	failed: number;
+	failures: { path: string; error: string }[];
+}
+
+export function emptySummary(total: number): BulkSummary {
+	return {
+		total,
+		added: 0,
+		merged: 0,
+		overwritten: 0,
+		skipped: 0,
+		unchanged: 0,
+		failed: 0,
+		failures: [],
+	};
+}
+
+export function recordOutcome(summary: BulkSummary, outcome: BulkOutcome): void {
+	summary[outcome] += 1;
+}
+
+/**
+ * Human-readable one-line summary for the completion Notice. Only non-zero
+ * buckets are listed so the common case stays terse, and the destructive
+ * "overwritten" count is always called out when present.
+ */
+export function formatSummary(summary: BulkSummary, key: string): string {
+	const parts: string[] = [];
+	const add = (n: number, label: string) => {
+		if (n > 0) parts.push(`${n} ${label}`);
+	};
+
+	add(summary.added, "added");
+	add(summary.merged, "merged");
+	add(summary.overwritten, "overwritten");
+	add(summary.skipped, "skipped");
+	add(summary.unchanged, "unchanged");
+	add(summary.failed, "failed");
+
+	const noteWord = summary.total === 1 ? "note" : "notes";
+	const detail = parts.length > 0 ? parts.join(", ") : "no changes";
+	const failureHint = summary.failed > 0 ? " (see console for failed notes)" : "";
+
+	return `MetaEdit bulk "${key}": ${detail} across ${summary.total} ${noteWord}.${failureHint}`;
+}
+
+function wrapScalar(rawValue: string, wrapInArray: boolean): unknown {
+	return wrapInArray ? [rawValue] : rawValue;
+}
+
+export function isPlainObject(value: unknown): boolean {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Normalize a frontmatter value into a list for merging. */
+export function toArray(value: unknown): unknown[] {
+	if (Array.isArray(value)) return value.slice();
+	if (value === null || value === undefined) return [];
+	return [value];
+}
+
+/**
+ * Concatenate `additions` onto `base`, dropping values already present. Equality
+ * is by stable string form, so `5` and `"5"` count as the same value and object
+ * elements are compared structurally. This is what keeps merge idempotent.
+ */
+export function uniqueConcat(base: unknown[], additions: unknown[]): unknown[] {
+	const seen = new Set(base.map(dedupeKey));
+	const out = base.slice();
+
+	for (const candidate of additions) {
+		const key = dedupeKey(candidate);
+		if (!seen.has(key)) {
+			seen.add(key);
+			out.push(candidate);
+		}
+	}
+
+	return out;
+}
+
+export function valuesEqual(a: unknown, b: unknown): boolean {
+	return stableStringify(a) === stableStringify(b);
+}
+
+function dedupeKey(value: unknown): string {
+	if (value !== null && typeof value === "object") {
+		return `o:${stableStringify(value)}`;
+	}
+	return `s:${String(value)}`;
+}
+
+/** Deterministic JSON serialization with sorted object keys. */
+function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== "object") {
+		return JSON.stringify(value) ?? "null";
+	}
+
+	if (Array.isArray(value)) {
+		return `[${value.map(stableStringify).join(",")}]`;
+	}
+
+	const record = value as Record<string, unknown>;
+	const keys = Object.keys(record).sort();
+	const entries = keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
+	return `{${entries.join(",")}}`;
+}

--- a/src/bulk/bulkMetadata.ts
+++ b/src/bulk/bulkMetadata.ts
@@ -50,7 +50,11 @@ export function decideBulkWrite(args: DecideArgs): BulkDecision {
 	const { exists, currentValue, rawValue, policy, wrapInArray } = args;
 
 	if (!exists) {
-		return { action: "write", value: wrapScalar(rawValue, wrapInArray), outcome: "added" };
+		// Under merge the property is meant to be a list, so seed it as one even
+		// when adding it fresh - that keeps every note in a merge run list-shaped
+		// rather than scalar-for-added vs list-for-merged.
+		const value = policy === "merge" ? [rawValue] : wrapScalar(rawValue, wrapInArray);
+		return { action: "write", value, outcome: "added" };
 	}
 
 	switch (policy) {

--- a/src/bulk/bulkMetadataEditor.ts
+++ b/src/bulk/bulkMetadataEditor.ts
@@ -2,7 +2,6 @@ import { type App, type TAbstractFile, Notice, TFile, TFolder } from "obsidian";
 import type MetaEdit from "../main";
 import { EditMode } from "../Types/editMode";
 import GenericPrompt from "../Modals/GenericPrompt/GenericPrompt";
-import { log } from "../logger/logManager";
 import { BulkOptionModal } from "./BulkOptionModal";
 import {
 	type BulkOutcome,
@@ -74,7 +73,9 @@ export class BulkMetadataEditor {
 		const rawValue = await GenericPrompt.Prompt(this.app, `Value for "${key}"`, "Value").catch(
 			() => null,
 		);
-		if (rawValue === null) return;
+		// Abort on cancel or an empty value rather than writing a blank property
+		// across the whole batch, matching the prior folder command's guard.
+		if (!rawValue) return;
 
 		const conflicts = this.countExisting(files, key);
 		let policy: ConflictPolicy = "skip";
@@ -106,12 +107,15 @@ export class BulkMetadataEditor {
 			policy = choice as ConflictPolicy;
 
 			if (policy === "overwrite") {
+				// The confirmation is framed against the authoritative selection size,
+				// not the cache-derived conflict count, so the stated blast radius can
+				// never understate what the live apply will overwrite.
 				const confirm = await BulkOptionModal.Choose(this.app, {
-					title: `Overwrite "${key}" in ${conflicts} ${conflictWord}?`,
+					title: `Overwrite "${key}" across ${files.length} ${noteWord}?`,
 					description:
-						"Existing values will be replaced. Bulk edits are not undoable with Ctrl+Z.",
+						"Existing values will be replaced wherever the property is present. Bulk edits cannot be undone with Ctrl+Z.",
 					danger: true,
-					options: [{ key: "yes", label: `Overwrite ${conflicts} ${conflictWord}` }],
+					options: [{ key: "yes", label: "Overwrite" }],
 				});
 				if (confirm !== "yes") return;
 			}
@@ -136,12 +140,21 @@ export class BulkMetadataEditor {
 				const outcome = await this.applyToFile(file, key, rawValue, policy, wrapInArray);
 				recordOutcome(summary, outcome);
 			} catch (error) {
+				// Isolate the failure so one unwritable note never aborts the batch.
 				const message = error instanceof Error ? error.message : String(error);
 				summary.failed += 1;
 				summary.failures.push({ path: file.path, error: message });
-				// logWarning records without throwing, so one bad note never aborts the batch.
-				log.logWarning(`MetaEdit bulk: failed to update ${file.path}: ${message}`);
 			}
+		}
+
+		// Report failures once, as a warning, rather than per-note error Notices
+		// (LogManager.logWarning routes to logError, which would spam the UI and
+		// register as runtime errors).
+		if (summary.failures.length > 0) {
+			console.warn(
+				`MetaEdit bulk: failed to update ${summary.failures.length} note(s) for "${key}":`,
+				summary.failures,
+			);
 		}
 
 		return summary;

--- a/src/bulk/bulkMetadataEditor.ts
+++ b/src/bulk/bulkMetadataEditor.ts
@@ -1,0 +1,210 @@
+import { type App, type TAbstractFile, Notice, TFile, TFolder } from "obsidian";
+import type MetaEdit from "../main";
+import { EditMode } from "../Types/editMode";
+import GenericPrompt from "../Modals/GenericPrompt/GenericPrompt";
+import { log } from "../logger/logManager";
+import { BulkOptionModal } from "./BulkOptionModal";
+import {
+	type BulkOutcome,
+	type BulkSummary,
+	type ConflictPolicy,
+	decideBulkWrite,
+	emptySummary,
+	formatSummary,
+	recordOutcome,
+} from "./bulkMetadata";
+
+/**
+ * Drives the bulk "add/update a YAML property across many notes" flow shared by
+ * the folder context-menu item and the multi-select (`files-menu`) item.
+ *
+ * Writes go through Obsidian's `app.fileManager.processFrontMatter` - the exact
+ * frontmatter primitive the rewritten controller write path is built on (see
+ * metaController.processFrontMatter) - never hand-rolled YAML text edits. The
+ * read, the conflict decision, and the write all happen inside a single
+ * processFrontMatter callback per note, so each note's decision is made against
+ * its live frontmatter rather than the lazily-updated metadata cache.
+ */
+export class BulkMetadataEditor {
+	constructor(private app: App, private plugin: MetaEdit) {}
+
+	/** Recursively collect markdown files within a folder. */
+	public collectFromFolder(folder: TFolder): TFile[] {
+		return this.dedupeByPath(this.markdownFilesIn(folder));
+	}
+
+	/**
+	 * Collect markdown files from an arbitrary selection of files and folders
+	 * (e.g. a multi-selection in the file explorer), expanding folders and
+	 * dropping duplicates so a file reached two ways is only edited once.
+	 */
+	public collectFromSelection(files: TAbstractFile[]): TFile[] {
+		const collected: TFile[] = [];
+		for (const file of files) {
+			if (file instanceof TFile) {
+				if (file.extension === "md") collected.push(file);
+			} else if (file instanceof TFolder) {
+				collected.push(...this.markdownFilesIn(file));
+			}
+		}
+		return this.dedupeByPath(collected);
+	}
+
+	/**
+	 * Run the full interactive flow: prompt for the property name and value,
+	 * choose a conflict policy when some notes already have the key, confirm
+	 * destructive overwrites, apply, and report a single summary Notice.
+	 */
+	public async run(files: TFile[], scopeLabel: string): Promise<void> {
+		if (files.length === 0) {
+			new Notice("MetaEdit: no markdown notes to edit here.");
+			return;
+		}
+
+		const noteWord = files.length === 1 ? "note" : "notes";
+		const key = (
+			await GenericPrompt.Prompt(
+				this.app,
+				`Property to add/update across ${files.length} ${noteWord} in ${scopeLabel}`,
+				"Property name",
+			).catch(() => null)
+		)?.trim();
+		if (!key) return;
+
+		const rawValue = await GenericPrompt.Prompt(this.app, `Value for "${key}"`, "Value").catch(
+			() => null,
+		);
+		if (rawValue === null) return;
+
+		const conflicts = this.countExisting(files, key);
+		let policy: ConflictPolicy = "skip";
+
+		if (conflicts > 0) {
+			const conflictWord = conflicts === 1 ? "note" : "notes";
+			const choice = await BulkOptionModal.Choose(this.app, {
+				title: `${conflicts} ${conflictWord} already have "${key}"`,
+				description: "Choose how to handle notes that already define this property.",
+				options: [
+					{
+						key: "skip",
+						label: "Skip notes that already have it",
+						description: "Only add the property where it is missing. Nothing is overwritten.",
+					},
+					{
+						key: "merge",
+						label: "Merge into a list",
+						description: `Add "${rawValue}" to the existing value(s) as a list, without duplicating.`,
+					},
+					{
+						key: "overwrite",
+						label: "Overwrite existing values",
+						description: "Replace the current value. This cannot be undone.",
+					},
+				],
+			});
+			if (!choice) return;
+			policy = choice as ConflictPolicy;
+
+			if (policy === "overwrite") {
+				const confirm = await BulkOptionModal.Choose(this.app, {
+					title: `Overwrite "${key}" in ${conflicts} ${conflictWord}?`,
+					description:
+						"Existing values will be replaced. Bulk edits are not undoable with Ctrl+Z.",
+					danger: true,
+					options: [{ key: "yes", label: `Overwrite ${conflicts} ${conflictWord}` }],
+				});
+				if (confirm !== "yes") return;
+			}
+		}
+
+		const summary = await this.apply(files, key, rawValue, policy);
+		new Notice(formatSummary(summary, key), 10_000);
+	}
+
+	/** Apply the property to every note, isolating per-note failures. */
+	public async apply(
+		files: TFile[],
+		key: string,
+		rawValue: string,
+		policy: ConflictPolicy,
+	): Promise<BulkSummary> {
+		const wrapInArray = this.wrapInArrayFor(key);
+		const summary = emptySummary(files.length);
+
+		for (const file of files) {
+			try {
+				const outcome = await this.applyToFile(file, key, rawValue, policy, wrapInArray);
+				recordOutcome(summary, outcome);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				summary.failed += 1;
+				summary.failures.push({ path: file.path, error: message });
+				// logWarning records without throwing, so one bad note never aborts the batch.
+				log.logWarning(`MetaEdit bulk: failed to update ${file.path}: ${message}`);
+			}
+		}
+
+		return summary;
+	}
+
+	private async applyToFile(
+		file: TFile,
+		key: string,
+		rawValue: string,
+		policy: ConflictPolicy,
+		wrapInArray: boolean,
+	): Promise<BulkOutcome> {
+		let outcome: BulkOutcome = "skipped";
+
+		await this.app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+			const exists = Object.prototype.hasOwnProperty.call(frontmatter, key);
+			const decision = decideBulkWrite({
+				exists,
+				currentValue: frontmatter[key],
+				rawValue,
+				policy,
+				wrapInArray,
+			});
+			outcome = decision.outcome;
+			if (decision.action === "write") {
+				frontmatter[key] = decision.value;
+			}
+		});
+
+		return outcome;
+	}
+
+	private markdownFilesIn(folder: TFolder): TFile[] {
+		const files: TFile[] = [];
+		for (const child of folder.children) {
+			if (child instanceof TFile) {
+				if (child.extension === "md") files.push(child);
+			} else if (child instanceof TFolder) {
+				files.push(...this.markdownFilesIn(child));
+			}
+		}
+		return files;
+	}
+
+	private dedupeByPath(files: TFile[]): TFile[] {
+		const byPath = new Map<string, TFile>();
+		for (const file of files) {
+			if (!byPath.has(file.path)) byPath.set(file.path, file);
+		}
+		return [...byPath.values()];
+	}
+
+	private countExisting(files: TFile[], key: string): number {
+		let count = 0;
+		for (const file of files) {
+			const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+			if (frontmatter && Object.prototype.hasOwnProperty.call(frontmatter, key)) count += 1;
+		}
+		return count;
+	}
+
+	private wrapInArrayFor(key: string): boolean {
+		const { mode, properties } = this.plugin.settings.EditMode;
+		return mode === EditMode.AllMulti || (mode === EditMode.SomeMulti && properties.includes(key));
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,14 @@
-import {Plugin, TFile, TFolder} from 'obsidian';
+import {type TAbstractFile, type TFile, type TFolder, Plugin} from 'obsidian';
 import {MetaEditSettingsTab} from "./Settings/metaEditSettingsTab";
 import MetaEditSuggester from "./Modals/metaEditSuggester";
 import MetaController from "./metaController";
+import {BulkMetadataEditor} from "./bulk/bulkMetadataEditor";
 import type {MetaEditSettings} from "./Settings/metaEditSettings";
 import {DEFAULT_SETTINGS} from "./Settings/defaultSettings";
 import {LinkMenu} from "./Modals/LinkMenu";
 import type {Property} from "./parser";
 import type {IMetaEditApi} from "./IMetaEditApi";
 import {MetaEditApi} from "./MetaEditApi";
-import GenericPrompt from "./Modals/GenericPrompt/GenericPrompt";
 import {getActiveMarkdownFile} from "./utility";
 import {ConsoleErrorLogger} from "./logger/consoleErrorLogger";
 import {GuiLogger} from "./logger/guiLogger";
@@ -24,12 +24,14 @@ export default class MetaEdit extends Plugin {
     public linkMenu: LinkMenu;
     public api: IMetaEditApi;
     public controller: MetaController;
+    public bulkEditor: BulkMetadataEditor;
     private automatorManager: IAutomatorManager;
 
     async onload() {
         console.log('Loading MetaEdit');
 
         this.controller = new MetaController(this.app, this);
+        this.bulkEditor = new BulkMetadataEditor(this.app, this);
 
         await this.loadSettings();
 
@@ -124,23 +126,14 @@ export default class MetaEdit extends Plugin {
     }
 
     public async runMetaEditForFolder(targetFolder: TFolder) {
-        const pName = await GenericPrompt.Prompt(this.app, `Add a new property to all files in ${targetFolder.name} (and subfolders)`);
-        if (!pName) return;
+        const files = this.bulkEditor.collectFromFolder(targetFolder);
+        await this.bulkEditor.run(files, `${targetFolder.name} (and subfolders)`);
+    }
 
-        const pVal = await GenericPrompt.Prompt(this.app, "Enter a value");
-        if (!pVal) return;
-
-        const updateFilesInFolder = async (targetFolder: TFolder, propertyName: string, propertyValue: string) => {
-            for (const child of targetFolder.children) {
-                if (child instanceof TFile && child.extension == "md")
-                    await this.controller.addYamlProp(pName, pVal, child);
-
-                if (child instanceof TFolder)
-                    await updateFilesInFolder(child, propertyName, propertyValue);
-            }
-        }
-
-        await updateFilesInFolder(targetFolder, pName, pVal);
+    public async runBulkEditForSelection(selection: TAbstractFile[]) {
+        const files = this.bulkEditor.collectFromSelection(selection);
+        const scope = files.length === 1 ? files[0].name : `${selection.length} selected items`;
+        await this.bulkEditor.run(files, scope);
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -13,3 +13,37 @@
     cursor: pointer;
     outline: inherit;
 }
+
+.metaedit-bulk-modal-description {
+    color: var(--text-muted);
+    margin-top: 0;
+}
+
+.metaedit-bulk-options {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.metaedit-bulk-option {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    width: 100%;
+    height: auto;
+    padding: 10px 12px;
+    text-align: left;
+    white-space: normal;
+    cursor: pointer;
+}
+
+.metaedit-bulk-option-label {
+    font-weight: var(--font-semibold);
+}
+
+.metaedit-bulk-option-description {
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+}

--- a/tests/e2e/bulk-metadata.test.ts
+++ b/tests/e2e/bulk-metadata.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from "vitest";
+import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID, WAIT_OPTS } from "./harness";
+
+const getContext = createMetaEditE2EHarness("bulk-metadata");
+
+type BulkSummary = {
+	total: number;
+	added: number;
+	merged: number;
+	overwritten: number;
+	skipped: number;
+	unchanged: number;
+	failed: number;
+};
+
+describe("MetaEdit bulk metadata edit", () => {
+	test("adds a property to every note in a folder and is idempotent on re-run", async () => {
+		const { obsidian, sandbox } = getContext();
+		const dir = "skip-folder";
+		await seed(obsidian, sandbox.path(dir), {
+			"a.md": "# A\n\nbody\n",
+			"b.md": "---\nstatus: draft\n---\n\nbody\n",
+			"sub/c.md": "no frontmatter\n",
+		});
+
+		const first = await applyBulk(obsidian, sandbox.path(dir), "project", "Alpha", "skip");
+		expect(first.added).toBe(3);
+		expect(first.total).toBe(3);
+
+		for (const rel of [`${dir}/a.md`, `${dir}/b.md`, `${dir}/sub/c.md`]) {
+			expect(await sandbox.waitForContent(rel, (c) => c.includes("project: Alpha"), WAIT_OPTS)).toContain(
+				"project: Alpha",
+			);
+		}
+		// The pre-existing status on b.md must survive an additive bulk add.
+		expect(await sandbox.read(`${dir}/b.md`)).toContain("status: draft");
+
+		// Re-running with a different value must change nothing: skip is idempotent.
+		const second = await applyBulk(obsidian, sandbox.path(dir), "project", "Beta", "skip");
+		expect(second.skipped).toBe(3);
+		expect(second.added).toBe(0);
+
+		const a = await sandbox.read(`${dir}/a.md`);
+		expect(a).toContain("project: Alpha");
+		expect(a).not.toContain("Beta");
+		expect((a.match(/project:/g) ?? []).length).toBe(1);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("merge appends into a list without duplicating and converges on re-run", async () => {
+		const { obsidian, sandbox } = getContext();
+		const dir = "merge-folder";
+		await seed(obsidian, sandbox.path(dir), {
+			"has-list.md": "---\ntags:\n  - x\n  - y\n---\n\nbody\n",
+			"no-fm.md": "# fresh\n",
+		});
+
+		const first = await applyBulk(obsidian, sandbox.path(dir), "tags", "z", "merge");
+		expect(first.merged).toBe(1); // has-list.md
+		expect(first.added).toBe(1); // no-fm.md seeded as a list
+
+		const list = await sandbox.waitForContent(
+			`${dir}/has-list.md`,
+			(c) => c.includes("- z"),
+			WAIT_OPTS,
+		);
+		expect(list).toContain("- x");
+		expect(list).toContain("- y");
+		expect(list).toContain("- z");
+
+		// no-fm.md should be list-shaped, matching the merged note (not a scalar).
+		const fresh = await sandbox.read(`${dir}/no-fm.md`);
+		expect(fresh).toMatch(/tags:\s*\n\s*- z/);
+
+		// Re-merging the same value is a no-op and never duplicates.
+		const second = await applyBulk(obsidian, sandbox.path(dir), "tags", "z", "merge");
+		expect(second.unchanged).toBe(2);
+		expect(second.merged).toBe(0);
+		const after = await sandbox.read(`${dir}/has-list.md`);
+		expect((after.match(/- z/g) ?? []).length).toBe(1);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("overwrite replaces existing values and is idempotent", async () => {
+		const { obsidian, sandbox } = getContext();
+		const dir = "overwrite-folder";
+		await seed(obsidian, sandbox.path(dir), {
+			"one.md": "---\nstatus: draft\n---\n\nbody\n",
+			"two.md": "---\nstatus: review\n---\n\nbody\n",
+		});
+
+		const first = await applyBulk(obsidian, sandbox.path(dir), "status", "final", "overwrite");
+		expect(first.overwritten).toBe(2);
+
+		for (const rel of [`${dir}/one.md`, `${dir}/two.md`]) {
+			const content = await sandbox.waitForContent(rel, (c) => c.includes("status: final"), WAIT_OPTS);
+			expect(content).toContain("status: final");
+			expect(content).not.toMatch(/status: (draft|review)/);
+		}
+
+		const second = await applyBulk(obsidian, sandbox.path(dir), "status", "final", "overwrite");
+		expect(second.unchanged).toBe(2);
+		expect(second.overwritten).toBe(0);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("collects a multi-selection without duplicates and wires the files-menu item", async () => {
+		const { obsidian, sandbox } = getContext();
+		const dir = "selection-folder";
+		await seed(obsidian, sandbox.path(dir), {
+			"a.md": "# A\n",
+			"b.md": "# B\n",
+			"notes.txt": "not markdown\n",
+		});
+
+		const result = await evalJsonAsync<{
+			collected: string[];
+			menuTitles: string[];
+			ignoredSource: number;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const dir = ${JSON.stringify(sandbox.path(dir))};
+				const folder = app.vault.getAbstractFileByPath(dir);
+				const aFile = app.vault.getAbstractFileByPath(dir + "/a.md");
+
+				// Folder + a file already inside it: the file must not be collected twice.
+				const collected = plugin.bulkEditor
+					.collectFromSelection([folder, aFile])
+					.map((f) => f.path)
+					.sort();
+
+				// Drive the real registered handler directly (not workspace.trigger,
+				// which would fan out to unrelated core listeners with a fake menu).
+				const makeMenu = (sink) => ({
+					addItem(cb) {
+						const item = {
+							setIcon: () => item,
+							setTitle: (t) => { item._t = t; return item; },
+							onClick: () => item,
+						};
+						cb(item);
+						sink.push(item._t);
+						return this;
+					},
+				});
+
+				const menuTitles = [];
+				plugin.linkMenu.onFilesMenuOpenCallback(
+					makeMenu(menuTitles),
+					[aFile, app.vault.getAbstractFileByPath(dir + "/b.md")],
+					"file-explorer-context-menu",
+				);
+
+				const ignored = [];
+				plugin.linkMenu.onFilesMenuOpenCallback(makeMenu(ignored), [aFile], "search-context-menu");
+
+				return { collected, menuTitles, ignoredSource: ignored.length };
+			})()
+		`,
+		);
+
+		expect(result.collected).toEqual([`${sandbox.path(dir)}/a.md`, `${sandbox.path(dir)}/b.md`]);
+		expect(result.menuTitles).toContain("Bulk edit metadata in selected notes");
+		expect(result.ignoredSource).toBe(0);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+});
+
+// Seed a set of notes (relative paths under `baseVaultPath`) in the live vault,
+// creating parent folders as needed, then let the metadata cache settle.
+async function seed(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	baseVaultPath: string,
+	notes: Record<string, string>,
+): Promise<void> {
+	await evalJsonAsync<void>(
+		obsidian,
+		`
+		(async () => {
+			const base = ${JSON.stringify(baseVaultPath)};
+			const notes = ${JSON.stringify(notes)};
+			const ensureFolder = async (folder) => {
+				const parts = folder.split("/");
+				let current = "";
+				for (const part of parts) {
+					current = current ? current + "/" + part : part;
+					if (!app.vault.getAbstractFileByPath(current)) await app.vault.createFolder(current);
+				}
+			};
+			await ensureFolder(base);
+			for (const [rel, content] of Object.entries(notes)) {
+				const full = base + "/" + rel;
+				const folder = full.split("/").slice(0, -1).join("/");
+				await ensureFolder(folder);
+				const existing = app.vault.getAbstractFileByPath(full);
+				if (existing) await app.vault.delete(existing);
+				await app.vault.create(full, content);
+			}
+			await new Promise((resolve) => setTimeout(resolve, 600));
+		})()
+	`,
+	);
+}
+
+// Run the bulk apply over every markdown file under `folderVaultPath`.
+async function applyBulk(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	folderVaultPath: string,
+	key: string,
+	value: string,
+	policy: "skip" | "merge" | "overwrite",
+): Promise<BulkSummary> {
+	return await evalJsonAsync<BulkSummary>(
+		obsidian,
+		`
+		(async () => {
+			const plugin = app.plugins.plugins.${PLUGIN_ID};
+			const folder = app.vault.getAbstractFileByPath(${JSON.stringify(folderVaultPath)});
+			const files = plugin.bulkEditor.collectFromFolder(folder);
+			const summary = await plugin.bulkEditor.apply(files, ${JSON.stringify(key)}, ${JSON.stringify(value)}, ${JSON.stringify(policy)});
+			await new Promise((resolve) => setTimeout(resolve, 400));
+			return summary;
+		})()
+	`,
+	);
+}

--- a/tests/e2e/bulk-metadata.test.ts
+++ b/tests/e2e/bulk-metadata.test.ts
@@ -167,6 +167,55 @@ describe("MetaEdit bulk metadata edit", () => {
 		expect(result.ignoredSource).toBe(0);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
+
+	test("offers the folder bulk item when markdown lives only in a subfolder", async () => {
+		const { obsidian, sandbox } = getContext();
+		const dir = "nested-only-folder";
+		await seed(obsidian, sandbox.path(dir), {
+			"deep/note.md": "# nested\n",
+			"side/readme.txt": "not markdown\n",
+		});
+
+		const result = await evalJsonAsync<{ nestedFolder: string[]; noMarkdown: string[] }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const base = ${JSON.stringify(sandbox.path(dir))};
+				const makeMenu = (sink) => ({
+					addItem(cb) {
+						const item = { setIcon: () => item, setTitle: (t) => { item._t = t; return item; }, onClick: () => item };
+						cb(item);
+						sink.push(item._t);
+						return this;
+					},
+				});
+
+				// Folder whose only markdown is nested two levels down.
+				const nestedFolder = [];
+				plugin.linkMenu.onMenuOpenCallback(
+					makeMenu(nestedFolder),
+					app.vault.getAbstractFileByPath(base),
+					"file-explorer-context-menu",
+				);
+
+				// Folder containing no markdown at any depth.
+				const noMarkdown = [];
+				plugin.linkMenu.onMenuOpenCallback(
+					makeMenu(noMarkdown),
+					app.vault.getAbstractFileByPath(base + "/side"),
+					"file-explorer-context-menu",
+				);
+
+				return { nestedFolder, noMarkdown };
+			})()
+		`,
+		);
+
+		expect(result.nestedFolder).toContain("Bulk edit metadata in this folder (and subfolders)");
+		expect(result.noMarkdown).not.toContain("Bulk edit metadata in this folder (and subfolders)");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
 });
 
 // Seed a set of notes (relative paths under `baseVaultPath`) in the live vault,


### PR DESCRIPTION
## Summary

Adds a coherent **bulk metadata edit** capability: add or update a single YAML
frontmatter property across many notes at once, safely and idempotently.

Reachable two ways:
- **Folder context menu** -> "Bulk edit metadata in this folder (and subfolders)" (replaces the old blind per-file writer).
- **File-explorer multi-selection** -> "Bulk edit metadata in selected notes" (new `files-menu` entry - the literal ask of #64).

The flow: prompt for a property name and value, then - only when some notes
already define the property - choose a **conflict policy** once:

| Policy | Behavior |
|--------|----------|
| **Skip** (default) | Add only where missing; never touch existing values (no duplicates). |
| **Merge** | Add the value into a list, without duplicating; every note ends up list-shaped. |
| **Overwrite** | Replace existing values. Gated behind a blast-radius confirmation. |

A single summary Notice reports the outcome (`added / merged / overwritten /
skipped / unchanged / failed`). Per-note failures are isolated and logged; one
bad note never aborts the batch.

Closes #64. Closes #20.

## Why these issues, and what about #32?

- **#64** ("add a property to multiple notes") and **#20** ("don't duplicate a
  property when bulk-applying in folders; merge into arrays; confirm before
  overwriting") are the same capability from two angles, delivered together here.
  On today's master #20's literal duplicate is already prevented by the
  controller's `hasOwnProperty` guard; what was missing - and is added here - is
  the actual bulk *capability*: a multi-select entry point, a conflict policy
  (merge into lists / confirmed overwrite), idempotency, and a single summary.
- **#32** ("search for a line with a keyword and add it to a property") is
  **intentionally scoped out**. It is a content-harvest operation (scan note
  *body* lines, collect matches into a property) - a fundamentally different
  mental model from "apply property = value across a set of notes," and
  single-note-oriented in the issue. Folding it in would muddy a clean
  capability. The bulk engine is operation-shaped so #32 can be added later as
  its own feature. Recommend keeping #32 open as a separate follow-up.

## Design

- **Idempotent by construction.** Each note's decision is a pure function
  (`src/bulk/bulkMetadata.ts`): re-running any policy is a no-op (proven by unit
  tests and live re-run E2E). Merge dedupes by stable serialization and every
  policy converges.
- **Atomic, safe writes.** Each note's read -> decide -> write happens inside a
  single `app.fileManager.processFrontMatter` callback - the same frontmatter
  primitive the controller write path is built on - **not** hand-rolled YAML text
  edits. Decisions use the note's *live* frontmatter, never the lazy metadata
  cache.
- **Parity with single-note adds.** Bulk adds honor EditMode multi-value
  wrapping, so YAML shape is consistent whether you add one note or many.
- **Cancel-safe UI.** An owned `BulkOptionModal` resolves `null` on Escape; text
  prompts catch the prompt's cancel rejection and abort cleanly.

## Adversarial review

Design and implementation each went through opposing-model adversarial review
(refute-first, multiple lenses). Findings folded in: cancel-safe modal; atomic
read-decide-write against live frontmatter; EditMode parity; recursive menu
reachability (items now appear when markdown lives only in subfolders);
overwrite confirmation framed against the authoritative selection size (never a
cache count that could understate the blast radius); empty value aborts; failures
reported once via `console.warn` (not per-note error Notices). Verified live that
`processFrontMatter` performs **no write on a no-op**, so skip/unchanged re-runs
don't churn files or fire automators.

## Collision boundary

Touches only `src/main.ts`, `src/Modals/LinkMenu.ts`, new files under
`src/bulk/`, `src/Types/obsidian-augmentations.d.ts`, and `styles.css`. It edits
none of: `metaController.ts`, `parser.ts`, `Settings/`, the suggester modals, or
`MetaEditApi.ts`.

## Validation

Obsidian **1.12.7**, isolated worktree E2E vault. Branch rebased on current
master (integrates #120 / #122).

- `pnpm run lint` -> 0 errors (only pre-existing warnings; 2 adjacent ones fixed).
- `pnpm run build` -> clean.
- `pnpm run test` -> **96** unit tests pass (22 new for the decision engine).
- `pnpm run test:e2e` -> **16** live tests pass (11 pre-existing + 5 new), each asserting zero runtime errors.
- **Live multi-note proof**: seeded a nested folder with mixed states (no
  frontmatter, scalar conflict, array, empty, subfolder note, non-md file) and
  verified collection (recursion + md filter + dedup), every policy, idempotent
  re-runs, EditMode wrapping, recursive menu reachability, the multi-select menu
  wiring, the **full interactive flow** (prompts -> option modal -> summary), and
  **cancel-safety** (Escape aborts with no writes, no hang). Final frontmatter
  verified clean (correct fences, list formatting, merged `[x, y, z]` with no
  duplicates).

## Known limitations / deliberate choices

- **Not undoable.** Bulk edits write programmatically and aren't reversible with
  Ctrl+Z (same as the previous folder command); that's why Overwrite is confirmed.
- **Merge dedupes by string form**, so `5` and `"5"` are treated as the same
  value (prevents visually-identical duplicates). Pre-existing duplicates inside
  a list are left as-is rather than silently rewritten.
- **Conflict count in the policy prompt** is read from Obsidian's metadata cache
  (the same source as the existing `getFilesWithProperty`); the apply uses live
  frontmatter and the summary reports the true counts. The destructive overwrite
  confirmation is framed against the authoritative selection size, so it can
  never understate the blast radius.
- **Write serialization.** Bulk writes use `processFrontMatter` (atomic,
  key-scoped) sequentially; they are not cross-serialized with the controller's
  private per-file queue, which lives in a file outside this change's boundary.
  Risk is low because writes are sequential and merge into existing frontmatter
  by key.
- Large folders are processed sequentially (correct; no mid-run progress beyond
  the final summary).
