### PR TITLE
fix: edit YAML lists (incl. tags) as native lists instead of collapsing them to a string (#94)

### DIFF
--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -4,7 +4,6 @@ import type MetaEdit from "./main";
 import GenericPrompt from "./Modals/GenericPrompt/GenericPrompt";
 import {EditMode} from "./Types/editMode";
 import GenericSuggester from "./Modals/GenericSuggester/GenericSuggester";
-import type {MetaEditSettings} from "./Settings/metaEditSettings";
 import {ADD_FIRST_ELEMENT, ADD_TO_BEGINNING, ADD_TO_END} from "./constants";
 import type {ProgressProperty} from "./Types/progressProperty";
 import {ProgressPropertyOptions} from "./Types/progressPropertyOptions";
@@ -14,6 +13,7 @@ import {log} from "./logger/logManager";
 import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoPropertyValueModal";
 import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
+import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
 
@@ -87,8 +87,6 @@ export default class MetaController {
     }
 
     public async editMetaElement(property: Property, meta: Property[], file: TFile): Promise<void> {
-        const mode: EditMode = this.plugin.settings.EditMode.mode;
-
         if (property.type === MetaType.Tag) {
             await this.editTag(property, file);
             return;
@@ -101,7 +99,11 @@ export default class MetaController {
             return;
         }
 
-        if (mode === EditMode.AllMulti || mode === EditMode.SomeMulti)
+        // A real YAML list is inherently multi-value, so it always uses the
+        // element-aware list editor - editing it as a single text line (the
+        // `standardMode` path) would flatten the list and shred elements that
+        // contain commas or `[[wikilinks]]`.
+        if (shouldUseMultiValueEditor(property, this.plugin.settings.EditMode))
             await this.multiValueMode(property, file);
         else
             await this.standardMode(property, file);
@@ -224,70 +226,69 @@ export default class MetaController {
     }
 
     private async multiValueMode(property: Property, file: TFile): Promise<boolean> {
-        const settings: MetaEditSettings = this.plugin.settings;
-        let newValue: string | string[];
+        // A YAML list is edited element-by-element off its ORIGINAL typed array,
+        // so every element the user does not touch keeps its exact type, order,
+        // and spelling (commas and `[[wikilinks]]` included). An inline field (or
+        // a YAML value stored as a comma string) has no real array, so it is
+        // split on commas and re-joined.
+        const editsArray = isMultiValueYamlProperty(property);
+        const writeBase: unknown[] = editsArray
+            ? (property.content as unknown[])
+            : this.splitMultiValue(property);
+        // The selectable view is always strings, kept 1:1 with `writeBase` so a
+        // selection maps back to the correct element.
+        const displayValues: string[] = editsArray
+            ? writeBase.map(value => (value ?? "").toString())
+            : (writeBase as string[]);
 
-
-        if (settings.EditMode.mode == EditMode.SomeMulti && !settings.EditMode.properties.includes(property.key)) {
-            await this.standardMode(property, file);
-            return false;
-        }
-
-        let selectedOption: string, tempValue: string, splitValues: string[];
-        splitValues = this.splitMultiValue(property);
-
-        if (splitValues.length == 0 || (splitValues.length == 1 && splitValues[0] == "")) {
+        let selectedOption: string;
+        if (displayValues.length == 0 || (displayValues.length == 1 && displayValues[0] == "")) {
             const options = ["Add new value"];
             selectedOption = await GenericSuggester.Suggest(this.app, options, [ADD_FIRST_ELEMENT]);
         }
-        else if (splitValues.length == 1) {
-            const options = [splitValues[0], "Add to end", "Add to beginning"];
-            selectedOption = await GenericSuggester.Suggest(this.app, options, [splitValues[0], ADD_TO_END, ADD_TO_BEGINNING]);
+        else if (displayValues.length == 1) {
+            const options = [displayValues[0], "Add to end", "Add to beginning"];
+            selectedOption = await GenericSuggester.Suggest(this.app, options, [displayValues[0], ADD_TO_END, ADD_TO_BEGINNING]);
         } else {
-            const options = ["Add to end", ...splitValues, "Add to beginning"];
-            selectedOption = await GenericSuggester.Suggest(this.app, options, [ADD_TO_END, ...splitValues, ADD_TO_BEGINNING]);
+            const options = ["Add to end", ...displayValues, "Add to beginning"];
+            selectedOption = await GenericSuggester.Suggest(this.app, options, [ADD_TO_END, ...displayValues, ADD_TO_BEGINNING]);
         }
 
-        if (!selectedOption) return;
-        let selectedIndex;
+        if (!selectedOption) return false;
 
-        // Auto Properties are intercepted in editMetaElement; this path is free-text.
-        if (selectedOption.includes("cmd")) {
+        let tempValue: string;
+        let selectedIndex = -1;
+        // Match the add/insert sentinels EXACTLY. A substring `includes("cmd")`
+        // check would misread a real list element that merely contains "cmd"
+        // (e.g. `cmd:build`) as a command and collapse the whole list.
+        // (Auto Properties are intercepted in editMetaElement; this path is free-text.)
+        const isAddCommand =
+            selectedOption === ADD_FIRST_ELEMENT ||
+            selectedOption === ADD_TO_BEGINNING ||
+            selectedOption === ADD_TO_END;
+        if (isAddCommand) {
             tempValue = await GenericPrompt.Prompt(this.app, "Enter a new value");
         } else {
-            selectedIndex = splitValues.findIndex(el => el == selectedOption);
+            selectedIndex = displayValues.findIndex(el => el == selectedOption);
             tempValue = await GenericPrompt.Prompt(this.app, `Change ${selectedOption} to`, selectedOption);
         }
 
-        if (!tempValue) return;
-        switch(selectedOption) {
-            case ADD_FIRST_ELEMENT:
-                newValue = `${tempValue}`;
-                break;
-            case ADD_TO_BEGINNING:
-                newValue = `${[tempValue, ...splitValues].join(", ")}`;
-                break;
-            case ADD_TO_END:
-                newValue = `${[...splitValues, tempValue].join(", ")}`;
-                break;
-            default:
-                if (selectedIndex !== -1)
-                    splitValues[selectedIndex] = tempValue;
-                else
-                    splitValues = [tempValue];
-                newValue = splitValues.join(", ");
-                break;
-        }
+        if (!tempValue) return false;
 
-        if (property.type === MetaType.YAML)
-            newValue = this.splitMultiValue({...property, content: newValue});
+        const edit: MultiValueEdit =
+            selectedOption === ADD_FIRST_ELEMENT ? {kind: "addFirst", value: tempValue} :
+            selectedOption === ADD_TO_BEGINNING ? {kind: "prepend", value: tempValue} :
+            selectedOption === ADD_TO_END ? {kind: "append", value: tempValue} :
+            {kind: "replace", index: selectedIndex, value: tempValue};
 
-        if (newValue) {
-            await this.updatePropertyInFile(property, newValue, file);
-            return true;
-        }
+        const newList = applyMultiValueEdit(writeBase, edit);
 
-        return false;
+        // YAML persists a real list (round-trips as a native YAML array); an
+        // inline/tag field stores the comma-joined string per the inline convention.
+        const newValue: unknown = property.type === MetaType.YAML ? newList : newList.join(", ");
+
+        await this.updatePropertyInFile(property, newValue, file);
+        return true;
     }
 
     private getActiveAutoProperty(propertyName: string): AutoProperty | undefined {

--- a/src/multiValue.test.ts
+++ b/src/multiValue.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from "vitest";
+import {MetaType} from "./Types/metaType";
+import {EditMode} from "./Types/editMode";
+import {
+    applyMultiValueEdit,
+    isMultiValueYamlProperty,
+    shouldUseMultiValueEditor,
+} from "./multiValue";
+
+describe("isMultiValueYamlProperty", () => {
+    it("is true only for a YAML property whose value is a real array", () => {
+        expect(isMultiValueYamlProperty({type: MetaType.YAML, content: ["a", "b"]})).toBe(true);
+        expect(isMultiValueYamlProperty({type: MetaType.YAML, content: []})).toBe(true);
+    });
+
+    it("is false for YAML scalars, non-YAML types, and empty content", () => {
+        expect(isMultiValueYamlProperty({type: MetaType.YAML, content: "a, b"})).toBe(false);
+        expect(isMultiValueYamlProperty({type: MetaType.YAML, content: null})).toBe(false);
+        expect(isMultiValueYamlProperty({type: MetaType.YAML, content: 5})).toBe(false);
+        expect(isMultiValueYamlProperty({type: MetaType.Dataview, content: ["a", "b"]})).toBe(false);
+        expect(isMultiValueYamlProperty({type: MetaType.Tag, content: "#a"})).toBe(false);
+    });
+});
+
+describe("shouldUseMultiValueEditor", () => {
+    const allSingle = {mode: EditMode.AllSingle, properties: [] as string[]};
+    const allMulti = {mode: EditMode.AllMulti, properties: [] as string[]};
+
+    it("always routes a real YAML list to the list editor, even in AllSingle (#94)", () => {
+        expect(shouldUseMultiValueEditor({key: "tags", type: MetaType.YAML, content: ["a", "b"]}, allSingle)).toBe(true);
+    });
+
+    it("keeps a YAML scalar on the single-value path in AllSingle", () => {
+        expect(shouldUseMultiValueEditor({key: "status", type: MetaType.YAML, content: "open"}, allSingle)).toBe(false);
+    });
+
+    it("honours AllMulti and SomeMulti for non-array values", () => {
+        expect(shouldUseMultiValueEditor({key: "status", type: MetaType.Dataview, content: "a"}, allMulti)).toBe(true);
+
+        const someMulti = {mode: EditMode.SomeMulti, properties: ["tags"]};
+        expect(shouldUseMultiValueEditor({key: "tags", type: MetaType.Dataview, content: "a"}, someMulti)).toBe(true);
+        expect(shouldUseMultiValueEditor({key: "status", type: MetaType.Dataview, content: "a"}, someMulti)).toBe(false);
+    });
+});
+
+describe("applyMultiValueEdit", () => {
+    it("adds the first element to an empty list", () => {
+        expect(applyMultiValueEdit([], {kind: "addFirst", value: "a"})).toEqual(["a"]);
+    });
+
+    it("prepends and appends without disturbing existing elements", () => {
+        expect(applyMultiValueEdit(["b", "c"], {kind: "prepend", value: "a"})).toEqual(["a", "b", "c"]);
+        expect(applyMultiValueEdit(["a", "b"], {kind: "append", value: "c"})).toEqual(["a", "b", "c"]);
+    });
+
+    it("replaces only the targeted element", () => {
+        expect(applyMultiValueEdit(["a", "b", "c"], {kind: "replace", index: 1, value: "B"})).toEqual(["a", "B", "c"]);
+    });
+
+    it("replaces the whole list when no element matched (index -1)", () => {
+        expect(applyMultiValueEdit(["a", "b"], {kind: "replace", index: -1, value: "x"})).toEqual(["x"]);
+    });
+
+    // The core regression: editing one element must NOT shred the others.
+    it("preserves elements that contain commas (#94)", () => {
+        expect(applyMultiValueEdit(["Smith, John", "Doe, Jane"], {kind: "replace", index: 1, value: "Roe, Jane"}))
+            .toEqual(["Smith, John", "Roe, Jane"]);
+    });
+
+    it("preserves bracketed values and wikilinks", () => {
+        expect(applyMultiValueEdit(["[[Home]]"], {kind: "append", value: "[[Away]]"}))
+            .toEqual(["[[Home]]", "[[Away]]"]);
+        expect(applyMultiValueEdit(["[draft]", "[final]"], {kind: "replace", index: 0, value: "[wip]"}))
+            .toEqual(["[wip]", "[final]"]);
+    });
+
+    it("keeps the type of every untouched element (numbers, booleans, null)", () => {
+        expect(applyMultiValueEdit([1, true, null, 3], {kind: "replace", index: 1, value: "maybe"}))
+            .toEqual([1, "maybe", null, 3]);
+    });
+
+    it("does not mutate the input list", () => {
+        const base = ["a", "b"];
+        applyMultiValueEdit(base, {kind: "replace", index: 0, value: "X"});
+        expect(base).toEqual(["a", "b"]);
+    });
+});

--- a/src/multiValue.ts
+++ b/src/multiValue.ts
@@ -1,0 +1,79 @@
+import {MetaType} from "./Types/metaType";
+import {EditMode} from "./Types/editMode";
+
+/**
+ * Pure, Obsidian-free helpers for editing multi-value (list) properties. Kept
+ * separate from `metaController` so the list-mutation logic - where array
+ * corruption bugs live - can be unit-tested in the jsdom-free `node` env.
+ */
+
+export interface EditModeSettings {
+    mode: EditMode;
+    properties: string[];
+}
+
+interface PropertyLike {
+    key?: string;
+    type?: MetaType;
+    content?: unknown;
+}
+
+/**
+ * Whether a property's stored value is a real YAML list. Such a value is
+ * inherently multi-value and must be edited as a list regardless of the global
+ * EditMode - editing it through a single-line text field would flatten the list
+ * and destroy element boundaries (commas, `[[wikilinks]]`, types).
+ */
+export function isMultiValueYamlProperty(property: PropertyLike): boolean {
+    return property.type === MetaType.YAML && Array.isArray(property.content);
+}
+
+/**
+ * Decide whether to open the element-aware list editor for a property.
+ *
+ * A real YAML list always uses the list editor; otherwise the global EditMode
+ * decides (AllMulti, or SomeMulti when the property is opted in).
+ */
+export function shouldUseMultiValueEditor(property: PropertyLike, editMode: EditModeSettings): boolean {
+    if (isMultiValueYamlProperty(property)) return true;
+    if (editMode.mode === EditMode.AllMulti) return true;
+    if (editMode.mode === EditMode.SomeMulti && !!property.key && editMode.properties.includes(property.key)) {
+        return true;
+    }
+    return false;
+}
+
+export type MultiValueEdit =
+    | {kind: "addFirst"; value: string}
+    | {kind: "prepend"; value: string}
+    | {kind: "append"; value: string}
+    | {kind: "replace"; index: number; value: string};
+
+/**
+ * Apply a single add/replace edit to a list, returning a NEW list.
+ *
+ * `base` is the list being edited: the original (typed) array for a YAML list,
+ * or the comma-split string elements for an inline field. Untouched elements are
+ * carried over by reference, so a YAML list keeps the exact type, ordering, and
+ * spelling of every element the user did not touch - numbers stay numbers, null
+ * stays null, and a value containing a comma or `[[wikilink]]` is never
+ * re-split. Only the one element the user actually edited becomes their typed
+ * string. A `replace` whose index is out of range (no element matched) replaces
+ * the whole list with the single new value, mirroring the prior behaviour.
+ */
+export function applyMultiValueEdit(base: readonly unknown[], edit: MultiValueEdit): unknown[] {
+    switch (edit.kind) {
+        case "addFirst":
+            return [edit.value];
+        case "prepend":
+            return [edit.value, ...base];
+        case "append":
+            return [...base, edit.value];
+        case "replace": {
+            if (edit.index < 0 || edit.index >= base.length) return [edit.value];
+            const next = [...base];
+            next[edit.index] = edit.value;
+            return next;
+        }
+    }
+}

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -46,6 +46,29 @@ describe("MetaEditParser frontmatter parsing", () => {
         ]);
     });
 
+    // #94/#31: a YAML list must read back as a real array (not a joined string),
+    // so the edit/write path can keep it a native list. Exercises the position +
+    // parseYaml read path (the cache-fallback path is covered below).
+    it("reads a YAML array via the parseYaml position path as a real array", async () => {
+        const file = new TFile("tags-list.md");
+        const parser = createParser(
+            {
+                frontmatter: {tags: ["state/inprogress", "course/x"]},
+                frontmatterPosition: {
+                    start: {line: 0, col: 0, offset: 0},
+                    end: {line: 2, col: 3, offset: 0},
+                },
+            },
+            "---\ntags: [state/inprogress, course/x]\n---\nbody\n",
+        );
+
+        const props = await parser.parseFrontmatter(file);
+        expect(props).toEqual([
+            {key: "tags", content: ["state/inprogress", "course/x"], type: MetaType.YAML},
+        ]);
+        expect(Array.isArray(props[0].content)).toBe(true);
+    });
+
     it("falls back to cached frontmatter entries when no position metadata exists", async () => {
         const file = new TFile("cache-only.md");
         const parser = createParser(

--- a/tests/e2e/multi-value.test.ts
+++ b/tests/e2e/multi-value.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "vitest";
+import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID } from "./harness";
+
+const getContext = createMetaEditE2EHarness("multi-value");
+
+// Live regressions for the multi-value / array editing cluster (#94, #51, #31, #36).
+// These drive the real Obsidian write path (processFrontMatter / stringifyYaml) and,
+// for the command flow, the real suggester + prompt UI.
+describe("MetaEdit multi-value editing", () => {
+	// #94: in the DEFAULT All Single mode, editing a YAML `tags` block list must keep
+	// it a native list - not collapse it to a comma-joined string.
+	test("edits a YAML tags list in All Single mode and keeps it a native list (#94)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("tags-list.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\ntags:\n  - state/inprogress\n  - course-flash/writing-obsidian-plugins\n---\nbody\n",
+		);
+
+		const result = await driveListEdit(obsidian, notePath, {
+			mode: "All Single",
+			key: "tags",
+			selectText: "state/inprogress",
+			enterValue: "state/finished",
+		});
+
+		expect(result.content).toBe(
+			"---\ntags:\n  - state/finished\n  - course-flash/writing-obsidian-plugins\n---\nbody\n",
+		);
+		expect(result.readBack).toEqual([
+			"state/finished",
+			"course-flash/writing-obsidian-plugins",
+		]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	// #51: adding another tag to a `tags` list grows the native list.
+	test("adds a tag to a YAML tags list via Add to end (#51)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("tags-add.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\ntags:\n  - cookingQ\n  - chicken\n---\nbody\n",
+		);
+
+		const result = await driveListEdit(obsidian, notePath, {
+			mode: "All Single",
+			key: "tags",
+			selectText: "Add to end",
+			enterValue: "asia",
+		});
+
+		expect(result.content).toBe(
+			"---\ntags:\n  - cookingQ\n  - chicken\n  - asia\n---\nbody\n",
+		);
+		expect(result.readBack).toEqual(["cookingQ", "chicken", "asia"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	// Editing one element of a list whose elements contain commas must NOT shred the
+	// other elements - the element-preserving core fix.
+	test("preserves list elements that contain commas", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("comma-list.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nauthors:\n  - Smith, John\n  - Doe, Jane\n---\nbody\n",
+		);
+
+		const result = await driveListEdit(obsidian, notePath, {
+			mode: "All Single",
+			key: "authors",
+			selectText: "Doe, Jane",
+			enterValue: "Roe, Jane",
+		});
+
+		expect(result.readBack).toEqual(["Smith, John", "Roe, Jane"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	// A list element whose value merely contains "cmd" must be editable as a normal
+	// element - it must not be mistaken for an add/insert command and collapse the list.
+	test("edits a list element whose value contains 'cmd' without collapsing the list", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("cmd-element.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nscripts:\n  - cmd:build\n  - test\n---\nbody\n",
+		);
+
+		const result = await driveListEdit(obsidian, notePath, {
+			mode: "All Single",
+			key: "scripts",
+			selectText: "cmd:build",
+			enterValue: "cmd:rebuild",
+		});
+
+		expect(result.readBack).toEqual(["cmd:rebuild", "test"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	// A YAML scalar in All Single mode still uses the single-line editor (no suggester),
+	// so the routing change does not regress ordinary scalar edits.
+	test("keeps a YAML scalar on the single-line editor in All Single mode", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("scalar.md");
+		await writeLiveFile(obsidian, notePath, "---\nstatus: open\n---\nbody\n");
+
+		const result = await evalJsonAsync<{ content: string; readBack: unknown; suggesterOpened: boolean }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+				const waitFor = async (selector) => {
+					const start = Date.now();
+					while (Date.now() - start < 5000) {
+						const el = document.querySelector(selector);
+						if (el) return el;
+						await sleep(80);
+					}
+					throw new Error("Timed out waiting for " + selector);
+				};
+				const originalMode = plugin.settings.EditMode.mode;
+				plugin.settings.EditMode.mode = "All Single";
+				try {
+					const props = await plugin.controller.getPropertiesInFile(file);
+					const property = props.find((p) => p.key === "status");
+					const editPromise = plugin.controller.editMetaElement(property, props, file);
+					const input = await waitFor(".metaEditPromptInput");
+					const suggesterOpened = Boolean(document.querySelector(".suggestion-item"));
+					input.value = "closed";
+					input.dispatchEvent(new Event("input", { bubbles: true }));
+					input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+					await editPromise;
+					await sleep(300);
+					return {
+						content: await app.vault.read(file),
+						readBack: await plugin.api.getPropertyValue("status", file),
+						suggesterOpened,
+					};
+				} finally {
+					plugin.settings.EditMode.mode = originalMode;
+				}
+			})()
+		`,
+		);
+
+		expect(result.suggesterOpened).toBe(false);
+		expect(result.content).toBe("---\nstatus: closed\n---\nbody\n");
+		expect(result.readBack).toBe("closed");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	// #36: the public API update with an array writes a native YAML list (verifying the
+	// processFrontMatter write path that already fixed this stays fixed).
+	test("api.update with an array writes a native YAML list (#36)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("api-array.md");
+		await writeLiveFile(obsidian, notePath, "---\nfoo: [a, b]\n---\nbody\n");
+
+		const result = await evalJsonAsync<{ content: string; readBack: unknown }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				await plugin.api.update("foo", ["a", "c"], file);
+				await new Promise((r) => setTimeout(r, 300));
+				return {
+					content: await app.vault.read(file),
+					readBack: await plugin.api.getPropertyValue("foo", file),
+				};
+			})()
+		`,
+		);
+
+		expect(result.content).toBe("---\nfoo:\n  - a\n  - c\n---\nbody\n");
+		expect(result.readBack).toEqual(["a", "c"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+});
+
+// Drive the command edit flow for a list property: open editMetaElement, click a
+// suggestion by its text, then type a value into the prompt and submit.
+async function driveListEdit(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	notePath: string,
+	opts: { mode: string; key: string; selectText: string; enterValue: string },
+): Promise<{ content: string; readBack: unknown }> {
+	return await evalJsonAsync(
+		obsidian,
+		`
+		(async () => {
+			const plugin = app.plugins.plugins.${PLUGIN_ID};
+			const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+			const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+			const waitFor = async (selector, predicate = () => true) => {
+				const start = Date.now();
+				while (Date.now() - start < 5000) {
+					const el = Array.from(document.querySelectorAll(selector)).find(predicate);
+					if (el) return el;
+					await sleep(80);
+				}
+				throw new Error("Timed out waiting for " + selector);
+			};
+			const originalMode = plugin.settings.EditMode.mode;
+			plugin.settings.EditMode.mode = ${JSON.stringify(opts.mode)};
+			try {
+				const props = await plugin.controller.getPropertiesInFile(file);
+				const property = props.find((p) => p.key === ${JSON.stringify(opts.key)});
+				if (!property) throw new Error("Property not parsed: " + ${JSON.stringify(opts.key)});
+				const editPromise = plugin.controller.editMetaElement(property, props, file);
+
+				const item = await waitFor(
+					".suggestion-item",
+					(el) => el.textContent?.trim() === ${JSON.stringify(opts.selectText)},
+				);
+				item.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+				item.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+				item.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+				const input = await waitFor(".metaEditPromptInput");
+				input.value = ${JSON.stringify(opts.enterValue)};
+				input.dispatchEvent(new Event("input", { bubbles: true }));
+				input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+				await editPromise;
+				await sleep(300);
+				return {
+					content: await app.vault.read(file),
+					readBack: await plugin.api.getPropertyValue(${JSON.stringify(opts.key)}, file),
+				};
+			} finally {
+				plugin.settings.EditMode.mode = originalMode;
+			}
+		})()
+	`,
+	);
+}
+
+async function writeLiveFile(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	path: string,
+	content: string,
+): Promise<void> {
+	await evalJsonAsync<void>(
+		obsidian,
+		`
+		(async () => {
+			const path = ${JSON.stringify(path)};
+			const content = ${JSON.stringify(content)};
+			const parts = path.split("/");
+			let current = "";
+			for (const part of parts.slice(0, -1)) {
+				current = current ? current + "/" + part : part;
+				if (!app.vault.getAbstractFileByPath(current)) {
+					try {
+						await app.vault.createFolder(current);
+					} catch (error) {
+						if (!String(error.message).includes("Folder already exists")) throw error;
+					}
+				}
+			}
+			const existing = app.vault.getAbstractFileByPath(path);
+			if (existing) await app.vault.delete(existing);
+			await app.vault.create(path, content);
+			// Wait for the metadata cache to populate the new file's frontmatter.
+			for (let i = 0; i < 40; i++) {
+				const cache = app.metadataCache.getFileCache(app.vault.getAbstractFileByPath(path));
+				if (cache && cache.frontmatter) break;
+				await new Promise((r) => setTimeout(r, 50));
+			}
+		})()
+	`,
+	);
+}


### PR DESCRIPTION
## Summary

The multi-value cluster (#94, #51, #31, #36) is one defect: **MetaEdit lost the YAML list type when editing array properties** (especially `tags`). Editing a `tags`/`aliases` list through the default **All Single** edit mode collapsed it into a comma-joined string.

Root cause: a real YAML list is inherently multi-value, but the editor chose its mode from the global single/multi flag, not from the value's structure. In All Single mode a list went through the single-line text editor, which flattened it. The element-aware list editor also round-tripped lists through `join(", ")` + re-split, shredding elements that contain commas or `[[wikilinks]]`.

### Fix
- **Structure drives the editor.** A real YAML array always opens the element-aware list editor, regardless of EditMode (`shouldUseMultiValueEditor`). `standardMode` is untouched and still handles scalars.
- **Element-preserving edits.** The list editor now operates on the *original typed array* and replaces only the touched element (`applyMultiValueEdit`), so every untouched element keeps its exact type, order, and spelling. No more `join`+resplit. YAML persists a real list via `processFrontMatter` (Obsidian's native block-list format); inline fields keep the comma-string convention.
- **Exact command matching.** Add/insert sentinels are matched exactly, so a real element that merely contains `"cmd"` (e.g. `cmd:build`) is edited normally instead of collapsing the list (caught in adversarial review).
- New pure, Obsidian-free `src/multiValue.ts` holds the routing + list logic so it is unit-tested in the jsdom-free node env.

### What was already fixed (verified, not rebuilt)
On today's master, **#36** (API `update` with an array), **#51** (the write half), and **#31** (list format) are already handled by the `processFrontMatter` write path from #119 - given a real array, Obsidian writes a native YAML list. Live evidence: `api.update("foo", ["a","c"])` on `foo: [a, b]` -> `foo:\n  - a\n  - c`. The remaining defect was #94's edit-flow collapse. Regression tests lock all of them.

## Closes
Closes #94. Addresses #51, #31, #36 (each reproduced live; the write-path ones were already fixed and are now covered by regression tests).

## Validation
- `pnpm run lint` (0 errors), `pnpm run build`, `pnpm run test` -> **171 unit tests pass** (incl. new `src/multiValue.test.ts` and a `parser.test.ts` read-back case).
- Live isolated Obsidian E2E (`tests/e2e/multi-value.test.ts`, 6 tests) driving the **real suggester + prompt UI** and `processFrontMatter`:
  - #94: All Single editing `tags:\n  - state/inprogress\n  - ...` -> native list `state/finished` applied, read back as a real array.
  - #51: "Add to end" grows the native list.
  - comma-bearing elements (`Smith, John`) and `[[wikilinks]]` survive an edit of a sibling element.
  - a `cmd:build` element is edited, not collapsed.
  - a YAML scalar still uses the single-line editor (no regression).
  - #36: `api.update` with an array writes a native YAML list.
- Full live E2E suite passes (29/29 on a clean run; the harness has pre-existing load-related `obsidian`-CLI timeout flakiness unrelated to this change - a different non-mine test times out on different runs and passes on retry).
- Obsidian runtime: `dev:errors` clean. Obsidian 1.x, isolated worktree vault.

## Adversarial review
Design and implementation were each reviewed by 3 opposing-model (Codex) reviewers. The design review rejected an initial `toValueArray` split-back approach (it corrupts commas/brackets/types); the current structure-drives-editor + element-preserving design is the result. The implementation review caught the `cmd`-substring collapse (fixed). Remaining reviewer notes are pre-existing, out-of-scope behaviors, surfaced below.

## Out of scope (surfaced, not folded - separate features/workers)
- API `update` with a **string** into an existing array stays a scalar - the documented "you get the type you pass" contract (maintainer's #36 position).
- Bulk edit array handling, Auto-Property *Single* on an existing array, and create-time `addYamlProp`/`addDataviewField` comma handling each have their own type semantics in separate (recently merged) features.
- Duplicate identical elements edit the first match - a pre-existing `GenericSuggester` limitation (returns the value, not the row); not regressed.

## Release impact
No settings/storage/API changes. Behavior change: editing a YAML list now always opens the list editor (correct for a list); scalar editing is unchanged.
