### PR TITLE
fix: stop inline-field updates appending a stray bracket

### DIFF
--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -395,7 +395,7 @@ export default class MetaController {
         let newLine: string;
         switch (property.type) {
             case MetaType.Dataview:
-                newLine = line.replace(this.dataviewPropertyRegex(property.key), `$1${property.key}:: ${newValue}$4`);
+                newLine = this.parser.replaceInlineFieldValue(line, property.key, String(newValue));
                 break;
             case MetaType.YAML:
                 newLine = `${property.key}: ${newValue}`;

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -23,6 +23,9 @@ const parseInline = (content: string): Array<{key: string, content: unknown}> =>
         .parseInlineContent(content)
         .map(({key, content: value}) => ({key, content: value}));
 
+const replaceInline = (line: string, key: string, value: string): string =>
+    new MetaEditParser({} as any).replaceInlineFieldValue(line, key, value);
+
 describe("MetaEditParser frontmatter parsing", () => {
     it("uses legacy frontmatter.position when frontmatterPosition is missing", async () => {
         const file = new TFile("legacy.md");
@@ -194,5 +197,40 @@ describe("MetaEditParser inline field parsing", () => {
         expect(parseInline("> spaced:: v")).toEqual([{key: "spaced", content: "v"}]);
         expect(parseInline(">tight:: v")).toEqual([{key: ">tight", content: "v"}]);
         expect(parseInline("-tight:: v")).toEqual([{key: "-tight", content: "v"}]);
+    });
+});
+
+describe("MetaEditParser inline value replacement", () => {
+    it("replaces a full-line value to end of line without appending a bracket (#121)", () => {
+        expect(replaceInline("ref:: [[Some Note]]", "ref", "[[Other Note]]")).toBe("ref:: [[Other Note]]");
+        expect(replaceInline("note:: foo (bar)", "note", "baz (qux)")).toBe("note:: baz (qux)");
+        expect(replaceInline("status:: open", "status", "closed")).toBe("status:: closed");
+    });
+
+    it("preserves the wrapper of a bracketed field (#67)", () => {
+        expect(replaceInline("[number:: 3]", "number", "4")).toBe("[number:: 4]");
+        expect(replaceInline("(num:: 3)", "num", "4")).toBe("(num:: 4)");
+    });
+
+    it("updates only the targeted cell of a table row", () => {
+        expect(replaceInline("| (task:: old) | (result:: None) |", "task", "DONE"))
+            .toBe("| (task:: DONE) | (result:: None) |");
+    });
+
+    it("keeps surrounding markers and trailing text intact", () => {
+        expect(replaceInline("> - bqListKey:: old", "bqListKey", "NEW")).toBe("> - bqListKey:: NEW");
+        expect(replaceInline("(ref:: old) trailing", "ref", "NEW")).toBe("(ref:: NEW) trailing");
+    });
+
+    it("treats the new value literally (no $-group injection)", () => {
+        expect(replaceInline("price:: x", "price", "$2 each")).toBe("price:: $2 each");
+    });
+
+    it("replaces every occurrence of a repeated key on the line", () => {
+        expect(replaceInline("(k:: a) (k:: b)", "k", "X")).toBe("(k:: X) (k:: X)");
+    });
+
+    it("returns the line unchanged when the key is not present", () => {
+        expect(replaceInline("foo:: bar", "other", "x")).toBe("foo:: bar");
     });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,7 +4,11 @@ import {MetaType} from "./Types/metaType";
 
 export type Property = {key: string, content: any, type: MetaType};
 type FrontmatterPosition = {start: Loc, end: Loc};
-type InlineField = {key: string, value: string, start: number, end: number};
+// `start`/`end` are the field's span in the line; `sepEnd` is the offset just
+// after `::`; `valueEnd` is where the value content ends (the closing bracket
+// for a bracketed field, or end-of-line for a full-line field). The latter two
+// let the value be rewritten in place without disturbing the key or wrapper.
+type InlineField = {key: string, value: string, start: number, end: number, sepEnd: number, valueEnd: number};
 
 // Dataview wraps inline fields in either square brackets or parentheses.
 const INLINE_FIELD_WRAPPERS: Readonly<Record<string, string>> = Object.freeze({"[": "]", "(": ")"});
@@ -213,7 +217,9 @@ export default class MetaEditParser {
         const closing = this.findClosingBracket(line, sep + 2, open, close);
         if (!closing) return null;
 
-        return {key, value: closing.value, start, end: closing.end};
+        // closing.end points just past the close bracket, so the value content
+        // ends one character earlier (at the close bracket itself).
+        return {key, value: closing.value, start, end: closing.end, sepEnd: sep + 2, valueEnd: closing.end - 1};
     }
 
     private findClosingBracket(line: string, start: number, open: string, close: string): {value: string, end: number} | null {
@@ -250,7 +256,33 @@ export default class MetaEditParser {
         if (!key) return null;
 
         const value = body.substring(sep + 2).trim();
-        return {key, value, start: prefix.length, end: line.length};
+        // A full-line field has no wrapper: its value runs to end of line.
+        const sepEnd = prefix.length + sep + 2;
+        return {key, value, start: prefix.length, end: line.length, sepEnd, valueEnd: line.length};
+    }
+
+    /**
+     * Rewrite the value of every inline field named `key` on a single line,
+     * leaving the key, surrounding text, and any `[...]`/`(...)` wrapper intact.
+     *
+     * This is the write-side counterpart to {@link parseInlineContent}: because
+     * it reuses the same field boundaries, a full-line value (which may itself
+     * contain `]`/`)`, e.g. `ref:: [[Note]]`) is replaced up to end-of-line and a
+     * bracketed value only up to its matching close bracket - so updates no
+     * longer append a stray closing bracket. Returns the line unchanged when no
+     * field matches.
+     */
+    public replaceInlineFieldValue(line: string, key: string, newValue: string): string {
+        const matches = this.parseLineFields(line).filter(field => field.key === key);
+        if (matches.length === 0) return line;
+
+        // Splice right-to-left so each field's offsets stay valid as we rewrite.
+        let result = line;
+        for (let i = matches.length - 1; i >= 0; i--) {
+            const field = matches[i];
+            result = result.slice(0, field.sepEnd) + " " + newValue + result.slice(field.valueEnd);
+        }
+        return result;
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes #121: updating an inline `key:: value` field whose value ends in `)` or `]` appended a stray closing bracket, corrupting the line. Most visible with wikilink values:

| Before | `update(...)` | Old (buggy) | New |
|---|---|---|---|
| `ref:: [[Some Note]]` | `("ref", "[[Other Note]]")` | `ref:: [[Other Note]]]]` | `ref:: [[Other Note]]` |
| `note:: foo (bar)` | `("note", "baz (qux)")` | `note:: baz (qux))` | `note:: baz (qux)` |
| `links:: [[A]] and [[B]]` | `("links", "[[C]] only")` | `links:: [[C]] only` (lucky) / truncated | `links:: [[C]] only` |

## Root cause

In `metaController`, `dataviewPropertyRegex` captured a trailing `]]`/`)`/`]` in group 4 and `updatePropertyLine` re-appended it after the new value (`$1${key}:: ${newValue}$4`). Group 4 is only meaningful as a *bracketed field's wrapper*; for a full-line value that merely contains brackets, it re-appended part of the value. The value group `[^\)\]\n\r]*` also can't span a value containing brackets at all.

## Fix

The parser already computes each field's exact boundaries while reading, so it now owns the write-back too. New `parser.replaceInlineFieldValue(line, key, newValue)`:

- Reuses the same field parse, so it distinguishes a **full-line** field (value replaced to end-of-line) from a **bracketed** field (value replaced only up to the matching close bracket, wrapper preserved).
- Splices by offset (`sepEnd`/`valueEnd`) right-to-left for repeated keys, so the key, surrounding text, and wrapper stay intact.
- Splices the new value **literally**, removing a latent bug where a value like `$2` was interpreted as a regex backreference.

`updatePropertyLine`'s Dataview case (used by both single and multi/progress updates) delegates to it. `lineMatch`/`dataviewPropertyRegex` are unchanged (still used to select lines).

## Scope note

This is the `metaController` write-path follow-up I filed as #121 while shipping the #84 parsing cluster (#122). It also resolves **#67** (square-bracket field `[number:: 3]`): reads are clean (`3`) since #122, and updates now preserve the wrapper (`[number:: 4]`). I'm closing #67 with live evidence rather than a code change here, since its read fix already shipped in #122. The open PR #125 (suggester) does not touch these files.

## Validation

Isolated Obsidian E2E instance (`metaedit-84-parsing`), on this branch rebased onto latest `master`.

- `pnpm run lint` clean for changed files; `pnpm run build`; `pnpm run test` - 144 passing (25 parser, incl. 8 new value-replacement cases).
- `pnpm run test:e2e` - 22/22 live Obsidian runtime tests pass.
- Live update round-trips (read -> update -> re-read raw file):
  - `ref:: [[Some Note]]` -> `ref:: [[Other Note]]` (no stray `]]`)
  - `note:: foo (bar)` -> `note:: baz (qux)`
  - `links:: [[A]] and [[B]]` -> `links:: [[C]] only`
  - `[number:: 3]` -> `[number:: 4]` (#67)
  - unchanged: `status:: open`->`closed`, table `(task)`/`(result)`, `> - bqListKey::`, `progress (%)::`
- `dev:errors`: none.

Fixes #121
Refs #67, #122, #84
