### PR TITLE
feat: assist property-value entry with autocomplete and a native date picker

### DIFF
--- a/src/Modals/GenericPrompt/GenericPrompt.ts
+++ b/src/Modals/GenericPrompt/GenericPrompt.ts
@@ -1,20 +1,27 @@
 import {type App, Modal} from "obsidian";
 import GenericPromptContent from "./GenericPromptContent.svelte"
+import type {PromptValueContext} from "./promptValueContext";
+
+export interface PromptOptions {
+    placeholder?: string;
+    value?: string;
+    suggestValues?: string[];
+    valueContext?: PromptValueContext;
+}
 
 export default class GenericPrompt extends Modal {
     private modalContent: GenericPromptContent;
-    private resolvePromise: (input: string) => void;
+    private resolvePromise: (input: string | null) => void;
     private input: string;
-    public waitForClose: Promise<string>;
-    private rejectPromise: (reason?: any) => void;
+    public waitForClose: Promise<string | null>;
     private didSubmit: boolean = false;
 
-    public static Prompt(app: App, header: string, placeholder?: string, value?: string, suggestValues?: string[]): Promise<string> {
-        const newPromptModal = new GenericPrompt(app, header, placeholder, value, suggestValues);
+    public static Prompt(app: App, header: string, options?: PromptOptions): Promise<string | null> {
+        const newPromptModal = new GenericPrompt(app, header, options);
         return newPromptModal.waitForClose;
     }
 
-    private constructor(app: App, header: string, placeholder?: string, value?: string, suggestValues?: string[]) {
+    private constructor(app: App, header: string, options: PromptOptions = {}) {
         super(app);
 
         this.modalContent = new GenericPromptContent({
@@ -22,9 +29,10 @@ export default class GenericPrompt extends Modal {
             props: {
                 app,
                 header,
-                placeholder,
-                value,
-                suggestValues,
+                placeholder: options.placeholder,
+                value: options.value,
+                suggestValues: options.suggestValues,
+                valueContext: options.valueContext ?? null,
                 onSubmit: (input: string) => {
                     this.input = input;
                     this.didSubmit = true;
@@ -33,10 +41,9 @@ export default class GenericPrompt extends Modal {
             }
         });
 
-        this.waitForClose = new Promise<string>(
-            (resolve, reject) => {
+        this.waitForClose = new Promise<string | null>(
+            (resolve) => {
                 this.resolvePromise = resolve;
-                this.rejectPromise = reject;
             }
         );
 
@@ -58,7 +65,9 @@ export default class GenericPrompt extends Modal {
         super.onClose();
         this.modalContent.$destroy();
 
-        if(!this.didSubmit) this.rejectPromise("No input given.");
+        // Cancelling (Escape/close without submitting) resolves to null rather than
+        // rejecting, so a normal cancel never surfaces as an unhandled rejection.
+        if (!this.didSubmit) this.resolvePromise(null);
         else this.resolvePromise(this.input);
     }
 }

--- a/src/Modals/GenericPrompt/GenericPrompt.ts
+++ b/src/Modals/GenericPrompt/GenericPrompt.ts
@@ -46,10 +46,12 @@ export default class GenericPrompt extends Modal {
     onOpen() {
         super.onOpen();
 
-        const modalPrompt: HTMLElement = document.querySelector('.metaEditPrompt');
-        const modalInput: any = modalPrompt.querySelector('.metaEditPromptInput');
-        modalInput.focus();
-        modalInput.select();
+        const modalPrompt = document.querySelector('.metaEditPrompt');
+        const modalInput = modalPrompt?.querySelector('.metaEditPromptInput') as HTMLInputElement | null;
+        modalInput?.focus();
+        // select() is only meaningful (and only safe) on text inputs - calling it
+        // on a date/datetime input throws in some engines.
+        if (modalInput?.type === "text") modalInput.select();
     }
 
     onClose() {

--- a/src/Modals/GenericPrompt/GenericPromptContent.svelte
+++ b/src/Modals/GenericPrompt/GenericPromptContent.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-    import {onMount} from "svelte";
+    import {onDestroy, onMount} from "svelte";
     import {GenericTextSuggester} from "./genericTextSuggester";
+    import {consumePendingValueContext} from "./promptValueContext";
+    import {getDateInputType, getValueSuggestions} from "./valueSuggest";
     import type {App} from "obsidian";
 
     export let app: App;
@@ -12,13 +14,38 @@
     let suggester: GenericTextSuggester;
     let inputEl: HTMLInputElement;
 
-    onMount(() => {
-        if (suggestValues && suggestValues.length > 0)
-            suggester = new GenericTextSuggester(app, inputEl, suggestValues);
+    // Context for the property being edited (set by metaEditSuggester). Taken once
+    // so a stale context never leaks into a later prompt.
+    const context = consumePendingValueContext();
+    const hasExplicitSuggestions = Array.isArray(suggestValues) && suggestValues.length > 0;
 
-        inputEl.select();
+    // Date detection is cheap (property-type registry lookups), so resolve it up
+    // front to pick the input type before first paint. Explicit suggestion lists
+    // (Auto Properties) keep their plain choice-list behaviour and never become a
+    // date picker.
+    const dateInputType = !hasExplicitSuggestions && context
+        ? getDateInputType(context.app, context.key, value, context.type)
+        : null;
+
+    onMount(() => {
+        if (!dateInputType) {
+            const suggestions = hasExplicitSuggestions
+                ? suggestValues
+                : context
+                    ? getValueSuggestions(context.app, context.key, context.type)
+                    : [];
+
+            if (suggestions.length > 0)
+                suggester = new GenericTextSuggester(app, inputEl, suggestions);
+        }
+
         inputEl.focus();
+        if (!dateInputType) inputEl.select();
     })
+
+    // The suggester's dropdown lives in appContainerEl (outside the modal), so it
+    // must be torn down explicitly when the prompt closes or it lingers.
+    onDestroy(() => suggester?.close())
 
     function submit(evt: KeyboardEvent) {
         if (evt.key === "Enter") {
@@ -30,11 +57,27 @@
 
 <div class="metaEditPrompt">
     <h1 style="text-align: center">{header}</h1>
-    <input bind:this={inputEl}
-           bind:value={value}
-           class="metaEditPromptInput"
-           on:keydown={submit}
-           placeholder={placeholder}
-           style="width: 100%;"
-           type="text">
+    {#if dateInputType === "date"}
+        <input bind:this={inputEl}
+               bind:value={value}
+               class="metaEditPromptInput metadata-input metadata-input-text mod-date"
+               on:keydown={submit}
+               style="width: 100%;"
+               type="date">
+    {:else if dateInputType === "datetime"}
+        <input bind:this={inputEl}
+               bind:value={value}
+               class="metaEditPromptInput metadata-input metadata-input-text mod-datetime"
+               on:keydown={submit}
+               style="width: 100%;"
+               type="datetime-local">
+    {:else}
+        <input bind:this={inputEl}
+               bind:value={value}
+               class="metaEditPromptInput"
+               on:keydown={submit}
+               placeholder={placeholder}
+               style="width: 100%;"
+               type="text">
+    {/if}
 </div>

--- a/src/Modals/GenericPrompt/GenericPromptContent.svelte
+++ b/src/Modals/GenericPrompt/GenericPromptContent.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import {onDestroy, onMount} from "svelte";
     import {GenericTextSuggester} from "./genericTextSuggester";
-    import {consumePendingValueContext} from "./promptValueContext";
     import {getDateInputType, getValueSuggestions} from "./valueSuggest";
+    import type {PromptValueContext} from "./promptValueContext";
     import type {App} from "obsidian";
 
     export let app: App;
@@ -11,36 +11,47 @@
     export let value: string = "";
     export let onSubmit: (value: string) => void;
     export let suggestValues: string[];
+    export let valueContext: PromptValueContext | null = null;
     let suggester: GenericTextSuggester;
     let inputEl: HTMLInputElement;
 
-    // Context for the property being edited (set by metaEditSuggester). Taken once
-    // so a stale context never leaks into a later prompt.
-    const context = consumePendingValueContext();
     const hasExplicitSuggestions = Array.isArray(suggestValues) && suggestValues.length > 0;
 
     // Date detection is cheap (property-type registry lookups), so resolve it up
     // front to pick the input type before first paint. Explicit suggestion lists
     // (Auto Properties) keep their plain choice-list behaviour and never become a
     // date picker.
-    const dateInputType = !hasExplicitSuggestions && context
-        ? getDateInputType(context.app, context.key, value, context.type)
+    const dateInputType = !hasExplicitSuggestions && valueContext
+        ? getDateInputType(app, valueContext.key, value, valueContext.type)
         : null;
+    // datetime-local needs step="1" to show/keep seconds; without it a seconds
+    // value would be silently truncated.
+    const datetimeStep = dateInputType === "datetime" && /T\d{2}:\d{2}:\d{2}/.test(value) ? "1" : undefined;
 
     onMount(() => {
         if (!dateInputType) {
             const suggestions = hasExplicitSuggestions
                 ? suggestValues
-                : context
-                    ? getValueSuggestions(context.app, context.key, context.type)
+                : valueContext
+                    ? getValueSuggestions(app, valueContext.key, valueContext.type)
                     : [];
 
-            if (suggestions.length > 0)
-                suggester = new GenericTextSuggester(app, inputEl, suggestions);
+            if (suggestions.length > 0) {
+                // Open on focus only when the input is empty (discovery of choices /
+                // known values). When it is seeded with the current value, opening on
+                // focus would pre-highlight a suggestion and make a bare Enter
+                // overwrite that value.
+                suggester = new GenericTextSuggester(app, inputEl, suggestions, {openOnFocus: !value});
+            }
         }
 
         inputEl.focus();
         if (!dateInputType) inputEl.select();
+
+        // Empty-seeded prompts (Auto Property choices, name discovery) should show
+        // their options immediately; the programmatic focus above does not reliably
+        // fire a focus event, so open the dropdown explicitly.
+        if (suggester && !value) suggester.onInputChanged();
     })
 
     // The suggester's dropdown lives in appContainerEl (outside the modal), so it
@@ -69,6 +80,7 @@
                bind:value={value}
                class="metaEditPromptInput metadata-input metadata-input-text mod-datetime"
                on:keydown={submit}
+               step={datetimeStep}
                style="width: 100%;"
                type="datetime-local">
     {:else}

--- a/src/Modals/GenericPrompt/genericTextSuggester.ts
+++ b/src/Modals/GenericPrompt/genericTextSuggester.ts
@@ -1,22 +1,18 @@
 import {TextInputSuggest} from "../../suggest";
+import {filterSuggestions} from "./valueSuggest";
 import type {App} from "obsidian";
 
 export class GenericTextSuggester extends TextInputSuggest<string> {
 
     constructor(public app: App, public inputEl: HTMLInputElement, private items: string[]) {
-        super(app, inputEl);
+        // The prompt seeds the input with the current value, so opening on focus
+        // would pre-highlight a suggestion and make a bare Enter overwrite that
+        // value. Only open once the user actually types.
+        super(app, inputEl, {openOnFocus: false});
     }
 
     getSuggestions(inputStr: string): string[] {
-        const inputLowerCase: string = inputStr.toLowerCase();
-        const filtered = this.items.filter(item => {
-            if (item.toLowerCase().contains(inputLowerCase))
-                return item;
-        });
-
-        if (!filtered) this.close();
-        if (filtered?.length === 1) return [...filtered, inputStr];
-        if (filtered?.length > 1) return filtered;
+        return filterSuggestions(this.items, inputStr);
     }
 
     selectSuggestion(item: string): void {

--- a/src/Modals/GenericPrompt/genericTextSuggester.ts
+++ b/src/Modals/GenericPrompt/genericTextSuggester.ts
@@ -4,11 +4,13 @@ import type {App} from "obsidian";
 
 export class GenericTextSuggester extends TextInputSuggest<string> {
 
-    constructor(public app: App, public inputEl: HTMLInputElement, private items: string[]) {
-        // The prompt seeds the input with the current value, so opening on focus
-        // would pre-highlight a suggestion and make a bare Enter overwrite that
-        // value. Only open once the user actually types.
-        super(app, inputEl, {openOnFocus: false});
+    constructor(
+        public app: App,
+        public inputEl: HTMLInputElement,
+        private items: string[],
+        options?: {openOnFocus?: boolean},
+    ) {
+        super(app, inputEl, options);
     }
 
     getSuggestions(inputStr: string): string[] {

--- a/src/Modals/GenericPrompt/promptValueContext.ts
+++ b/src/Modals/GenericPrompt/promptValueContext.ts
@@ -1,0 +1,31 @@
+import type {App} from "obsidian";
+import type {MetaType} from "../../Types/metaType";
+
+export interface PromptValueContext {
+    app: App;
+    key: string;
+    type: MetaType;
+}
+
+let pending: PromptValueContext | null = null;
+
+/**
+ * Bridges the property being edited from the entry point (metaEditSuggester) to
+ * the value prompt (GenericPrompt).
+ *
+ * The controller orchestrates the edit and opens the prompt, but it does not
+ * carry UI-suggestion context. Rather than threading that context through the
+ * write/parse core (intentionally left untouched), the suggester stashes it here
+ * for the next prompt to pick up. The suggester always sets it inside a
+ * try/finally so it never outlives a single edit, and consumers take-and-clear
+ * it on read so a stale context can never bleed into an unrelated later prompt.
+ */
+export function setPendingValueContext(context: PromptValueContext | null): void {
+    pending = context;
+}
+
+export function consumePendingValueContext(): PromptValueContext | null {
+    const context = pending;
+    pending = null;
+    return context;
+}

--- a/src/Modals/GenericPrompt/promptValueContext.ts
+++ b/src/Modals/GenericPrompt/promptValueContext.ts
@@ -1,31 +1,12 @@
-import type {App} from "obsidian";
 import type {MetaType} from "../../Types/metaType";
 
+/**
+ * The property a value prompt is editing. The controller passes this into
+ * GenericPrompt.Prompt so the prompt can self-source value suggestions and
+ * detect a date/datetime type. It carries only what the prompt needs (the
+ * app comes in separately) and never the value itself.
+ */
 export interface PromptValueContext {
-    app: App;
     key: string;
     type: MetaType;
-}
-
-let pending: PromptValueContext | null = null;
-
-/**
- * Bridges the property being edited from the entry point (metaEditSuggester) to
- * the value prompt (GenericPrompt).
- *
- * The controller orchestrates the edit and opens the prompt, but it does not
- * carry UI-suggestion context. Rather than threading that context through the
- * write/parse core (intentionally left untouched), the suggester stashes it here
- * for the next prompt to pick up. The suggester always sets it inside a
- * try/finally so it never outlives a single edit, and consumers take-and-clear
- * it on read so a stale context can never bleed into an unrelated later prompt.
- */
-export function setPendingValueContext(context: PromptValueContext | null): void {
-    pending = context;
-}
-
-export function consumePendingValueContext(): PromptValueContext | null {
-    const context = pending;
-    pending = null;
-    return context;
 }

--- a/src/Modals/GenericPrompt/valueSuggest.test.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest";
 import {TFile} from "obsidian";
-import {filterSuggestions, getDateInputType, getValueSuggestions} from "./valueSuggest";
+import {filterSuggestions, getDateInputType, getKnownPropertyNames, getValueSuggestions} from "./valueSuggest";
 import {MetaType} from "../../Types/metaType";
 
 type FileCache = {frontmatter?: Record<string, unknown>};
@@ -114,6 +114,26 @@ describe("getValueSuggestions - tags", () => {
         });
 
         expect(getValueSuggestions(app, "#a/draft", MetaType.Tag)).toEqual(["draft"]);
+    });
+});
+
+describe("getKnownPropertyNames", () => {
+    it("returns the names of all properties known to Obsidian", () => {
+        const app = {
+            metadataTypeManager: {
+                getAllProperties: () => ({
+                    status: {name: "status", widget: "text", occurrences: 3},
+                    due: {name: "due", widget: "date", occurrences: 1},
+                    tags: {name: "tags", widget: "tags", occurrences: 0},
+                }),
+            },
+        } as never;
+
+        expect(getKnownPropertyNames(app)).toEqual(["status", "due", "tags"]);
+    });
+
+    it("degrades to an empty list when the registry is unavailable", () => {
+        expect(getKnownPropertyNames({} as never)).toEqual([]);
     });
 });
 

--- a/src/Modals/GenericPrompt/valueSuggest.test.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.test.ts
@@ -1,0 +1,161 @@
+import {describe, expect, it} from "vitest";
+import {TFile} from "obsidian";
+import {getDateInputType, getValueSuggestions} from "./valueSuggest";
+import {MetaType} from "../../Types/metaType";
+
+type FileCache = {frontmatter?: Record<string, unknown>};
+
+const makeApp = (options: {
+    files?: Record<string, FileCache>;
+    tags?: Record<string, number>;
+    assignedWidget?: (key: string) => string | null;
+    typeInfo?: (key: string) => {expected?: {type?: string}} | undefined;
+    noTypeManager?: boolean;
+}) => {
+    const files = options.files ?? {};
+    const markdownFiles = Object.keys(files).map(path => new TFile(path));
+
+    return {
+        vault: {
+            getMarkdownFiles: () => markdownFiles,
+        },
+        metadataCache: {
+            getTags: () => options.tags ?? {},
+            getFileCache: (file: TFile) => files[file.path],
+        },
+        ...(options.noTypeManager
+            ? {}
+            : {
+                metadataTypeManager: {
+                    getAssignedWidget: options.assignedWidget ?? (() => null),
+                    getTypeInfo: options.typeInfo ?? (() => undefined),
+                },
+            }),
+    } as never;
+};
+
+describe("getValueSuggestions - frontmatter values", () => {
+    it("returns distinct values ranked by frequency, then alphabetically", () => {
+        const app = makeApp({
+            files: {
+                "a.md": {frontmatter: {status: "reading"}},
+                "b.md": {frontmatter: {status: "finished"}},
+                "c.md": {frontmatter: {status: "reading"}},
+                "d.md": {frontmatter: {genre: "fiction"}},
+            },
+        });
+
+        expect(getValueSuggestions(app, "status", MetaType.YAML)).toEqual(["reading", "finished"]);
+    });
+
+    it("flattens array values element-wise and unions scalars and arrays", () => {
+        const app = makeApp({
+            files: {
+                "a.md": {frontmatter: {tags: ["a", "b"]}},
+                "b.md": {frontmatter: {tags: "a"}},
+                "c.md": {frontmatter: {tags: ["c"]}},
+            },
+        });
+
+        // "a" occurs twice -> first; then b, c alphabetically.
+        expect(getValueSuggestions(app, "tags", MetaType.YAML)).toEqual(["a", "b", "c"]);
+    });
+
+    it("coerces numbers and skips null, empty, and object values", () => {
+        const app = makeApp({
+            files: {
+                "a.md": {frontmatter: {rating: 4}},
+                "b.md": {frontmatter: {rating: null}},
+                "c.md": {frontmatter: {rating: ""}},
+                "d.md": {frontmatter: {rating: {nested: true}}},
+                "e.md": {frontmatter: {}},
+                "f.md": {},
+            },
+        });
+
+        expect(getValueSuggestions(app, "rating", MetaType.YAML)).toEqual(["4"]);
+    });
+
+    it("returns an empty list when the key is unknown or empty", () => {
+        const app = makeApp({files: {"a.md": {frontmatter: {status: "reading"}}}});
+
+        expect(getValueSuggestions(app, "missing", MetaType.YAML)).toEqual([]);
+        expect(getValueSuggestions(app, "", MetaType.YAML)).toEqual([]);
+    });
+});
+
+describe("getValueSuggestions - tags", () => {
+    it("suggests leaf segments (not full paths) ranked by count", () => {
+        const app = makeApp({
+            tags: {
+                "#topic/science": 2,
+                "#topic/history": 1,
+                "#topic": 5,
+                "#status/active": 3,
+            },
+        });
+
+        // leaves: science(2), history(1), topic(5), active(3) -> by count desc
+        expect(getValueSuggestions(app, "#topic/science", MetaType.Tag)).toEqual([
+            "topic",
+            "active",
+            "science",
+            "history",
+        ]);
+    });
+
+    it("merges identical leaf segments under different parents", () => {
+        const app = makeApp({
+            tags: {
+                "#a/draft": 1,
+                "#b/draft": 2,
+                "#draft": 4,
+            },
+        });
+
+        expect(getValueSuggestions(app, "#a/draft", MetaType.Tag)).toEqual(["draft"]);
+    });
+});
+
+describe("getDateInputType", () => {
+    const dateApp = (assigned: string | null, inferred?: string) =>
+        makeApp({
+            assignedWidget: () => assigned,
+            typeInfo: () => (inferred ? {expected: {type: inferred}} : undefined),
+        });
+
+    it("returns 'date' for an explicitly date-typed key with an ISO value", () => {
+        expect(getDateInputType(dateApp("date"), "due", "2026-07-01", MetaType.YAML)).toBe("date");
+    });
+
+    it("returns 'date' for an empty value on a date-typed key", () => {
+        expect(getDateInputType(dateApp("date"), "due", "", MetaType.YAML)).toBe("date");
+        expect(getDateInputType(dateApp("date"), "due", null, MetaType.YAML)).toBe("date");
+    });
+
+    it("falls back to inferred type when no widget is explicitly assigned", () => {
+        expect(getDateInputType(dateApp(null, "date"), "due", "2026-07-01", MetaType.YAML)).toBe("date");
+    });
+
+    it("returns 'datetime' only for a minute-precision ISO datetime value", () => {
+        expect(getDateInputType(dateApp("datetime"), "when", "2026-07-01T13:30", MetaType.YAML)).toBe("datetime");
+        expect(getDateInputType(dateApp("datetime"), "when", "2026-07-01T13:30:45", MetaType.YAML)).toBeNull();
+        expect(getDateInputType(dateApp("datetime"), "when", "2026-07-01", MetaType.YAML)).toBeNull();
+    });
+
+    it("falls back to text (null) for non-ISO values so they are never clobbered", () => {
+        expect(getDateInputType(dateApp("date"), "due", "next friday", MetaType.YAML)).toBeNull();
+        expect(getDateInputType(dateApp("date"), "due", "TBD", MetaType.YAML)).toBeNull();
+    });
+
+    it("never offers a picker for non-date types or non-YAML properties", () => {
+        expect(getDateInputType(dateApp("text"), "title", "2026-07-01", MetaType.YAML)).toBeNull();
+        expect(getDateInputType(dateApp("date"), "due", "2026-07-01", MetaType.Dataview)).toBeNull();
+        expect(getDateInputType(dateApp("date"), "#due", "2026-07-01", MetaType.Tag)).toBeNull();
+    });
+
+    it("degrades to text when metadataTypeManager is unavailable", () => {
+        const app = makeApp({noTypeManager: true});
+        expect(getDateInputType(app, "due", "2026-07-01", MetaType.YAML)).toBeNull();
+    });
+});

--- a/src/Modals/GenericPrompt/valueSuggest.test.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.test.ts
@@ -82,6 +82,12 @@ describe("getValueSuggestions - frontmatter values", () => {
         expect(getValueSuggestions(app, "missing", MetaType.YAML)).toEqual([]);
         expect(getValueSuggestions(app, "", MetaType.YAML)).toEqual([]);
     });
+
+    it("does not source inline Dataview field values yet (deferred follow-up)", () => {
+        const app = makeApp({files: {"a.md": {frontmatter: {status: "reading"}}}});
+
+        expect(getValueSuggestions(app, "status", MetaType.Dataview)).toEqual([]);
+    });
 });
 
 describe("getValueSuggestions - tags", () => {
@@ -185,9 +191,10 @@ describe("getDateInputType", () => {
         expect(getDateInputType(dateApp(null, "date"), "due", "2026-07-01", MetaType.YAML)).toBe("date");
     });
 
-    it("returns 'datetime' only for a minute-precision ISO datetime value", () => {
+    it("returns 'datetime' for minute- and second-precision ISO datetime values", () => {
         expect(getDateInputType(dateApp("datetime"), "when", "2026-07-01T13:30", MetaType.YAML)).toBe("datetime");
-        expect(getDateInputType(dateApp("datetime"), "when", "2026-07-01T13:30:45", MetaType.YAML)).toBeNull();
+        expect(getDateInputType(dateApp("datetime"), "when", "2026-07-01T13:30:45", MetaType.YAML)).toBe("datetime");
+        // A date-only value on a datetime field is not representable, so fall back.
         expect(getDateInputType(dateApp("datetime"), "when", "2026-07-01", MetaType.YAML)).toBeNull();
     });
 

--- a/src/Modals/GenericPrompt/valueSuggest.test.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.test.ts
@@ -158,6 +158,11 @@ describe("filterSuggestions", () => {
         // ...but still shows it while the input is a strict prefix.
         expect(filterSuggestions(items, "finishe")).toEqual(["finished"]);
     });
+
+    it("caps the rendered list so a huge value set cannot build an unbounded dropdown", () => {
+        const many = Array.from({length: 250}, (_, i) => `value-${i}`);
+        expect(filterSuggestions(many, "value").length).toBe(100);
+    });
 });
 
 describe("getDateInputType", () => {

--- a/src/Modals/GenericPrompt/valueSuggest.test.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest";
 import {TFile} from "obsidian";
-import {getDateInputType, getValueSuggestions} from "./valueSuggest";
+import {filterSuggestions, getDateInputType, getValueSuggestions} from "./valueSuggest";
 import {MetaType} from "../../Types/metaType";
 
 type FileCache = {frontmatter?: Record<string, unknown>};
@@ -114,6 +114,29 @@ describe("getValueSuggestions - tags", () => {
         });
 
         expect(getValueSuggestions(app, "#a/draft", MetaType.Tag)).toEqual(["draft"]);
+    });
+});
+
+describe("filterSuggestions", () => {
+    const items = ["reading", "finished", "to-read"];
+
+    it("returns case-insensitive substring matches", () => {
+        expect(filterSuggestions(items, "re")).toEqual(["reading", "to-read"]);
+        expect(filterSuggestions(items, "FIN")).toEqual(["finished"]);
+    });
+
+    it("returns all items for an empty query (discovery)", () => {
+        expect(filterSuggestions(items, "")).toEqual(items);
+    });
+
+    it("returns nothing when there are no matches", () => {
+        expect(filterSuggestions(items, "zzz")).toEqual([]);
+    });
+
+    it("hides the dropdown when the only match equals the input exactly", () => {
+        expect(filterSuggestions(items, "finished")).toEqual([]);
+        // ...but still shows it while the input is a strict prefix.
+        expect(filterSuggestions(items, "finishe")).toEqual(["finished"]);
     });
 });
 

--- a/src/Modals/GenericPrompt/valueSuggest.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.ts
@@ -6,6 +6,11 @@ export type DateInputType = "date" | "datetime";
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
 
+// Cap the rendered dropdown so a property with thousands of distinct values
+// cannot build an unbounded list. Filtering runs over the full set first, so a
+// specific query still finds rare values; the cap only bounds broad queries.
+const MAX_RENDERED_SUGGESTIONS = 100;
+
 /**
  * Distinct values already used for a property across the vault, ranked so the
  * most frequently used values surface first.
@@ -86,7 +91,7 @@ export function filterSuggestions(items: string[], inputStr: string): string[] {
     if (filtered.length === 0) return [];
     if (filtered.length === 1 && filtered[0] === inputStr) return [];
 
-    return filtered;
+    return filtered.slice(0, MAX_RENDERED_SUGGESTIONS);
 }
 
 function collectTagLeafCounts(app: App): Map<string, number> {

--- a/src/Modals/GenericPrompt/valueSuggest.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.ts
@@ -4,7 +4,7 @@ import {MetaType} from "../../Types/metaType";
 export type DateInputType = "date" | "datetime";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
-const ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+const ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/;
 
 // Cap the rendered dropdown so a property with thousands of distinct values
 // cannot build an unbounded list. Filtering runs over the full set first, so a
@@ -20,15 +20,29 @@ const MAX_RENDERED_SUGGESTIONS = 100;
  * full `topic/science` path while editing `#topic/science` would write
  * `#topic/topic/science`. Leaf segments are the only values that round-trip
  * safely through the tag writer.
+ *
+ * Inline Dataview (`key:: value`) fields are not in the metadata cache, so
+ * sourcing their values would mean a full-text scan that duplicates the parser;
+ * that is a deliberate follow-up, so Dataview keys return nothing for now.
  */
 export function getValueSuggestions(app: App, key: string, type: MetaType): string[] {
     if (!key) return [];
 
-    if (type === MetaType.Tag) {
-        return rankByCount(collectTagLeafCounts(app));
-    }
+    // These read untyped runtime APIs (getTags, metadataCache); never let a
+    // sourcing failure break the prompt - degrade to no suggestions.
+    try {
+        if (type === MetaType.Tag) {
+            return rankByCount(collectTagLeafCounts(app));
+        }
 
-    return rankByCount(collectFrontmatterValueCounts(app, key));
+        if (type === MetaType.YAML) {
+            return rankByCount(collectFrontmatterValueCounts(app, key));
+        }
+
+        return [];
+    } catch {
+        return [];
+    }
 }
 
 /**
@@ -50,7 +64,12 @@ export function getDateInputType(
 ): DateInputType | null {
     if (type !== MetaType.YAML || !key) return null;
 
-    const obsidianType = readObsidianType(app, key);
+    let obsidianType: string | null;
+    try {
+        obsidianType = readObsidianType(app, key);
+    } catch {
+        return null;
+    }
     if (obsidianType !== "date" && obsidianType !== "datetime") return null;
 
     const value = currentValue === null || currentValue === undefined ? "" : String(currentValue).trim();
@@ -67,16 +86,20 @@ export function getDateInputType(
  * can autocomplete known keys instead of free-typing them.
  */
 export function getKnownPropertyNames(app: App): string[] {
-    const typeManager = (app as unknown as {
-        metadataTypeManager?: {getAllProperties?: () => Record<string, {name?: string}>};
-    }).metadataTypeManager;
+    try {
+        const typeManager = (app as unknown as {
+            metadataTypeManager?: {getAllProperties?: () => Record<string, {name?: string}>};
+        }).metadataTypeManager;
 
-    const all = typeManager?.getAllProperties?.();
-    if (!all) return [];
+        const all = typeManager?.getAllProperties?.();
+        if (!all) return [];
 
-    return Object.values(all)
-        .map(info => info?.name)
-        .filter((name): name is string => typeof name === "string" && name.length > 0);
+        return Object.values(all)
+            .map(info => info?.name)
+            .filter((name): name is string => typeof name === "string" && name.length > 0);
+    } catch {
+        return [];
+    }
 }
 
 /**

--- a/src/Modals/GenericPrompt/valueSuggest.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.ts
@@ -57,9 +57,26 @@ export function getDateInputType(
     return null;
 }
 
+/**
+ * Filter known values against the current input for the dropdown. Hides the
+ * dropdown when it has nothing useful to add: no matches, or a single match
+ * identical to what the user already typed.
+ */
+export function filterSuggestions(items: string[], inputStr: string): string[] {
+    const query = inputStr.toLowerCase();
+    const filtered = items.filter(item => item.toLowerCase().includes(query));
+
+    if (filtered.length === 0) return [];
+    if (filtered.length === 1 && filtered[0] === inputStr) return [];
+
+    return filtered;
+}
+
 function collectTagLeafCounts(app: App): Map<string, number> {
     const counts = new Map<string, number>();
-    const tags: Record<string, number> = app.metadataCache.getTags?.() ?? {};
+    // getTags() is present at runtime but missing from the pinned obsidian typings.
+    const metadataCache = app.metadataCache as unknown as {getTags?: () => Record<string, number>};
+    const tags: Record<string, number> = metadataCache.getTags?.() ?? {};
 
     for (const [tag, count] of Object.entries(tags)) {
         const leaf = tag.replace(/^#/, "").split("/").pop()?.trim();

--- a/src/Modals/GenericPrompt/valueSuggest.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.ts
@@ -1,0 +1,124 @@
+import type {App} from "obsidian";
+import {MetaType} from "../../Types/metaType";
+
+export type DateInputType = "date" | "datetime";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+
+/**
+ * Distinct values already used for a property across the vault, ranked so the
+ * most frequently used values surface first.
+ *
+ * Tags resolve to their leaf segment (the part after the last `/`) because
+ * MetaEdit rewrites a tag by replacing only that last segment - suggesting a
+ * full `topic/science` path while editing `#topic/science` would write
+ * `#topic/topic/science`. Leaf segments are the only values that round-trip
+ * safely through the tag writer.
+ */
+export function getValueSuggestions(app: App, key: string, type: MetaType): string[] {
+    if (!key) return [];
+
+    if (type === MetaType.Tag) {
+        return rankByCount(collectTagLeafCounts(app));
+    }
+
+    return rankByCount(collectFrontmatterValueCounts(app, key));
+}
+
+/**
+ * Whether the value input for this property should be a native date/datetime
+ * picker, and which one.
+ *
+ * Obsidian's property types live in `metadataTypeManager`, which is keyed off
+ * frontmatter, so only YAML properties can be typed as date/datetime in a way
+ * that round-trips natively. The explicit, user-assigned type wins; otherwise we
+ * fall back to Obsidian's own inference (the same signal its Properties panel
+ * uses). The picker is only offered when the current value is empty or a value
+ * the picker can represent, so free-text/non-ISO values are never clobbered.
+ */
+export function getDateInputType(
+    app: App,
+    key: string,
+    currentValue: unknown,
+    type: MetaType,
+): DateInputType | null {
+    if (type !== MetaType.YAML || !key) return null;
+
+    const obsidianType = readObsidianType(app, key);
+    if (obsidianType !== "date" && obsidianType !== "datetime") return null;
+
+    const value = currentValue === null || currentValue === undefined ? "" : String(currentValue).trim();
+    if (value === "") return obsidianType;
+
+    if (obsidianType === "date" && ISO_DATE.test(value)) return "date";
+    if (obsidianType === "datetime" && ISO_DATETIME.test(value)) return "datetime";
+
+    return null;
+}
+
+function collectTagLeafCounts(app: App): Map<string, number> {
+    const counts = new Map<string, number>();
+    const tags: Record<string, number> = app.metadataCache.getTags?.() ?? {};
+
+    for (const [tag, count] of Object.entries(tags)) {
+        const leaf = tag.replace(/^#/, "").split("/").pop()?.trim();
+        if (!leaf) continue;
+        counts.set(leaf, (counts.get(leaf) ?? 0) + (count ?? 1));
+    }
+
+    return counts;
+}
+
+function collectFrontmatterValueCounts(app: App, key: string): Map<string, number> {
+    const counts = new Map<string, number>();
+
+    for (const file of app.vault.getMarkdownFiles()) {
+        const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+        if (!frontmatter || !Object.prototype.hasOwnProperty.call(frontmatter, key)) continue;
+
+        for (const value of flattenValues(frontmatter[key])) {
+            counts.set(value, (counts.get(value) ?? 0) + 1);
+        }
+    }
+
+    return counts;
+}
+
+function flattenValues(raw: unknown): string[] {
+    const values = Array.isArray(raw) ? raw : [raw];
+    const out: string[] = [];
+
+    for (const value of values) {
+        if (value === null || value === undefined) continue;
+        if (typeof value === "object") continue;
+        const text = String(value).trim();
+        if (text) out.push(text);
+    }
+
+    return out;
+}
+
+function rankByCount(counts: Map<string, number>): string[] {
+    return [...counts.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([value]) => value);
+}
+
+function readObsidianType(app: App, key: string): string | null {
+    // metadataTypeManager is not in the pinned obsidian typings but is present at
+    // runtime (Obsidian >= 1.4). Feature-detect and degrade to plain text.
+    const typeManager = (app as unknown as {
+        metadataTypeManager?: {
+            getAssignedWidget?: (key: string) => string | null;
+            getTypeInfo?: (key: string) => {expected?: {type?: string}} | undefined;
+        };
+    }).metadataTypeManager;
+    if (!typeManager) return null;
+
+    const assigned = typeManager.getAssignedWidget?.(key);
+    if (typeof assigned === "string") return assigned;
+
+    const inferred = typeManager.getTypeInfo?.(key)?.expected?.type;
+    return typeof inferred === "string" ? inferred : null;
+}

--- a/src/Modals/GenericPrompt/valueSuggest.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.ts
@@ -58,6 +58,23 @@ export function getDateInputType(
 }
 
 /**
+ * Property names already used anywhere in the vault, so adding a new property
+ * can autocomplete known keys instead of free-typing them.
+ */
+export function getKnownPropertyNames(app: App): string[] {
+    const typeManager = (app as unknown as {
+        metadataTypeManager?: {getAllProperties?: () => Record<string, {name?: string}>};
+    }).metadataTypeManager;
+
+    const all = typeManager?.getAllProperties?.();
+    if (!all) return [];
+
+    return Object.values(all)
+        .map(info => info?.name)
+        .filter((name): name is string => typeof name === "string" && name.length > 0);
+}
+
+/**
  * Filter known values against the current input for the dropdown. Hides the
  * dropdown when it has nothing useful to add: no matches, or a single match
  * identical to what the user already typed.

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -6,7 +6,6 @@ import {MAIN_SUGGESTER_OPTIONS, newDataView, newYaml} from "../constants";
 import {MetaType} from "../Types/metaType";
 import {concat} from "svelte-preprocess/dist/modules/utils";
 import type {AutoProperty} from "../Types/autoProperty";
-import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
 import {getKnownPropertyNames} from "./GenericPrompt/valueSuggest";
 
 export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
@@ -56,7 +55,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
 
     async onChooseItem(item: Property, _evt: MouseEvent | KeyboardEvent): Promise<void> {
         if (item.content === newYaml) {
-            const newProperty = await this.controller.createNewProperty(this.suggestValues);
+            const newProperty = await this.controller.createNewProperty(this.suggestValues, MetaType.YAML);
             if (!newProperty) return null;
 
             const {propName, propValue} = newProperty;
@@ -65,7 +64,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
         }
 
         if (item.content === newDataView) {
-            const newProperty = await this.controller.createNewProperty(this.suggestValues);
+            const newProperty = await this.controller.createNewProperty(this.suggestValues, MetaType.Dataview);
             if (!newProperty) return null;
 
             const {propName, propValue} = newProperty;
@@ -73,15 +72,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
             return;
         }
 
-        // Hand the prompt the property it is editing so it can offer value
-        // autocomplete and a native date picker. Cleared in finally so it never
-        // outlives this edit. The controller is an untouched pass-through.
-        setPendingValueContext({app: this.app, key: item.key, type: item.type});
-        try {
-            await this.controller.editMetaElement(item, this.data, this.file);
-        } finally {
-            setPendingValueContext(null);
-        }
+        await this.controller.editMetaElement(item, this.data, this.file);
     }
 
     private deleteItem(item: FuzzyMatch<Property>) {

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -6,6 +6,7 @@ import {MAIN_SUGGESTER_OPTIONS, newDataView, newYaml} from "../constants";
 import {MetaType} from "../Types/metaType";
 import {concat} from "svelte-preprocess/dist/modules/utils";
 import type {AutoProperty} from "../Types/autoProperty";
+import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
 
 export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     public app: App;
@@ -52,7 +53,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
         return concat(this.options, this.data);
     }
 
-    async onChooseItem(item: Property, evt: MouseEvent | KeyboardEvent): Promise<void> {
+    async onChooseItem(item: Property, _evt: MouseEvent | KeyboardEvent): Promise<void> {
         if (item.content === newYaml) {
             const newProperty = await this.controller.createNewProperty(this.suggestValues);
             if (!newProperty) return null;
@@ -71,7 +72,15 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
             return;
         }
 
-        await this.controller.editMetaElement(item, this.data, this.file);
+        // Hand the prompt the property it is editing so it can offer value
+        // autocomplete and a native date picker. Cleared in finally so it never
+        // outlives this edit. The controller is an untouched pass-through.
+        setPendingValueContext({app: this.app, key: item.key, type: item.type});
+        try {
+            await this.controller.editMetaElement(item, this.data, this.file);
+        } finally {
+            setPendingValueContext(null);
+        }
     }
 
     private deleteItem(item: FuzzyMatch<Property>) {

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -7,6 +7,7 @@ import {MetaType} from "../Types/metaType";
 import {concat} from "svelte-preprocess/dist/modules/utils";
 import type {AutoProperty} from "../Types/autoProperty";
 import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
+import {getKnownPropertyNames} from "./GenericPrompt/valueSuggest";
 
 export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     public app: App;
@@ -137,14 +138,18 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     }
 
     private setSuggestValues() {
-        const autoProps = this.plugin.settings.AutoProperties.properties;
+        const existing = new Set(this.data.map(prop => prop.key));
+        const names = new Set<string>();
 
-        this.suggestValues = autoProps.reduce((arr: string[], val: AutoProperty) => {
-            if (!this.data.find(prop => val.name === prop.key || val.name.startsWith('#'))) {
-                arr.push(val.name);
-            }
+        // Configured Auto Property names (existing behaviour).
+        for (const autoProp of this.plugin.settings.AutoProperties.properties as AutoProperty[]) {
+            if (!autoProp.name.startsWith('#')) names.add(autoProp.name);
+        }
 
-            return arr;
-        }, []);
+        // Property names already used in the vault, so the "new property" name
+        // prompt autocompletes known keys instead of free-typing them.
+        for (const name of getKnownPropertyNames(this.app)) names.add(name);
+
+        this.suggestValues = [...names].filter(name => !existing.has(name));
     }
 }

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -104,7 +104,7 @@ export default class MetaController {
         if (!method) return;
 
         if (method === trackerPluginMethod) {
-            newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`)
+            newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`, {valueContext: {key: property.key, type: property.type}})
             this.useTrackerPlugin = true;
         } else if (method === metaEditMethod) {
             const autoProp = await this.handleAutoProperties(allButLast);
@@ -112,7 +112,7 @@ export default class MetaController {
             if (autoProp)
                 newValue = autoProp;
             else
-                newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`);
+                newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`, {valueContext: {key: property.key, type: property.type}});
         }
 
         if (newValue) {
@@ -141,8 +141,8 @@ export default class MetaController {
         }
     }
 
-    public async createNewProperty(suggestValues?: string[]) {
-        const propName = await GenericPrompt.Prompt(this.app, "Enter a property name", "Property", "", suggestValues);
+    public async createNewProperty(suggestValues?: string[], valueType: MetaType = MetaType.YAML) {
+        const propName = await GenericPrompt.Prompt(this.app, "Enter a property name", {placeholder: "Property", suggestValues});
         if (!propName) return null;
 
         let propValue: string;
@@ -151,8 +151,10 @@ export default class MetaController {
         if (autoProp) {
             propValue = autoProp;
         } else {
-            propValue = await GenericPrompt.Prompt(this.app, "Enter a property value", "Value")
-                .catch(() => null);
+            propValue = await GenericPrompt.Prompt(this.app, "Enter a property value", {
+                placeholder: "Value",
+                valueContext: {key: propName, type: valueType},
+            });
         }
 
         if (propValue === null) return null;
@@ -202,7 +204,11 @@ export default class MetaController {
         if (autoProp)
             newValue = autoProp;
         else
-            newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`, property.content, property.content);
+            newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`, {
+                placeholder: property.content,
+                value: property.content,
+                valueContext: {key: property.key, type: property.type},
+            });
 
         if (newValue) {
             await this.updatePropertyInFile(property, newValue, file);
@@ -241,10 +247,13 @@ export default class MetaController {
         if (autoProp) {
             tempValue = autoProp;
         } else if (selectedOption.includes("cmd")) {
-            tempValue = await GenericPrompt.Prompt(this.app, "Enter a new value");
+            tempValue = await GenericPrompt.Prompt(this.app, "Enter a new value", {valueContext: {key: property.key, type: property.type}});
         } else {
             selectedIndex = splitValues.findIndex(el => el == selectedOption);
-            tempValue = await GenericPrompt.Prompt(this.app, `Change ${selectedOption} to`, selectedOption);
+            tempValue = await GenericPrompt.Prompt(this.app, `Change ${selectedOption} to`, {
+                placeholder: selectedOption,
+                valueContext: {key: property.key, type: property.type},
+            });
         }
 
         if (!tempValue) return;
@@ -283,7 +292,7 @@ export default class MetaController {
 
         if (this.plugin.settings.AutoProperties.enabled && autoProp) {
             const options = autoProp.choices;
-            return await GenericPrompt.Prompt(this.app, `Enter a new value for ${propertyName}`, '', '', options);
+            return await GenericPrompt.Prompt(this.app, `Enter a new value for ${propertyName}`, {suggestValues: options});
         }
 
         return null;

--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -1,7 +1,7 @@
 // Sam stole all this from Liam's Periodic Notes Plugin: https://github.com/liamcain/obsidian-periodic-notes
 // And then I stole it from Sam's Buttons: https://github.com/shabegom/buttons
 
-import { type App, type ISuggestOwner, Scope, TFile, TAbstractFile } from "obsidian";
+import { type App, type ISuggestOwner, Scope } from "obsidian";
 import { createPopper, type Instance as PopperInstance } from "@popperjs/core";
 
 const wrapAround = (value: number, size: number): number => {
@@ -103,16 +103,27 @@ class Suggest<T> {
     }
 }
 
+export interface TextInputSuggestOptions {
+    /**
+     * Open the suggestion dropdown when the input gains focus. Defaults to true.
+     * Disable it for prompts that seed the input with an existing value, so a
+     * bare Enter submits that value instead of selecting a pre-highlighted
+     * suggestion.
+     */
+    openOnFocus?: boolean;
+}
+
 export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
     protected app: App;
     protected inputEl: HTMLInputElement;
 
-    private popper: PopperInstance;
+    private popper: PopperInstance | undefined;
     private scope: Scope;
     private suggestEl: HTMLElement;
     private suggest: Suggest<T>;
+    private isOpen = false;
 
-    constructor(app: App, inputEl: HTMLInputElement) {
+    constructor(app: App, inputEl: HTMLInputElement, options?: TextInputSuggestOptions) {
         this.app = app;
         this.inputEl = inputEl;
         this.scope = new Scope();
@@ -124,7 +135,9 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
         this.scope.register([], "Escape", this.close.bind(this));
 
         this.inputEl.addEventListener("input", this.onInputChanged.bind(this));
-        this.inputEl.addEventListener("focus", this.onInputChanged.bind(this));
+        if (options?.openOnFocus !== false) {
+            this.inputEl.addEventListener("focus", this.onInputChanged.bind(this));
+        }
         this.inputEl.addEventListener("blur", this.close.bind(this));
         this.suggestEl.on(
             "mousedown",
@@ -153,6 +166,14 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
     }
 
     open(container: HTMLElement, inputEl: HTMLElement): void {
+        if (this.isOpen) {
+            // Already open (e.g. on every keystroke) - just reposition for the new
+            // suggestion list instead of re-pushing the scope and leaking poppers.
+            this.popper?.update();
+            return;
+        }
+        this.isOpen = true;
+
         (<any>this.app).keymap.pushScope(this.scope);
 
         container.appendChild(this.suggestEl);
@@ -182,10 +203,14 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
     }
 
     close(): void {
+        if (!this.isOpen) return;
+        this.isOpen = false;
+
         (<any>this.app).keymap.popScope(this.scope);
 
         this.suggest.setSuggestions([]);
-        this.popper.destroy();
+        this.popper?.destroy();
+        this.popper = undefined;
         this.suggestEl.detach();
     }
 


### PR DESCRIPTION
## Summary

Editing a property value in MetaEdit was unassisted: a bare text box, no matter the field. This adds two native-feeling assists to the value prompt, generalised across property types:

- **#61 - autocomplete known values.** When you edit (or add an element to) a property value, MetaEdit now suggests the values you already use for that property across the vault, frequency-ranked. Tags resolve to their **leaf segment** (e.g. editing `#topic/science` suggests `science`, `history`, ...), matching how MetaEdit rewrites a tag, so a picked suggestion can never corrupt the tag. The "new property" name prompt likewise autocompletes property names already used in the vault.
- **#74 - native date picker.** When a YAML property is typed (or inferred) by Obsidian as `date`/`datetime`, the prompt renders a native `<input type="date">` / `<input type="datetime-local">` styled with Obsidian's own property-widget classes - the same control Obsidian's Properties panel uses, so it looks native on desktop and uses the OS picker on mobile.

Both work in single-value, multi-value (per element), and tag edits, and in the add-property flow.

## Why this design

The whole feature lives in the owned UI layer; **`metaController.ts` / `parser.ts` (the write/parse core, hardened in #119 and restructured in #123) are left byte-for-byte identical to `master`.** Value sourcing reads only the metadata cache (`getValueSuggestions`, `getDateInputType` in a small, unit-tested `valueSuggest.ts`). The property being edited is bridged from the entry suggester (`metaEditSuggester`) to the prompt (`GenericPrompt`) via a tiny module-level handoff: the suggester sets `{app, key, type}` inside a `try/finally`, and the prompt takes-and-clears it on mount. The controller stays an untouched pass-through; values round-trip as opaque strings (no `new Date()` anywhere). I considered threading the context explicitly through the controller's prompt calls, but kept the high-churn core untouched so this PR has zero merge surface against it and can't regress the frontmatter writes; the documented tradeoff is a narrow race (a concurrent *programmatic* prompt opening during an edit's intermediate modal could consume the pending context) that does not affect normal interactive use.

Date detection uses `app.metadataTypeManager` (`getAssignedWidget` -> `getTypeInfo`), feature-detected so it degrades to plain text on older Obsidian. The picker is only offered when the current value is empty or a valid ISO date, so a free-text value (`next friday`, `TBD`) on a date-typed field falls back to a text box and is never clobbered. Empty submit is a no-op.

Also hardened the shared `TextInputSuggest` (Boyscout, it's on the critical path now): a new `openOnFocus` option (true for empty-seeded choice/discovery prompts, false for seeded value edits so a bare Enter submits the current value rather than a pre-highlighted suggestion), dropped the phantom single-match row, made open/close idempotent (no repeated scope pushes or leaked poppers), tear the dropdown down on prompt close, and cap the rendered list. `openOnFocus` defaults to `true`, so the Kanban settings suggester that shares this base is unchanged. Cancelling a prompt now resolves to `null` instead of rejecting, removing a pre-existing unhandled-rejection wart.

## Scope / follow-ups (documented, not silently dropped)

- Inline `key:: value` (Dataview) **value** autocomplete is intentionally deferred (inline values aren't in the metadata cache; sourcing them would duplicate parser logic and add a full-text scan) - Dataview value prompts simply offer no suggestions rather than cross-sourcing frontmatter. Date typing is frontmatter-only by Obsidian's design, so inline fields don't get a date picker.
- Natural-language dates (the nldates plugin referenced in #74) are out of scope - a separate plugin dependency.

## Validation

Built and proven live in an isolated Obsidian E2E vault (worktree harness):

- **#61:** editing `status` (vault values `reading`/`finished`) shows both, filters as you type, and a picked suggestion writes correctly. Editing nested tag `#topic/science` suggests leaf segments `[topic, history, science, math]` (not full paths). Multi-value (`All Multi`) per-element editing of a `topics` list suggests `[alpha, beta]`.
- **#74:** `due` renders a native date input seeded `2026-07-01`; changing it writes `due: 2026-09-15` (unquoted, re-read as `date`). A `datetime` field renders `datetime-local` and round-trips `2026-03-20T14:45`. A date-typed field holding `next friday` falls back to a text box (value preserved). Empty submit leaves the value unchanged.
- **Enter-on-seed:** opening an edit and pressing Enter immediately submits the unchanged value (no accidental suggestion pick). Cancelling (Escape) logs no error.
- **Composes with merged work:** verified live on top of the current `master` (merged in) - #123's Auto Property modal still opens and overrides self-sourcing; multi-value and tag edits unaffected; inline Dataview edits show no suggestions and don't crash. The full live E2E suite (22 tests incl. #123 auto-properties and #124 bulk-metadata) is green.

Commands run: `pnpm run lint` (0 errors), `pnpm run build`, `pnpm run test` (137 unit tests), `pnpm run test:e2e` (22 tests). Unit coverage added for value sourcing, leaf-segment tags, array flattening, date-type detection (date/datetime/seconds/ISO-gate/feature-detection), Dataview returning no suggestions, suggestion filtering, the rendered cap, and known-property-name discovery.

This work was driven and validated with an adversarial (opposing-model) design and code review; the findings (focus regression, cancel rejection, datetime seconds, Dataview cross-sourcing, and the context-handoff tradeoff) are folded in or documented.

Closes #61
Closes #74
