### PR TITLE
fix: Kanban helper syncs only the card's leading link, not trailing date/reference links

### DIFF
--- a/__tests__/kanbanHelper.test.ts
+++ b/__tests__/kanbanHelper.test.ts
@@ -97,7 +97,7 @@ function buildBoardCache(content: string): {links: any[]; headings: any[]} {
   return {links, headings};
 }
 
-type NoteSpec = {path?: string; status?: string};
+type NoteSpec = {path?: string; status?: string; throws?: boolean};
 
 // Wire the mocks for an end-to-end onFileModify call against a board string and a
 // set of linked notes (keyed by basename) with their current "status" value.
@@ -124,6 +124,7 @@ function setupBoard(board: string, notes: Record<string, NoteSpec>, boardName = 
   );
   plugin.controller.getPropertiesInFile.mockImplementation(async (file: TFile) => {
     const spec = notes[file.basename];
+    if (spec?.throws) throw new Error(`malformed YAML in ${file.basename}`);
     if (!spec || spec.status === undefined) return [];
     return [{key: "status", content: spec.status, type: "YAML"}];
   });
@@ -354,6 +355,26 @@ describe("KanbanHelper updates linked file properties", () => {
     );
   });
 
+  // Issue #80, fault #1 via the throw path: a linked note with malformed YAML makes
+  // getPropertiesInFile reject; that must not abort syncing of later cards.
+  it("keeps updating later cards when an earlier card's property read throws", async () => {
+    const board = ["## Backlog", "", "- [ ] [[Bad Note]]", "- [ ] [[Good Note]]", ""].join("\n");
+    const {helper, plugin, boardFile, noteFiles, updatedFiles} = setupBoard(board, {
+      "Bad Note": {throws: true},
+      "Good Note": {status: "Done"},
+    });
+
+    await helper.onFileModify(boardFile);
+
+    expect(updatedFiles()).toEqual([{file: "Good Note", value: "Backlog"}]);
+    expect(plugin.controller.updatePropertyInFile).toHaveBeenCalledTimes(1);
+    expect(plugin.controller.updatePropertyInFile).toHaveBeenCalledWith(
+      expect.objectContaining({key: "status"}),
+      "Backlog",
+      noteFiles["Good Note"]
+    );
+  });
+
   it("does not treat a card whose text starts with prose then a link as a card link", async () => {
     const board = "## Doing\n\n- [ ] Read [[Book]] before Friday\n";
     const {helper, plugin, boardFile} = setupBoard(board, {
@@ -367,7 +388,7 @@ describe("KanbanHelper updates linked file properties", () => {
 
   it("ignores indented sub-checklist items (only top-level cards are cards)", async () => {
     const board = ["## Doing", "", "- [ ] [[Parent]]", "\t- [ ] [[Subtask]]", ""].join("\n");
-    const {helper, plugin, boardFile, updatedFiles} = setupBoard(board, {
+    const {helper, boardFile, updatedFiles} = setupBoard(board, {
       Parent: {status: "Backlog"},
       Subtask: {status: "Backlog"},
     });

--- a/__tests__/kanbanHelper.test.ts
+++ b/__tests__/kanbanHelper.test.ts
@@ -56,6 +56,87 @@ const createPlugin = (app: MockApp, boards = [{boardName: "Board", property: "st
   },
 });
 
+// Build a metadata-cache-shaped {links, headings} from a board string the way
+// Obsidian's metadataCache does: wiki/markdown links carry their exact line+col,
+// and headings carry the resolved heading text (ATX-closed "## X ##" -> "X",
+// setext supported). The fidelity of this builder against the real cache is
+// asserted in the "fixture builder fidelity" suite below, so the integration
+// tests below run against honest fixtures rather than hand-placed positions.
+function buildBoardCache(content: string): {links: any[]; headings: any[]} {
+  const lines = content.split("\n");
+  const links: any[] = [];
+  const headings: any[] = [];
+
+  const linkRegex = /\[\[([^\]]+?)\]\]|\[([^\]]*?)\]\(([^)]+?)\)/g;
+  lines.forEach((line, lineIdx) => {
+    linkRegex.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = linkRegex.exec(line)) !== null) {
+      const isWikiLink = match[1] !== undefined;
+      const link = isWikiLink ? match[1].split("|")[0] : match[3];
+      links.push({
+        link,
+        original: match[0],
+        position: {start: {line: lineIdx, col: match.index}},
+      });
+    }
+  });
+
+  lines.forEach((line, lineIdx) => {
+    const atx = /^(#{1,6})\s+(.*?)(?:\s+#+)?\s*$/.exec(line);
+    if (atx) {
+      headings.push({heading: atx[2].trim(), level: atx[1].length, position: {start: {line: lineIdx}}});
+      return;
+    }
+    const underline = lines[lineIdx + 1];
+    if (line.trim() !== "" && underline !== undefined && /^=+\s*$/.test(underline)) {
+      headings.push({heading: line.trim(), level: 1, position: {start: {line: lineIdx}}});
+    }
+  });
+
+  return {links, headings};
+}
+
+type NoteSpec = {path?: string; status?: string};
+
+// Wire the mocks for an end-to-end onFileModify call against a board string and a
+// set of linked notes (keyed by basename) with their current "status" value.
+function setupBoard(board: string, notes: Record<string, NoteSpec>, boardName = "Board") {
+  const app = createApp();
+  const plugin = createPlugin(app, [{boardName, property: "status"}]);
+  const helper = new KanbanHelper(plugin as any);
+  const boardFile = new TFile(`${boardName}.md`);
+
+  const noteFiles: Record<string, TFile> = {};
+  for (const name of Object.keys(notes)) {
+    noteFiles[name] = new TFile(notes[name].path ?? `${name}.md`);
+  }
+
+  app.metadataCache.getFileCache.mockReturnValue(buildBoardCache(board));
+  app.vault.cachedRead.mockResolvedValue(board);
+  app.metadataCache.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+    const basename = linkpath.replace(/\.md$/i, "").split("/").pop() ?? "";
+    return noteFiles[basename] ?? null;
+  });
+  app.vault.getMarkdownFiles.mockReturnValue(Object.values(noteFiles));
+  app.vault.getAbstractFileByPath.mockImplementation(
+    (p: string) => Object.values(noteFiles).find((f) => f.path === p) ?? null
+  );
+  plugin.controller.getPropertiesInFile.mockImplementation(async (file: TFile) => {
+    const spec = notes[file.basename];
+    if (!spec || spec.status === undefined) return [];
+    return [{key: "status", content: spec.status, type: "YAML"}];
+  });
+
+  const updatedFiles = () =>
+    plugin.controller.updatePropertyInFile.mock.calls.map((call) => ({
+      file: (call[2] as TFile).basename,
+      value: call[1],
+    }));
+
+  return {helper, plugin, boardFile, noteFiles, updatedFiles};
+}
+
 describe("KanbanHelper link resolution", () => {
   it("resolves markdown links with encoded spaces and .md via metadata cache", () => {
     const app = createApp();
@@ -129,116 +210,278 @@ describe("KanbanHelper link resolution", () => {
   });
 });
 
+describe("KanbanHelper fixture builder fidelity", () => {
+  // This board mirrors the live metadataCache probe run in the isolated Obsidian
+  // vault. Asserting against it keeps the unit fixtures honest to real Obsidian.
+  const board = [
+    "---",
+    "kanban-plugin: board",
+    "---",
+    "",
+    "## In Progress",
+    "",
+    "- [ ] [[Card A]] @[[2026-06-01]] see [[Ref]]",
+    "",
+    "## Done ##",
+    "",
+    "- [ ] Read [[Book]] later",
+    "\t- [ ] [[Indented]]",
+    "",
+    "## [[Project X]] tasks",
+    "",
+    "- [x] 2026-01-01 -- [[Archived]] @[[2026-05-23]]",
+    "",
+    "Backlog Setext",
+    "======",
+    "",
+    "- [ ] [[Setext Card]]",
+    "",
+  ].join("\n");
+
+  it("derives Obsidian-faithful heading text (ATX-closed and setext)", () => {
+    const {headings} = buildBoardCache(board);
+    expect(headings).toEqual([
+      {heading: "In Progress", level: 2, position: {start: {line: 4}}},
+      {heading: "Done", level: 2, position: {start: {line: 8}}},
+      {heading: "[[Project X]] tasks", level: 2, position: {start: {line: 13}}},
+      {heading: "Backlog Setext", level: 1, position: {start: {line: 17}}},
+    ]);
+  });
+
+  it("only treats the leading link of a top-level task as a card link", () => {
+    const helper = new KanbanHelper(createPlugin(createApp()) as any);
+    const lines = board.split("\n");
+    const {links} = buildBoardCache(board);
+    const cardLinks = links
+      .filter((link) => (helper as any).isCardLink(link, lines))
+      .map((link) => link.link);
+
+    // Card A and Setext Card lead their task lines; everything else (date links,
+    // trailing references, prose-then-link, indented sub-item, heading link,
+    // timestamp-prefixed archive entry) is correctly excluded.
+    expect(cardLinks).toEqual(["Card A", "Setext Card"]);
+  });
+});
+
 describe("KanbanHelper updates linked file properties", () => {
-  it("updates the target property based on the task heading", async () => {
-    const app = createApp();
-    const plugin = createPlugin(app, [{boardName: "Board", property: "status"}]);
-    const helper = new KanbanHelper(plugin as any);
-
-    const noteFile = new TFile("Notes/Note.md");
-    const boardFile = new TFile("Board.md");
-    const link = {link: "Notes/Note", original: "[[Notes/Note]]"};
-
-    app.metadataCache.getFileCache.mockReturnValue({links: [link]});
-    app.metadataCache.getFirstLinkpathDest.mockReturnValue(noteFile);
-    app.vault.cachedRead.mockResolvedValue(`# Idea\n- [ ] [[Notes/Note]]\n`);
-    plugin.controller.getPropertiesInFile.mockResolvedValue([{key: "status", content: "Draft"}]);
+  it("updates the target property based on the lane heading", async () => {
+    const board = "## Idea\n\n- [ ] [[Note]]\n";
+    const {helper, plugin, boardFile, noteFiles, updatedFiles} = setupBoard(board, {
+      Note: {path: "Notes/Note.md", status: "Draft"},
+    });
 
     await helper.onFileModify(boardFile);
 
     expect(plugin.controller.updatePropertyInFile).toHaveBeenCalledWith(
       expect.objectContaining({key: "status"}),
       "Idea",
-      noteFile
+      noteFiles.Note
     );
+    expect(updatedFiles()).toEqual([{file: "Note", value: "Idea"}]);
   });
 
-  it("does not update when the property already matches the heading", async () => {
-    const app = createApp();
-    const plugin = createPlugin(app, [{boardName: "Board", property: "status"}]);
-    const helper = new KanbanHelper(plugin as any);
-
-    const noteFile = new TFile("Notes/Note.md");
-    const boardFile = new TFile("Board.md");
-    const link = {link: "Notes/Note", original: "[[Notes/Note]]"};
-
-    app.metadataCache.getFileCache.mockReturnValue({links: [link]});
-    app.metadataCache.getFirstLinkpathDest.mockReturnValue(noteFile);
-    app.vault.cachedRead.mockResolvedValue(`# Idea\n- [ ] [[Notes/Note]]\n`);
-    plugin.controller.getPropertiesInFile.mockResolvedValue([{key: "status", content: "Idea"}]);
+  it("does not update when the property already matches the lane", async () => {
+    const board = "## Idea\n\n- [ ] [[Note]]\n";
+    const {helper, plugin, boardFile} = setupBoard(board, {
+      Note: {status: "Idea"},
+    });
 
     await helper.onFileModify(boardFile);
 
     expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
   });
 
-  it("skips tasks that appear before any heading", async () => {
-    const app = createApp();
-    const plugin = createPlugin(app, [{boardName: "Board", property: "status"}]);
-    const helper = new KanbanHelper(plugin as any);
-
-    const noteFile = new TFile("Notes/Note.md");
-    const boardFile = new TFile("Board.md");
-    const link = {link: "Notes/Note", original: "[[Notes/Note]]"};
-
-    app.metadataCache.getFileCache.mockReturnValue({links: [link]});
-    app.metadataCache.getFirstLinkpathDest.mockReturnValue(noteFile);
-    app.vault.cachedRead.mockResolvedValue(`- [ ] [[Notes/Note]]\n# Idea\n- [ ] [[Notes/Other]]\n`);
-    plugin.controller.getPropertiesInFile.mockResolvedValue([{key: "status", content: "Draft"}]);
+  it("skips cards that appear before any lane heading", async () => {
+    const board = "- [ ] [[Note]]\n\n## Idea\n";
+    const {helper, plugin, boardFile} = setupBoard(board, {
+      Note: {status: "Draft"},
+    });
 
     await helper.onFileModify(boardFile);
 
     expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
   });
 
-  it("processes a realistic board with mixed link types and skips invalid links", async () => {
-    const app = createApp();
-    const plugin = createPlugin(app, [{boardName: "Roadmap", property: "status"}]);
-    const helper = new KanbanHelper(plugin as any);
-
-    const ideaFile = new TFile("Notes/Idea.md");
-    const myNoteFile = new TFile("Notes/My Note.md");
-    const boardFile = new TFile("Kanban/Roadmap.md");
-
-    const linkIdea = {link: "Notes/Idea", original: "[[Notes/Idea]]"};
-    const linkMarkdown = {
-      link: "Notes/My%20Note.md#Section",
-      original: "[My Note](Notes/My%20Note.md)"
-    };
-    const linkInvalid = {
-      link: "https://example.com",
-      original: "[Example](https://example.com)"
-    };
-
-    app.metadataCache.getFileCache.mockReturnValue({links: [linkIdea, linkMarkdown, linkInvalid]});
-    app.metadataCache.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
-      if (linkpath === "Notes/Idea") return ideaFile;
-      if (linkpath === "Notes/My Note.md" || linkpath === "Notes/My Note") return myNoteFile;
-      return null;
-    });
-    app.vault.getMarkdownFiles.mockReturnValue([ideaFile, myNoteFile]);
-    app.vault.cachedRead.mockResolvedValue(
-      "# Idea\n- [ ] [[Notes/Idea]]\n\n# Drafts\n- [ ] [My Note](Notes/My%20Note.md)\n- [ ] [Example](https://example.com)\n"
-    );
-
-    plugin.controller.getPropertiesInFile.mockImplementation(async (file: TFile) => {
-      if (file.basename === "Idea") return [{key: "status", content: "Backlog"}];
-      if (file.basename === "My Note") return [{key: "status", content: "Idea"}];
-      return [];
+  // Issue #80, fault #2: the card's trailing links must not be touched.
+  it("never clobbers Kanban @[[date]] links or in-text reference links", async () => {
+    const board = [
+      "## In Progress",
+      "",
+      "- [ ] [[Project A]] @[[2026-06-01]] and see [[Reference Note]]",
+      "",
+    ].join("\n");
+    const {helper, plugin, boardFile, noteFiles, updatedFiles} = setupBoard(board, {
+      "Project A": {status: "Backlog"},
+      "2026-06-01": {status: "DATE-ORIGINAL"},
+      "Reference Note": {status: "REF-ORIGINAL"},
     });
 
     await helper.onFileModify(boardFile);
 
-    expect(plugin.controller.updatePropertyInFile).toHaveBeenCalledTimes(2);
+    // Only the card itself moves; the date and reference notes are untouched.
+    expect(updatedFiles()).toEqual([{file: "Project A", value: "In Progress"}]);
     expect(plugin.controller.updatePropertyInFile).toHaveBeenCalledWith(
       expect.objectContaining({key: "status"}),
-      "Idea",
-      ideaFile
+      "In Progress",
+      noteFiles["Project A"]
     );
+    const touched = plugin.controller.updatePropertyInFile.mock.calls.map((c) => (c[2] as TFile).basename);
+    expect(touched).not.toContain("2026-06-01");
+    expect(touched).not.toContain("Reference Note");
+  });
+
+  // Issue #80, fault #1: a bad/unresolvable card link must not abort the loop.
+  it("keeps updating later cards when an earlier card link is unresolvable", async () => {
+    const board = [
+      "## Backlog",
+      "",
+      "- [ ] [[Missing Note]]",
+      "- [ ] [[Project B]]",
+      "",
+    ].join("\n");
+    const {helper, plugin, boardFile, noteFiles, updatedFiles} = setupBoard(board, {
+      // "Missing Note" intentionally absent from the vault -> resolves to null.
+      "Project B": {status: "Done"},
+    });
+
+    await helper.onFileModify(boardFile);
+
+    expect(updatedFiles()).toEqual([{file: "Project B", value: "Backlog"}]);
     expect(plugin.controller.updatePropertyInFile).toHaveBeenCalledWith(
       expect.objectContaining({key: "status"}),
-      "Drafts",
-      myNoteFile
+      "Backlog",
+      noteFiles["Project B"]
     );
+  });
+
+  it("does not treat a card whose text starts with prose then a link as a card link", async () => {
+    const board = "## Doing\n\n- [ ] Read [[Book]] before Friday\n";
+    const {helper, plugin, boardFile} = setupBoard(board, {
+      Book: {status: "Shelf"},
+    });
+
+    await helper.onFileModify(boardFile);
+
+    expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
+  });
+
+  it("ignores indented sub-checklist items (only top-level cards are cards)", async () => {
+    const board = ["## Doing", "", "- [ ] [[Parent]]", "\t- [ ] [[Subtask]]", ""].join("\n");
+    const {helper, plugin, boardFile, updatedFiles} = setupBoard(board, {
+      Parent: {status: "Backlog"},
+      Subtask: {status: "Backlog"},
+    });
+
+    await helper.onFileModify(boardFile);
+
+    expect(updatedFiles()).toEqual([{file: "Parent", value: "Doing"}]);
+  });
+
+  it("does not treat a wikilink inside a lane heading as a card", async () => {
+    const board = "## [[Project X]] overview\n\n- [ ] [[Card]]\n";
+    const {helper, updatedFiles, boardFile} = setupBoard(board, {
+      "Project X": {status: "whatever"},
+      Card: {status: "Backlog"},
+    });
+
+    await helper.onFileModify(boardFile);
+
+    // The heading link is skipped; only the real card is synced to the raw lane text.
+    expect(updatedFiles()).toEqual([{file: "Card", value: "[[Project X]] overview"}]);
+  });
+
+  it("resolves the lane name from an ATX-closed heading without the trailing hashes", async () => {
+    const board = "## Done ##\n\n- [ ] [[Note]]\n";
+    const {helper, updatedFiles, boardFile} = setupBoard(board, {
+      Note: {status: "Doing"},
+    });
+
+    await helper.onFileModify(boardFile);
+
+    expect(updatedFiles()).toEqual([{file: "Note", value: "Done"}]);
+  });
+
+  it("resolves the lane name from a setext heading", async () => {
+    const board = "Backlog\n=======\n\n- [ ] [[Note]]\n";
+    const {helper, updatedFiles, boardFile} = setupBoard(board, {
+      Note: {status: "Doing"},
+    });
+
+    await helper.onFileModify(boardFile);
+
+    expect(updatedFiles()).toEqual([{file: "Note", value: "Backlog"}]);
+  });
+
+  it("skips a link whose cached position no longer matches the board content (stale cache)", async () => {
+    // Simulate the metadata cache lagging the freshly-read content: the cache says
+    // there is a card link on line 2, but cachedRead returns a board where that
+    // line no longer holds that link. The helper must not write a wrong lane.
+    const app = createApp();
+    const plugin = createPlugin(app, [{boardName: "Board", property: "status"}]);
+    const helper = new KanbanHelper(plugin as any);
+    const boardFile = new TFile("Board.md");
+    const noteFile = new TFile("Note.md");
+
+    const staleLink = {link: "Note", original: "[[Note]]", position: {start: {line: 2, col: 6}}};
+    app.metadataCache.getFileCache.mockReturnValue({
+      links: [staleLink],
+      headings: [{heading: "Done", level: 2, position: {start: {line: 0}}}],
+    });
+    // Content where line 2 is empty (the card was moved away before the cache caught up).
+    app.vault.cachedRead.mockResolvedValue("## Done\n\n\n");
+    app.metadataCache.getFirstLinkpathDest.mockReturnValue(noteFile);
+    plugin.controller.getPropertiesInFile.mockResolvedValue([{key: "status", content: "Doing", type: "YAML"}]);
+
+    await helper.onFileModify(boardFile);
+
+    expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
+  });
+
+  it("processes multiple lanes and only the leading card link in each", async () => {
+    const board = [
+      "## Backlog",
+      "",
+      "- [ ] [[Idea]]",
+      "",
+      "## Drafts",
+      "",
+      "- [ ] [My Note](Notes/My%20Note.md) @[[2026-01-01]]",
+      "- [ ] [Example](https://example.com)",
+      "",
+    ].join("\n");
+    const {helper, plugin, boardFile, updatedFiles} = setupBoard(board, {
+      Idea: {path: "Notes/Idea.md", status: "Backlog"},
+      "My Note": {path: "Notes/My Note.md", status: "Backlog"},
+      "2026-01-01": {status: "KEEP"},
+    });
+
+    await helper.onFileModify(boardFile);
+
+    // Idea already matches "Backlog" -> no write. My Note moves to Drafts.
+    // The external https card resolves to nothing; the date link is ignored.
+    expect(updatedFiles()).toEqual([{file: "My Note", value: "Drafts"}]);
+    expect(plugin.controller.updatePropertyInFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits a notice naming the linked file when the tracked property is missing", async () => {
+    const board = "## Doing\n\n- [ ] [[Note]]\n";
+    const {helper, plugin, boardFile} = setupBoard(board, {
+      Note: {status: undefined}, // note exists but has no status property
+    });
+
+    await helper.onFileModify(boardFile);
+
+    expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the modified file is not a configured board", async () => {
+    const board = "## Doing\n\n- [ ] [[Note]]\n";
+    const {helper, plugin} = setupBoard(board, {Note: {status: "Backlog"}});
+    const otherFile = new TFile("Not A Board.md");
+
+    await helper.onFileModify(otherFile);
+
+    expect(plugin.controller.getPropertiesInFile).not.toHaveBeenCalled();
+    expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
   });
 });

--- a/src/automators/onFileModifyAutomators/kanbanHelper.ts
+++ b/src/automators/onFileModifyAutomators/kanbanHelper.ts
@@ -1,4 +1,4 @@
-import {type CachedMetadata, type LinkCache, Notice, type TFile, getLinkpath, normalizePath} from "obsidian";
+import {type CachedMetadata, type HeadingCache, type LinkCache, Notice, type TFile, getLinkpath, normalizePath} from "obsidian";
 import type MetaEdit from "../../main";
 import type {KanbanProperty} from "../../Types/kanbanProperty";
 import {abstractFileToMarkdownTFile} from "../../utility";
@@ -7,8 +7,14 @@ import type {Property} from "../../parser";
 import {OnFileModifyAutomator} from "./onFileModifyAutomator";
 import {OnModifyAutomatorType} from "./onModifyAutomatorType";
 
-const MARKDOWN_HEADING = /#+\s+(.+)/;
-const TASK_REGEX = /(\s*)-\s*\[([ Xx\.]?)\]\s*(.+)/i;
+// A Kanban card is a top-level task line whose content begins with the card's
+// link: "- [ ] [[Note]] ...". Only that leading link identifies the note to keep
+// in sync with the lane; any trailing links on the same line (Kanban "@[[date]]"
+// links, "see [[ref]]" references) belong to the card's text and must be ignored.
+// The prefix is everything before the link, so it may contain only the list
+// marker, the checkbox, and whitespace. Indented sub-checklist items are excluded
+// (no leading whitespace) because Kanban cards are always top-level.
+const CARD_LINK_PREFIX = /^-\s+\[[^\]]?\]\s+$/;
 
 export class KanbanHelper extends OnFileModifyAutomator {
     private get boards(): KanbanProperty[] { return this.plugin.settings.KanbanHelper.boards }
@@ -18,19 +24,105 @@ export class KanbanHelper extends OnFileModifyAutomator {
     }
 
     public async onFileModify(file: TFile): Promise<void> {
-        const kanbanBoardFileContent: string = await this.app.vault.cachedRead(file);
-        const kanbanBoardFileCache: CachedMetadata = this.app.metadataCache.getFileCache(file);
         const targetBoard = this.findBoardByName(file.basename);
-        if (!targetBoard || !kanbanBoardFileCache) return;
+        if (!targetBoard) return;
 
-        const {links} = kanbanBoardFileCache;
-        if (!links) return;
+        const kanbanBoardFileCache: CachedMetadata = this.app.metadataCache.getFileCache(file);
+        if (!kanbanBoardFileCache?.links) return;
 
-        await this.updateFilesInBoard(links, targetBoard, file.path, kanbanBoardFileContent);
+        const kanbanBoardFileContent: string = await this.app.vault.cachedRead(file);
+        const boardLines = kanbanBoardFileContent.split("\n");
+        const laneForLine = this.buildLaneResolver(kanbanBoardFileCache.headings);
+
+        await this.updateFilesInBoard(kanbanBoardFileCache.links, targetBoard, file.path, boardLines, laneForLine);
     }
 
     private findBoardByName(boardName: string): KanbanProperty {
         return this.boards.find(board => board.boardName === boardName);
+    }
+
+    private async updateFilesInBoard(
+        links: LinkCache[],
+        board: KanbanProperty,
+        sourcePath: string,
+        boardLines: string[],
+        laneForLine: (line: number) => string | null
+    ): Promise<void> {
+        for (const link of links) {
+            // Only the card's leading link is updatable; date/reference links are skipped.
+            if (!this.isCardLink(link, boardLines)) continue;
+
+            const lane = laneForLine(link.position.start.line);
+            // A card placed above any lane heading has no lane to write.
+            if (!lane) continue;
+
+            const linkFile = this.resolveLinkFile(link, sourcePath);
+            if (!this.isMarkdownFile(linkFile)) {
+                // Keep processing the remaining cards (issue #80: do not abort on a bad link).
+                log.logMessage(`${link.link} is not updatable for the KanbanHelper.`);
+                continue;
+            }
+
+            await this.updateFileInBoard(linkFile, board, lane);
+        }
+    }
+
+    // A card link is the leading link of a top-level task line. We verify against
+    // the freshly-read board content that the cached link still sits at its
+    // recorded position, which also guards against the metadata cache lagging the
+    // board edit: on any drift the link is skipped rather than written to a wrong
+    // lane.
+    private isCardLink(link: LinkCache, boardLines: string[]): boolean {
+        const start = link.position?.start;
+        if (!start) return false;
+
+        const line = boardLines[start.line];
+        if (line === undefined) return false;
+
+        if (!line.slice(start.col).startsWith(link.original)) return false;
+
+        return CARD_LINK_PREFIX.test(line.slice(0, start.col));
+    }
+
+    // Map any line to its lane: the text of the nearest heading at or above it.
+    // Headings come from the metadata cache so ATX-closed ("## Done ##") and
+    // setext headings resolve to their clean lane name, matching Obsidian.
+    private buildLaneResolver(headings?: HeadingCache[]): (line: number) => string | null {
+        const orderedHeadings = (headings ?? [])
+            .slice()
+            .sort((a, b) => a.position.start.line - b.position.start.line);
+
+        return (line: number) => {
+            let lane: string | null = null;
+            for (const heading of orderedHeadings) {
+                if (heading.position.start.line > line) break;
+                lane = heading.heading;
+            }
+            return lane;
+        };
+    }
+
+    private async updateFileInBoard(linkFile: TFile, board: KanbanProperty, lane: string): Promise<void> {
+        const fileProperties: Property[] = await this.plugin.controller.getPropertiesInFile(linkFile);
+        if (!fileProperties) {
+            log.logWarning(`No properties found in '${linkFile.basename}', cannot update '${board.property}'.`);
+            return;
+        }
+
+        const targetProperty = fileProperties.find(prop => prop.key === board.property);
+        if (!targetProperty) {
+            // Only real card notes reach this point, so the warning is now actionable.
+            const message = `'${board.property}' not found in "${linkFile.basename}" (Kanban board '${board.boardName}').`;
+            log.logWarning(message);
+            new Notice(message); // This notice helps users debug "property not found" errors.
+            return;
+        }
+
+        const propertyHasChanged = targetProperty.content !== lane;
+        if (propertyHasChanged) {
+            console.debug(`Updating ${targetProperty.key} of file ${linkFile.name} to ${lane}`);
+            await this.plugin.controller.updatePropertyInFile(targetProperty, lane, linkFile);
+        }
     }
 
     private resolveLinkFile(link: LinkCache, sourcePath: string): TFile | null {
@@ -106,74 +198,5 @@ export class KanbanHelper extends OnFileModifyAutomator {
 
     private isMarkdownFile(file: TFile | null): file is TFile {
         return !!file && file.extension === "md";
-    }
-
-    private async updateFilesInBoard(
-        links: LinkCache[],
-        board: KanbanProperty,
-        sourcePath: string,
-        kanbanBoardFileContent: string
-    ) {
-        for (const link of links) {
-            const linkFile = this.resolveLinkFile(link, sourcePath);
-            if (!this.isMarkdownFile(linkFile)) {
-                log.logMessage(`${link.link} is not updatable for the KanbanHelper.`);
-                continue;
-            }
-
-            await this.updateFileInBoard(link, linkFile, board, kanbanBoardFileContent);
-        }
-    }
-
-    private async updateFileInBoard(link: LinkCache, linkFile: TFile, board: KanbanProperty, kanbanBoardFileContent: string)
-        : Promise<void>
-    {
-        const heading: string = this.getTaskHeading(link.original, kanbanBoardFileContent);
-        if (!heading) {
-            log.logMessage(`found linked file ${link.link} but could not get heading for task.`);
-            return;
-        }
-
-        const fileProperties: Property[] = await this.plugin.controller.getPropertiesInFile(linkFile);
-        if (!fileProperties) {
-            log.logWarning(`No properties found in '${board.boardName}', cannot update '${board.property}'.`)
-            return;
-        }
-        const targetProperty = fileProperties.find(prop => prop.key === board.property);
-        if (!targetProperty) {
-            log.logWarning(`'${board.property}' not found in '${board.boardName}' for file "${linkFile.name}".`);
-            new Notice(`'${board.property}' not found in '${board.boardName}' for file "${linkFile.name}".`); // This notice will help users debug "Property not found in board" errors.
-            return;
-        }
-
-        const propertyHasChanged = targetProperty.content !== heading;
-        if (propertyHasChanged) {
-            console.debug(`Updating ${targetProperty.key} of file ${linkFile.name} to ${heading}`);
-            await this.plugin.controller.updatePropertyInFile(targetProperty, heading, linkFile);
-        }
-    }
-
-    private getTaskHeading(targetTaskContent: string, fileContent: string): string | null {
-        let lastHeading: string = "";
-        const contentLines = fileContent.split("\n");
-        for (const line of contentLines) {
-            const headingMatch = MARKDOWN_HEADING.exec(line);
-
-            if (headingMatch) {
-                const headingText = headingMatch[1];
-                lastHeading = headingText;
-            }
-
-            const taskMatch = TASK_REGEX.exec(line);
-            if (taskMatch) {
-                const taskContent = taskMatch[3];
-
-                if (taskContent.includes(targetTaskContent)) {
-                    return lastHeading || null;
-                }
-            }
-        }
-
-        return null;
     }
 }

--- a/src/automators/onFileModifyAutomators/kanbanHelper.ts
+++ b/src/automators/onFileModifyAutomators/kanbanHelper.ts
@@ -27,7 +27,7 @@ export class KanbanHelper extends OnFileModifyAutomator {
         const targetBoard = this.findBoardByName(file.basename);
         if (!targetBoard) return;
 
-        const kanbanBoardFileCache: CachedMetadata = this.app.metadataCache.getFileCache(file);
+        const kanbanBoardFileCache: CachedMetadata | null = this.app.metadataCache.getFileCache(file);
         if (!kanbanBoardFileCache?.links) return;
 
         const kanbanBoardFileContent: string = await this.app.vault.cachedRead(file);
@@ -49,29 +49,40 @@ export class KanbanHelper extends OnFileModifyAutomator {
         laneForLine: (line: number) => string | null
     ): Promise<void> {
         for (const link of links) {
-            // Only the card's leading link is updatable; date/reference links are skipped.
-            if (!this.isCardLink(link, boardLines)) continue;
+            // Each card is processed in isolation: a bad link or a failed update of one
+            // card must never abort syncing of the rest of the board (issue #80, fault 1).
+            try {
+                // Only the card's leading link is updatable; date/reference links are skipped.
+                if (!this.isCardLink(link, boardLines)) continue;
 
-            const lane = laneForLine(link.position.start.line);
-            // A card placed above any lane heading has no lane to write.
-            if (!lane) continue;
+                const lane = laneForLine(link.position.start.line);
+                // A card placed above any lane heading has no lane to write.
+                if (!lane) continue;
 
-            const linkFile = this.resolveLinkFile(link, sourcePath);
-            if (!this.isMarkdownFile(linkFile)) {
-                // Keep processing the remaining cards (issue #80: do not abort on a bad link).
-                log.logMessage(`${link.link} is not updatable for the KanbanHelper.`);
-                continue;
+                const linkFile = this.resolveLinkFile(link, sourcePath);
+                if (!this.isMarkdownFile(linkFile)) {
+                    log.logMessage(`${link.link} is not updatable for the KanbanHelper.`);
+                    continue;
+                }
+
+                await this.updateFileInBoard(linkFile, board, lane);
+            } catch (error) {
+                // e.g. a linked note with malformed YAML makes getPropertiesInFile throw.
+                // logMessage is used (not logError, which re-throws) so one failing card
+                // is logged without aborting the rest or spamming a notice every edit.
+                const reason = error instanceof Error ? error.message : String(error);
+                log.logMessage(`KanbanHelper could not update '${link.link}': ${reason}`);
             }
-
-            await this.updateFileInBoard(linkFile, board, lane);
         }
     }
 
-    // A card link is the leading link of a top-level task line. We verify against
-    // the freshly-read board content that the cached link still sits at its
-    // recorded position, which also guards against the metadata cache lagging the
-    // board edit: on any drift the link is skipped rather than written to a wrong
-    // lane.
+    // A card link is the leading link of a top-level task line. We verify against the
+    // freshly-read board content that the cached link still sits at its recorded
+    // position with its recorded text; on a mismatch (the card moved or changed since
+    // the cache was built) the link is skipped rather than acted on with stale data.
+    // This validates the link's own identity only; it does not reconcile a lane
+    // heading that was renamed in place while the cache lagged (a transient state the
+    // 5s modify debounce makes negligible and that self-corrects on the next edit).
     private isCardLink(link: LinkCache, boardLines: string[]): boolean {
         const start = link.position?.start;
         if (!start) return false;
@@ -104,11 +115,6 @@ export class KanbanHelper extends OnFileModifyAutomator {
 
     private async updateFileInBoard(linkFile: TFile, board: KanbanProperty, lane: string): Promise<void> {
         const fileProperties: Property[] = await this.plugin.controller.getPropertiesInFile(linkFile);
-        if (!fileProperties) {
-            log.logWarning(`No properties found in '${linkFile.basename}', cannot update '${board.property}'.`);
-            return;
-        }
-
         const targetProperty = fileProperties.find(prop => prop.key === board.property);
         if (!targetProperty) {
             // Only real card notes reach this point, so the warning is now actionable.

--- a/tests/e2e/kanban-helper.test.ts
+++ b/tests/e2e/kanban-helper.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "vitest";
+import {
+	createMetaEditE2EHarness,
+	evalJsonAsync,
+	PLUGIN_ID,
+} from "./harness";
+
+const getContext = createMetaEditE2EHarness("kanban-helper");
+const WAIT = { timeoutMs: 25_000, intervalMs: 250 };
+
+// Enable the Kanban helper for one board and attach the automator to the live
+// modify pipeline, mirroring what the settings tab does at runtime.
+// `plugin.toggleAutomators()` detaches the disabled Progress Properties automator,
+// which logs to the console; that log line would corrupt evalJsonAsync's JSON
+// envelope, so this uses the plain (log-tolerant) eval and ignores the result.
+async function enableBoard(
+	obsidian: ReturnType<typeof getContext>["obsidian"],
+	boardName: string,
+	property: string,
+): Promise<void> {
+	await obsidian.dev.eval(`
+		(() => {
+			const plugin = app.plugins.plugins.${PLUGIN_ID};
+			plugin.settings.KanbanHelper = {
+				enabled: true,
+				boards: [{ boardName: ${JSON.stringify(boardName)}, property: ${JSON.stringify(property)} }],
+			};
+			plugin.toggleAutomators();
+			return "kanban-enabled";
+		})()
+	`);
+}
+
+async function writeLiveFile(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	path: string,
+	content: string,
+): Promise<void> {
+	await evalJsonAsync<void>(
+		obsidian,
+		`
+		(async () => {
+			const path = ${JSON.stringify(path)};
+			const content = ${JSON.stringify(content)};
+			const parts = path.split("/");
+			let current = "";
+			for (const part of parts.slice(0, -1)) {
+				current = current ? current + "/" + part : part;
+				if (!app.vault.getAbstractFileByPath(current)) {
+					await app.vault.createFolder(current);
+				}
+			}
+			const existing = app.vault.getAbstractFileByPath(path);
+			if (existing) await app.vault.delete(existing);
+			await app.vault.create(path, content);
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		})()
+	`,
+	);
+}
+
+// Rewrite the board file (the modification a Kanban drag produces), which fires
+// the vault "modify" event the helper reacts to.
+async function modifyLiveFile(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	path: string,
+	content: string,
+): Promise<void> {
+	await evalJsonAsync<void>(
+		obsidian,
+		`
+		(async () => {
+			const file = app.vault.getAbstractFileByPath(${JSON.stringify(path)});
+			if (!file) throw new Error("Board file not found: " + ${JSON.stringify(path)});
+			await app.vault.modify(file, ${JSON.stringify(content)});
+		})()
+	`,
+	);
+}
+
+function statusOf(content: string): string {
+	const match = content.match(/^status:\s*(.*)$/m);
+	return match ? match[1].trim() : "(no status)";
+}
+
+const note = (status: string) => `---\nstatus: ${status}\n---\n\nbody\n`;
+
+const FRONTMATTER = ["---", "kanban-plugin: board", "---", ""];
+
+describe("KanbanHelper live board behavior", () => {
+	test("moves the card's leading link to the new lane without clobbering trailing links", async () => {
+		const { obsidian, sandbox } = getContext();
+		await enableBoard(obsidian, "Roadmap", "status");
+
+		await writeLiveFile(obsidian, sandbox.path("Project A.md"), note("Backlog"));
+		await writeLiveFile(obsidian, sandbox.path("2026-06-01.md"), note("DATE-ORIGINAL"));
+		await writeLiveFile(obsidian, sandbox.path("Reference Note.md"), note("REF-ORIGINAL"));
+		await writeLiveFile(
+			obsidian,
+			sandbox.path("Roadmap.md"),
+			[
+				...FRONTMATTER,
+				"## Backlog",
+				"",
+				"- [ ] [[Project A]] @[[2026-06-01]] and see [[Reference Note]]",
+				"",
+				"## In Progress",
+				"",
+				"",
+			].join("\n"),
+		);
+
+		// Let the metadata cache index the seeded files before the move.
+		await evalJsonAsync<void>(
+			obsidian,
+			`(async () => { await new Promise((r) => setTimeout(r, 1500)); })()`,
+		);
+
+		// Simulate the drag: Project A goes Backlog -> In Progress.
+		await modifyLiveFile(
+			obsidian,
+			sandbox.path("Roadmap.md"),
+			[
+				...FRONTMATTER,
+				"## Backlog",
+				"",
+				"## In Progress",
+				"",
+				"- [ ] [[Project A]] @[[2026-06-01]] and see [[Reference Note]]",
+				"",
+				"",
+			].join("\n"),
+		);
+
+		const cardContent = await sandbox.waitForContent(
+			"Project A.md",
+			(value) => value.includes("status: In Progress"),
+			WAIT,
+		);
+		expect(statusOf(cardContent)).toBe("In Progress");
+
+		// The date and reference links on the card line must be untouched.
+		expect(statusOf(await sandbox.read("2026-06-01.md"))).toBe("DATE-ORIGINAL");
+		expect(statusOf(await sandbox.read("Reference Note.md"))).toBe("REF-ORIGINAL");
+
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("keeps updating later cards when an earlier card link is unresolvable", async () => {
+		const { obsidian, sandbox } = getContext();
+		await enableBoard(obsidian, "Sprint", "status");
+
+		await writeLiveFile(obsidian, sandbox.path("Project B.md"), note("Done"));
+		await writeLiveFile(
+			obsidian,
+			sandbox.path("Sprint.md"),
+			[...FRONTMATTER, "## Backlog", "", "## In Progress", "", ""].join("\n"),
+		);
+
+		await evalJsonAsync<void>(
+			obsidian,
+			`(async () => { await new Promise((r) => setTimeout(r, 1500)); })()`,
+		);
+
+		// An unresolvable card ([[Missing Note]]) precedes a real one ([[Project B]]).
+		await modifyLiveFile(
+			obsidian,
+			sandbox.path("Sprint.md"),
+			[
+				...FRONTMATTER,
+				"## Backlog",
+				"",
+				"- [ ] [[Missing Note]]",
+				"- [ ] [[Project B]]",
+				"",
+				"## In Progress",
+				"",
+				"",
+			].join("\n"),
+		);
+
+		const content = await sandbox.waitForContent(
+			"Project B.md",
+			(value) => value.includes("status: Backlog"),
+			WAIT,
+		);
+		expect(statusOf(content)).toBe("Backlog");
+
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #80 ("Kanban board faulty behavior"). When a Kanban card moves lanes, the
helper updates the linked note's tracked property (e.g. `status`) to the new lane.

The bug: the helper iterated over **every** wikilink in the board file and wrote
the card's lane into each linked note. A card line like

```
- [ ] [[Project A]] @[[2026-06-01]] and see [[Reference Note]]
```

therefore clobbered the date note (`@[[2026-06-01]]`) and the reference note with
the lane name - or raised a spurious `'status' not found in <board>` notice when
those notes lacked the property (the root of the long-running #45 noise).

A Kanban card is a top-level task whose content **begins** with its link; only
that leading link identifies the note to sync. The fix scopes updates to that
leading link.

## Root cause (restated)

The card's identity was never modeled. `updateFilesInBoard` looped over
`cache.links` (the whole file's links) and `getTaskHeading` reverse-mapped each
link to a lane via a fragile substring search (`taskContent.includes(link.original)`).
Trailing links and in-text references were indistinguishable from the card itself.

## What changed (`src/automators/onFileModifyAutomators/kanbanHelper.ts`)

- **Leading-link-only card detection.** A link is a card link only when it is the
  leading link of a top-level `- [ ] ` task line (only the checkbox + whitespace
  precede it). This excludes `@[[date]]` links, mid-text references, indented
  sub-checklist items, timestamp-prefixed archive entries, and links inside lane
  headings.
- **Lanes from the metadata cache's headings**, not a substring search - so
  ATX-closed (`## Done ##` → `Done`) and setext lane names resolve correctly
  (verified live).
- **Cache/content drift guard.** Card detection is validated against the
  freshly-read board content (the cached link must still sit at its recorded
  position with its recorded text); on a mismatch the link is skipped rather than
  acted on with stale data.
- **Per-card isolation (issue #80 fault 1).** Each card is processed in its own
  `try/catch`; an unresolvable link or a throwing property read (e.g. malformed
  YAML in a linked note) no longer aborts syncing of the remaining cards.
- **Clearer notice.** The missing-property notice now names the linked file and
  board, and only fires for genuine card notes.

## Contract note

A card syncs a note only when the card **starts** with the link (`- [ ] [[Note]] …`).
This matches the reporter's explicit intent in #80 ("…the `[[Thing]]` link is
obviously not meant to be updated" for prose cards) and is the only contract that
fixes #80 without silently clobbering incidental links. A purely descriptive card
like `- [ ] Read [[Book]]` is intentionally **not** synced.

## Validation

Reproduced-then-fixed live in an isolated Obsidian instance (the `80-kanban`
worktree vault), driving the real vault modify-event pipeline.

**Before the fix** (on today's `master`, post-#119): moving `Project A` clobbered
`2026-06-01` and `Reference Note` to `In Progress`.
**After the fix:** `Project A → In Progress`; `2026-06-01` and `Reference Note`
unchanged.

Generalization proven live (not just the reporter's setup):

| Scenario | Result |
| --- | --- |
| Card under ATX-closed `## Done ##` | lane `Done` (not `Done ##`) |
| Card after a card whose note lacks the property | still updated; accurate notice for the bad one |
| Rapid moves `Shipping → Review → Live` (within debounce) | final lane `Live` |
| Second board tracking a different property (`phase`) | isolated from the first board |
| A card whose property read throws | logged; later cards still sync |

Commands run:

```
pnpm run lint    # 0 errors (16 pre-existing warnings in untouched files)
pnpm run build
pnpm run test    # 71 unit tests pass
pnpm run test:e2e  # 9 live e2e tests pass (2 new Kanban + 7 existing)
```

## Tests

- `__tests__/kanbanHelper.test.ts`: regression coverage for the date/reference
  clobbering, prose-then-link and indented sub-items, heading links,
  ATX-closed/setext lanes, stale-cache drift, the throwing-card loop, and
  multi-lane boards - with a fixture builder asserted against the live cache shape.
- `tests/e2e/kanban-helper.test.ts` (new): live modify-pipeline regression for the
  no-clobber behavior and the unresolvable-card-doesn't-abort behavior.

## Review

A 3-lens adversarial design review ran **before** coding (folded into the
cache-headings + drift-guard design) and a 3-lens adversarial review ran on the
**committed diff**. The diff review's one blocking finding - fault 1 still
reachable via a throwing property read - is fixed in commit `fae4d5a` with live
proof and a regression test.

## Out of scope / follow-ups

- The drift guard validates the card link's identity, not a lane heading renamed
  in place while the cache lags (a transient, self-healing state the 5s modify
  debounce makes negligible). Deriving lanes fully from freshly-read content is a
  reasonable follow-up but would drop the cache's free ATX-closed/setext handling.
- #80 also asks why Kanban doesn't interoperate with Auto Progress - a separate
  automator concern, not addressed here.

Closes #80.
