### PR TITLE
fix: address review findings from PRs #119-#128

### DIFF
--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -5,7 +5,7 @@ import type {
     MetaEditPropertyValue,
     MetaEditUnsubscribe,
 } from "./IMetaEditApi";
-import type {Property} from "./parser";
+import MetaEditParser, {type Property} from "./parser";
 import {TFile} from "obsidian";
 import type {CachedMetadata} from "obsidian";
 import {MetaType} from "./Types/metaType";
@@ -13,8 +13,10 @@ import type {AutoProperty} from "./Types/autoProperty";
 
 export class MetaEditApi {
     private settingsWriteQueue: Promise<unknown> = Promise.resolve();
+    private parser: MetaEditParser;
 
     constructor(private plugin: MetaEdit) {
+        this.parser = new MetaEditParser(plugin.app);
     }
 
     public make(): IMetaEditApi {
@@ -152,7 +154,7 @@ export class MetaEditApi {
                 if (unsubscribed) return;
 
                 const previousProperties = previousPropertiesByPath.get(file.path) ?? null;
-                const properties = this.cloneProperties(await this.plugin.controller.getPropertiesInFile(file));
+                const properties = this.cloneProperties(this.getPropertiesFromEvent(data, cache));
                 if (unsubscribed) return;
 
                 if (previousProperties && this.propertiesSignature(previousProperties) === this.propertiesSignature(properties)) {
@@ -222,10 +224,15 @@ export class MetaEditApi {
     }
 
     private cloneAutoProperties(autoProperties: AutoProperty[]): AutoProperty[] {
-        return autoProperties.map(autoProperty => ({
-            name: autoProperty.name,
-            choices: [...autoProperty.choices],
-        }));
+        return autoProperties.map(autoProperty => {
+            const clone: AutoProperty = {
+                name: autoProperty.name,
+                choices: [...autoProperty.choices],
+            };
+            if (autoProperty.description !== undefined) clone.description = autoProperty.description;
+            if (autoProperty.type !== undefined) clone.type = autoProperty.type;
+            return clone;
+        });
     }
 
     private validateAutoProperties(autoProperties: AutoProperty[]): AutoProperty[] {
@@ -246,10 +253,21 @@ export class MetaEditApi {
                 throw new TypeError(`Auto Property at index ${index} must have a string name.`);
             }
 
-            return {
+            if (autoProperty.description !== undefined && typeof autoProperty.description !== "string") {
+                throw new TypeError(`Auto Property at index ${index} description must be a string.`);
+            }
+
+            if (autoProperty.type !== undefined && autoProperty.type !== "Single" && autoProperty.type !== "Multi") {
+                throw new TypeError(`Auto Property at index ${index} type must be "Single" or "Multi".`);
+            }
+
+            const validated: AutoProperty = {
                 name: autoProperty.name,
                 choices: [...autoProperty.choices],
             };
+            if (autoProperty.description !== undefined) validated.description = autoProperty.description;
+            if (autoProperty.type !== undefined) validated.type = autoProperty.type;
+            return validated;
         });
     }
 
@@ -264,6 +282,22 @@ export class MetaEditApi {
             key: property.key,
             type: property.type,
             content: this.cloneValue(property.content),
+        }));
+    }
+
+    private getPropertiesFromEvent(data: string, cache: CachedMetadata): Property[] {
+        return [
+            ...this.getTagsFromCache(cache),
+            ...this.parser.parseFrontmatterCache(cache),
+            ...this.parser.parseInlineContent(data, this.parser.getFrontmatterPosition(cache)),
+        ];
+    }
+
+    private getTagsFromCache(cache: CachedMetadata): Property[] {
+        return (cache.tags ?? []).map(tag => ({
+            key: tag.tag,
+            content: tag.tag,
+            type: MetaType.Tag,
         }));
     }
 

--- a/src/bulk/bulkMetadataEditor.ts
+++ b/src/bulk/bulkMetadataEditor.ts
@@ -1,4 +1,4 @@
-import { type App, type TAbstractFile, Notice, TFile, TFolder } from "obsidian";
+import { type App, type TAbstractFile, Notice, parseYaml, TFile, TFolder } from "obsidian";
 import type MetaEdit from "../main";
 import { EditMode } from "../Types/editMode";
 import GenericPrompt from "../Modals/GenericPrompt/GenericPrompt";
@@ -77,13 +77,14 @@ export class BulkMetadataEditor {
 		// across the whole batch, matching the prior folder command's guard.
 		if (!rawValue) return;
 
-		const conflicts = this.countExisting(files, key);
+		const conflicts = await this.countExisting(files, key);
 		let policy: ConflictPolicy = "skip";
 
 		if (conflicts > 0) {
 			const conflictWord = conflicts === 1 ? "note" : "notes";
+			const conflictVerb = conflicts === 1 ? "has" : "have";
 			const choice = await BulkOptionModal.Choose(this.app, {
-				title: `${conflicts} ${conflictWord} already have "${key}"`,
+				title: `${conflicts} ${conflictWord} already ${conflictVerb} "${key}"`,
 				description: "Choose how to handle notes that already define this property.",
 				options: [
 					{
@@ -207,13 +208,33 @@ export class BulkMetadataEditor {
 		return [...byPath.values()];
 	}
 
-	private countExisting(files: TFile[], key: string): number {
+	private async countExisting(files: TFile[], key: string): Promise<number> {
 		let count = 0;
 		for (const file of files) {
-			const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+			const frontmatter = await this.readLiveFrontmatter(file);
 			if (frontmatter && Object.prototype.hasOwnProperty.call(frontmatter, key)) count += 1;
 		}
 		return count;
+	}
+
+	private async readLiveFrontmatter(file: TFile): Promise<Record<string, unknown> | null> {
+		const content = await this.app.vault.cachedRead(file);
+		const lines = content.split(/\r?\n/);
+		const firstLine = (lines[0] ?? "").replace(/^\uFEFF/, "");
+		if (!/^---\s*$/.test(firstLine)) return null;
+
+		const end = lines.findIndex((line, index) => index > 0 && /^(?:---|\.\.\.)\s*$/.test(line));
+		if (end === -1) return null;
+
+		let parsed: unknown;
+		try {
+			parsed = parseYaml(lines.slice(1, end).join("\n"));
+		} catch {
+			return null;
+		}
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+		return parsed as Record<string, unknown>;
 	}
 
 	private wrapInArrayFor(key: string): boolean {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,6 @@
 import type {Property} from "./parser";
 import {MetaType} from "./Types/metaType";
 
-export const ADD_FIRST_ELEMENT: string = "cmd:addfirst";
-export const ADD_TO_BEGINNING: string = "cmd:beg";
-export const ADD_TO_END: string = "cmd:end";
-
 export const newDataView: string = "New Dataview field";
 export const newYaml: string = "New YAML property";
 export const MAIN_SUGGESTER_OPTIONS: Property[] = [

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -4,7 +4,6 @@ import type MetaEdit from "./main";
 import GenericPrompt from "./Modals/GenericPrompt/GenericPrompt";
 import {EditMode} from "./Types/editMode";
 import GenericSuggester from "./Modals/GenericSuggester/GenericSuggester";
-import {ADD_FIRST_ELEMENT, ADD_TO_BEGINNING, ADD_TO_END} from "./constants";
 import type {ProgressProperty} from "./Types/progressProperty";
 import {ProgressPropertyOptions} from "./Types/progressPropertyOptions";
 import {MetaType} from "./Types/metaType";
@@ -16,6 +15,10 @@ import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} fr
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
+const ADD_FIRST_SELECTION = "metaedit:multi-value:add-first";
+const ADD_TO_BEGINNING_SELECTION = "metaedit:multi-value:add-beginning";
+const ADD_TO_END_SELECTION = "metaedit:multi-value:add-end";
+const VALUE_SELECTION_PREFIX = "metaedit:multi-value:value:";
 
 export default class MetaController {
     private parser: MetaEditParser;
@@ -42,10 +45,13 @@ export default class MetaController {
 
     public async addYamlProp(propName: string, propValue: unknown, file: TFile): Promise<void> {
         const settings = this.plugin.settings;
+        const activeAutoProperty = this.getActiveAutoProperty(propName);
+        const autoPropertyKeepsScalar = !!activeAutoProperty &&
+            !isMultiAutoProperty(activeAutoProperty, settings.EditMode, propName);
         if (!Array.isArray(propValue) &&
+            !autoPropertyKeepsScalar &&
             (settings.EditMode.mode === EditMode.AllMulti ||
             (settings.EditMode.mode === EditMode.SomeMulti && settings.EditMode.properties.contains(propName)))) {
-            // A Multi auto property already produced a list; don't nest it.
             propValue = [propValue];
         }
 
@@ -242,50 +248,55 @@ export default class MetaController {
             : (writeBase as string[]);
 
         let selectedOption: string;
+        const valueSelection = (index: number) => `${VALUE_SELECTION_PREFIX}${index}`;
         if (displayValues.length == 0 || (displayValues.length == 1 && displayValues[0] == "")) {
             const options = ["Add new value"];
-            selectedOption = await GenericSuggester.Suggest(this.app, options, [ADD_FIRST_ELEMENT]);
+            selectedOption = await GenericSuggester.Suggest(this.app, options, [ADD_FIRST_SELECTION]);
         }
         else if (displayValues.length == 1) {
             const options = [displayValues[0], "Add to end", "Add to beginning"];
-            selectedOption = await GenericSuggester.Suggest(this.app, options, [displayValues[0], ADD_TO_END, ADD_TO_BEGINNING]);
+            selectedOption = await GenericSuggester.Suggest(this.app, options, [valueSelection(0), ADD_TO_END_SELECTION, ADD_TO_BEGINNING_SELECTION]);
         } else {
             const options = ["Add to end", ...displayValues, "Add to beginning"];
-            selectedOption = await GenericSuggester.Suggest(this.app, options, [ADD_TO_END, ...displayValues, ADD_TO_BEGINNING]);
+            selectedOption = await GenericSuggester.Suggest(
+                this.app,
+                options,
+                [ADD_TO_END_SELECTION, ...displayValues.map((_, index) => valueSelection(index)), ADD_TO_BEGINNING_SELECTION],
+            );
         }
 
         if (!selectedOption) return false;
 
         let tempValue: string;
-        let selectedIndex = -1;
-        // Match the add/insert sentinels EXACTLY. A substring `includes("cmd")`
-        // check would misread a real list element that merely contains "cmd"
-        // (e.g. `cmd:build`) as a command and collapse the whole list.
+        const parsedSelectedIndex = selectedOption.startsWith(VALUE_SELECTION_PREFIX)
+            ? Number(selectedOption.substring(VALUE_SELECTION_PREFIX.length))
+            : -1;
+        const selectedIndex = Number.isInteger(parsedSelectedIndex) ? parsedSelectedIndex : -1;
         // (Auto Properties are intercepted in editMetaElement; this path is free-text.)
         const isAddCommand =
-            selectedOption === ADD_FIRST_ELEMENT ||
-            selectedOption === ADD_TO_BEGINNING ||
-            selectedOption === ADD_TO_END;
+            selectedOption === ADD_FIRST_SELECTION ||
+            selectedOption === ADD_TO_BEGINNING_SELECTION ||
+            selectedOption === ADD_TO_END_SELECTION;
         if (isAddCommand) {
             tempValue = await GenericPrompt.Prompt(this.app, "Enter a new value");
         } else {
-            selectedIndex = displayValues.findIndex(el => el == selectedOption);
-            tempValue = await GenericPrompt.Prompt(this.app, `Change ${selectedOption} to`, selectedOption);
+            const selectedValue = displayValues[selectedIndex] ?? "";
+            tempValue = await GenericPrompt.Prompt(this.app, `Change ${selectedValue} to`, selectedValue);
         }
 
         if (!tempValue) return false;
 
         const edit: MultiValueEdit =
-            selectedOption === ADD_FIRST_ELEMENT ? {kind: "addFirst", value: tempValue} :
-            selectedOption === ADD_TO_BEGINNING ? {kind: "prepend", value: tempValue} :
-            selectedOption === ADD_TO_END ? {kind: "append", value: tempValue} :
+            selectedOption === ADD_FIRST_SELECTION ? {kind: "addFirst", value: tempValue} :
+            selectedOption === ADD_TO_BEGINNING_SELECTION ? {kind: "prepend", value: tempValue} :
+            selectedOption === ADD_TO_END_SELECTION ? {kind: "append", value: tempValue} :
             {kind: "replace", index: selectedIndex, value: tempValue};
 
         const newList = applyMultiValueEdit(writeBase, edit);
 
-        // YAML persists a real list (round-trips as a native YAML array); an
-        // inline/tag field stores the comma-joined string per the inline convention.
-        const newValue: unknown = property.type === MetaType.YAML ? newList : newList.join(", ");
+        // Only values that began as native YAML arrays persist as arrays. YAML
+        // scalars routed here by EditMode stay scalar strings.
+        const newValue: unknown = editsArray ? newList : newList.join(", ");
 
         await this.updatePropertyInFile(property, newValue, file);
         return true;

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -87,6 +87,15 @@ describe("MetaEditParser frontmatter parsing", () => {
         ]);
     });
 
+    it("reads live frontmatter content when the metadata cache has not populated yet", async () => {
+        const file = new TFile("live-only.md");
+        const parser = createParser(null, "---\nstatus: draft\n---\nBody\n");
+
+        await expect(parser.parseFrontmatter(file)).resolves.toEqual([
+            {key: "status", content: "draft", type: MetaType.YAML},
+        ]);
+    });
+
     // #85: `tags:value` (and other non-mapping frontmatter) must not be walked
     // with `for..in`, which would surface string/array indices like `0:value`.
     it("ignores non-mapping frontmatter instead of emitting index keys (#85)", async () => {
@@ -197,6 +206,13 @@ describe("MetaEditParser inline field parsing", () => {
         expect(parseInline(content)).toEqual([{key: "body", content: "yes"}]);
     });
 
+    it("does not hide inline fields after an unmatched leading thematic break", () => {
+        expect(parseInline("---\nstatus:: open\nbody:: yes")).toEqual([
+            {key: "status", content: "open"},
+            {key: "body", content: "yes"},
+        ]);
+    });
+
     it("parses two adjacent bracketed fields", () => {
         expect(parseInline("(a:: 1)(b:: 2)")).toEqual([
             {key: "a", content: "1"},
@@ -228,6 +244,10 @@ describe("MetaEditParser inline value replacement", () => {
         expect(replaceInline("ref:: [[Some Note]]", "ref", "[[Other Note]]")).toBe("ref:: [[Other Note]]");
         expect(replaceInline("note:: foo (bar)", "note", "baz (qux)")).toBe("note:: baz (qux)");
         expect(replaceInline("status:: open", "status", "closed")).toBe("status:: closed");
+    });
+
+    it("preserves a trailing carriage return when replacing a CRLF full-line field", () => {
+        expect(replaceInline("status:: open\r", "status", "closed")).toBe("status:: closed\r");
     });
 
     it("preserves the wrapper of a bracketed field (#67)", () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,7 +3,7 @@ import {parseYaml} from "obsidian";
 import {MetaType} from "./Types/metaType";
 
 export type Property = {key: string, content: any, type: MetaType};
-type FrontmatterPosition = {start: Loc, end: Loc};
+export type FrontmatterPosition = {start: Loc, end: Loc};
 // `start`/`end` are the field's span in the line; `sepEnd` is the offset just
 // after `::`; `valueEnd` is where the value content ends (the closing bracket
 // for a bracketed field, or end-of-line for a full-line field). The latter two
@@ -46,23 +46,27 @@ export default class MetaEditParser {
 
     public async parseFrontmatter(file: TFile): Promise<Property[]> {
         const fileCache = this.app.metadataCache.getFileCache(file);
+        const frontmatterPosition = this.getFrontmatterPosition(fileCache);
+        const filecontent = await this.app.vault.cachedRead(file);
+        const parsedYaml = this.parseFrontmatterContent(filecontent, frontmatterPosition);
+        if (parsedYaml !== null) return this.objectToYamlProperties(parsedYaml);
+
         const frontmatter = fileCache?.frontmatter;
         if (!frontmatter) return [];
 
-        const frontmatterPosition = this.getFrontmatterPosition(fileCache);
-        if (!frontmatterPosition) {
-            return this.objectToYamlProperties(frontmatter, true);
-        }
-
-        const {start, end} = frontmatterPosition;
-        const filecontent = await this.app.vault.cachedRead(file);
-        const yamlContent: string = filecontent.split("\n").slice(start.line, end.line).join("\n");
-        const parsedYaml = parseYaml(yamlContent);
-
-        return this.objectToYamlProperties(parsedYaml);
+        return this.objectToYamlProperties(frontmatter, true);
     }
 
-    private getFrontmatterPosition(fileCache: CachedMetadata): FrontmatterPosition | null {
+    public parseFrontmatterCache(fileCache: CachedMetadata | null | undefined): Property[] {
+        const frontmatter = fileCache?.frontmatter;
+        if (!frontmatter) return [];
+
+        return this.objectToYamlProperties(frontmatter, true);
+    }
+
+    public getFrontmatterPosition(fileCache: CachedMetadata | null | undefined): FrontmatterPosition | null {
+        if (!fileCache) return null;
+
         const frontmatterPosition = fileCache.frontmatterPosition;
         if (this.isFrontmatterPosition(frontmatterPosition)) return frontmatterPosition;
 
@@ -108,7 +112,8 @@ export default class MetaEditParser {
 
     public async parseInlineFields(file: TFile): Promise<Property[]> {
         const content = await this.app.vault.cachedRead(file);
-        return this.parseInlineContent(content);
+        const frontmatterPosition = this.getFrontmatterPosition(this.app.metadataCache.getFileCache(file));
+        return this.parseInlineContent(content, frontmatterPosition);
     }
 
     /**
@@ -121,22 +126,17 @@ export default class MetaEditParser {
      * full-line key is otherwise kept verbatim so odd-but-real keys like
      * `progress (%)` survive a read/write cycle.
      */
-    public parseInlineContent(content: string): Property[] {
+    public parseInlineContent(content: string, frontmatterPosition: FrontmatterPosition | null = null): Property[] {
         const properties: Property[] = [];
         const lines = content.split(/\r?\n/);
-        let inFrontmatter = false;
+        const frontmatterRange = this.getInlineFrontmatterRange(lines, frontmatterPosition);
         let openFence: string | null = null;
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
 
             // Skip a leading YAML frontmatter block - it is handled by parseFrontmatter.
-            if (i === 0 && /^---\s*$/.test(line)) {
-                inFrontmatter = true;
-                continue;
-            }
-            if (inFrontmatter) {
-                if (/^(?:---|\.\.\.)\s*$/.test(line)) inFrontmatter = false;
+            if (frontmatterRange && i >= frontmatterRange.startLine && i <= frontmatterRange.endLine) {
                 continue;
             }
 
@@ -163,6 +163,37 @@ export default class MetaEditParser {
         }
 
         return properties;
+    }
+
+    private getInlineFrontmatterRange(
+        lines: string[],
+        frontmatterPosition: FrontmatterPosition | null,
+    ): {startLine: number, endLine: number} | null {
+        if (frontmatterPosition) {
+            return {
+                startLine: frontmatterPosition.start.line,
+                endLine: frontmatterPosition.end.line,
+            };
+        }
+
+        if (!/^---\s*$/.test(lines[0] ?? "")) return null;
+
+        for (let i = 1; i < lines.length; i++) {
+            if (/^(?:---|\.\.\.)\s*$/.test(lines[i])) {
+                return {startLine: 0, endLine: i};
+            }
+        }
+
+        return null;
+    }
+
+    private parseFrontmatterContent(content: string, frontmatterPosition: FrontmatterPosition | null): unknown | null {
+        const lines = content.split(/\r?\n/);
+        const frontmatterRange = this.getInlineFrontmatterRange(lines, frontmatterPosition);
+        if (!frontmatterRange || frontmatterRange.startLine !== 0) return null;
+
+        const yamlContent = lines.slice(frontmatterRange.startLine + 1, frontmatterRange.endLine).join("\n");
+        return parseYaml(yamlContent);
     }
 
     private parseLineFields(line: string): InlineField[] {
@@ -246,8 +277,9 @@ export default class MetaEditParser {
     }
 
     private extractFullLineField(line: string): InlineField | null {
+        const lineEnd = line.endsWith("\r") ? line.length - 1 : line.length;
         const prefix = line.match(FULL_LINE_PREFIX)?.[0] ?? "";
-        const body = line.slice(prefix.length);
+        const body = line.slice(prefix.length, lineEnd);
 
         const sep = body.indexOf("::");
         if (sep < 0) return null;
@@ -258,7 +290,7 @@ export default class MetaEditParser {
         const value = body.substring(sep + 2).trim();
         // A full-line field has no wrapper: its value runs to end of line.
         const sepEnd = prefix.length + sep + 2;
-        return {key, value, start: prefix.length, end: line.length, sepEnd, valueEnd: line.length};
+        return {key, value, start: prefix.length, end: lineEnd, sepEnd, valueEnd: lineEnd};
     }
 
     /**

--- a/tests/e2e/auto-properties.test.ts
+++ b/tests/e2e/auto-properties.test.ts
@@ -233,6 +233,55 @@ describe("Auto Properties value prompt", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("adds an explicit Single auto property as a scalar under AllMulti", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("ap-single-add-allmulti.md");
+		const result = await evalJsonAsync<{ content: string; status: unknown }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+				const snapshot = {
+					auto: JSON.parse(JSON.stringify(plugin.settings.AutoProperties)),
+					mode: plugin.settings.EditMode.mode,
+				};
+				plugin.settings.AutoProperties.enabled = true;
+				plugin.settings.AutoProperties.properties = [
+					{ name: "status", choices: ["todo", "done"], type: "Single" },
+				];
+				plugin.settings.EditMode.mode = "All Multi";
+				await plugin.saveSettings();
+
+				const path = ${JSON.stringify(notePath)};
+				const existing = app.vault.getAbstractFileByPath(path);
+				if (existing) await app.vault.delete(existing);
+				const file = await app.vault.create(path, "Body\\n");
+				await sleep(300);
+
+				try {
+					await plugin.controller.addYamlProp("status", "done", file);
+					await sleep(300);
+					return {
+						content: await app.vault.read(file),
+						status: app.metadataCache.getFileCache(file)?.frontmatter?.status,
+					};
+				} finally {
+					plugin.settings.AutoProperties = snapshot.auto;
+					plugin.settings.EditMode.mode = snapshot.mode;
+					await plugin.saveSettings();
+				}
+			})()
+		`,
+		);
+
+		expect(result.content).toContain("status: done");
+		expect(result.content).not.toContain("- done");
+		expect(result.status).toBe("done");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("treats an entry without a type as single (back-compat)", async () => {
 		const { obsidian, sandbox } = getContext();
 

--- a/tests/e2e/bulk-metadata.test.ts
+++ b/tests/e2e/bulk-metadata.test.ts
@@ -47,6 +47,100 @@ describe("MetaEdit bulk metadata edit", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("shows conflict options from live frontmatter when the metadata cache is stale", async () => {
+		const { obsidian, sandbox } = getContext();
+		const dir = "stale-cache-folder";
+		await seed(obsidian, sandbox.path(dir), {
+			"existing.md": "---\nstatus: old\n---\n\nbody\n",
+		});
+
+		const result = await evalJsonAsync<{ content: string; conflictTitle: string | null }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+				const waitFor = async (selector, predicate = () => true) => {
+					const start = Date.now();
+					while (Date.now() - start < 5000) {
+						const found = Array.from(document.querySelectorAll(selector)).find(predicate);
+						if (found) return found;
+						await sleep(80);
+					}
+					throw new Error("Timed out waiting for " + selector);
+				};
+
+				const path = ${JSON.stringify(sandbox.path(`${dir}/existing.md`))};
+				const file = app.vault.getAbstractFileByPath(path);
+				const originalGetFileCache = app.metadataCache.getFileCache.bind(app.metadataCache);
+				app.metadataCache.getFileCache = (candidate) =>
+					candidate?.path === path ? {} : originalGetFileCache(candidate);
+
+				try {
+					const runPromise = plugin.bulkEditor.run([file], "stale cache").then(() => "resolved");
+
+					const keyInput = await waitFor(".metaEditPromptInput");
+					keyInput.value = "status";
+					keyInput.dispatchEvent(new Event("input", { bubbles: true }));
+					keyInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+					const valueInput = await waitFor(".metaEditPromptInput");
+					valueInput.value = "new";
+					valueInput.dispatchEvent(new Event("input", { bubbles: true }));
+					valueInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+					const conflictTitle = (await waitFor(".metaedit-bulk-modal h3")).textContent;
+					const overwrite = await waitFor(
+						".metaedit-bulk-option",
+						(el) => el.textContent.includes("Overwrite existing values"),
+					);
+					overwrite.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+					const confirm = await waitFor(
+						".metaedit-bulk-option",
+						(el) => el.textContent.trim() === "Overwrite",
+					);
+					confirm.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+					await runPromise;
+					await sleep(400);
+					return { content: await app.vault.read(file), conflictTitle };
+				} finally {
+					app.metadataCache.getFileCache = originalGetFileCache;
+					document.querySelectorAll(".modal-close-button").forEach((button) => button.click());
+				}
+			})()
+		`,
+		);
+
+		expect(result.conflictTitle).toBe('1 note already has "status"');
+		expect(result.content).toContain("status: new");
+		expect(result.content).not.toContain("status: old");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("does not abort conflict preflight on malformed frontmatter", async () => {
+		const { obsidian, sandbox } = getContext();
+		const dir = "malformed-frontmatter-folder";
+		await seed(obsidian, sandbox.path(dir), {
+			"bad.md": "---\nstatus: : :\n---\n\nbody\n",
+		});
+
+		const conflicts = await evalJsonAsync<number>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(sandbox.path(`${dir}/bad.md`))});
+				return await plugin.bulkEditor.countExisting([file], "status");
+			})()
+		`,
+		);
+
+		expect(conflicts).toBe(0);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("merge appends into a list without duplicating and converges on re-run", async () => {
 		const { obsidian, sandbox } = getContext();
 		const dir = "merge-folder";

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -124,6 +124,42 @@ describe("MetaEdit runtime", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("parses inline fields after an unmatched leading thematic break", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("thematic-break-inline.md");
+		await writeLiveFile(obsidian, notePath, "---\nstatus:: open\nbody:: yes\n");
+
+		const state = await evalJsonAsync<{
+			frontmatter: unknown;
+			frontmatterPosition: unknown;
+			properties: { key: string; content: unknown }[];
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				const cache = app.metadataCache.getFileCache(file);
+				const props = await plugin.controller.getPropertiesInFile(file);
+				return {
+					frontmatter: cache?.frontmatter ?? null,
+					frontmatterPosition: cache?.frontmatterPosition ?? cache?.frontmatter?.position ?? null,
+					properties: props.map((prop) => ({ key: prop.key, content: prop.content })),
+				};
+			})()
+		`,
+		);
+
+		expect(state.frontmatter).toBeNull();
+		expect(state.frontmatterPosition).toBeNull();
+		expect(state.properties).toEqual([
+			{ key: "status", content: "open" },
+			{ key: "body", content: "yes" },
+		]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("updates one numeric YAML property without changing its sibling", async () => {
 		const { obsidian, sandbox } = getContext();
 
@@ -151,12 +187,16 @@ describe("MetaEdit runtime", () => {
 	test("sets Auto Properties through the public API without exposing mutable settings", async () => {
 		const { obsidian } = getContext();
 
-		const state = await evalJsonAsync<{
-			returnedChoices: string[];
-			savedChoices: string[];
-			invalidMessage: string;
-			settingsAfterInvalid: { name: string; choices: string[] }[];
-		}>(
+			const state = await evalJsonAsync<{
+				returnedChoices: string[];
+				returnedType: string | undefined;
+				returnedDescription: string | undefined;
+				savedChoices: string[];
+				savedType: string | undefined;
+				savedDescription: string | undefined;
+				invalidMessage: string;
+				settingsAfterInvalid: { name: string; choices: string[]; type?: string; description?: string }[];
+			}>(
 			obsidian,
 			`
 			(async () => {
@@ -164,11 +204,16 @@ describe("MetaEdit runtime", () => {
 				const api = plugin?.api;
 				if (!api) throw new Error("MetaEdit API is not available.");
 
-				await api.setAutoProperties([
-					{ name: "", choices: [""] },
-					{ name: "Status", choices: ["Draft", "Done"] },
-					{ name: "Status", choices: ["Duplicate"] },
-				]);
+					await api.setAutoProperties([
+						{ name: "", choices: [""] },
+						{
+							name: "Status",
+							choices: ["Draft", "Done"],
+							description: "Workflow state",
+							type: "Single",
+						},
+						{ name: "Status", choices: ["Duplicate"] },
+					]);
 
 				const returned = api.getAutoProperties();
 				returned[1].choices.push("Leaked");
@@ -185,24 +230,37 @@ describe("MetaEdit runtime", () => {
 
 				const saved = await plugin.loadData();
 
-				return {
-					returnedChoices: api.getAutoProperties()[1].choices,
-					savedChoices: saved.AutoProperties.properties[1].choices,
-					invalidMessage,
-					settingsAfterInvalid: plugin.settings.AutoProperties.properties,
-				};
+					return {
+						returnedChoices: api.getAutoProperties()[1].choices,
+						returnedType: api.getAutoProperties()[1].type,
+						returnedDescription: api.getAutoProperties()[1].description,
+						savedChoices: saved.AutoProperties.properties[1].choices,
+						savedType: saved.AutoProperties.properties[1].type,
+						savedDescription: saved.AutoProperties.properties[1].description,
+						invalidMessage,
+						settingsAfterInvalid: plugin.settings.AutoProperties.properties,
+					};
 			})()
 		`,
 		);
 
-		expect(state.returnedChoices).toEqual(["Draft", "Done"]);
-		expect(state.savedChoices).toEqual(["Draft", "Done"]);
-		expect(state.invalidMessage).toContain("choices must be an array of strings");
-		expect(state.settingsAfterInvalid).toEqual([
-			{ name: "", choices: [""] },
-			{ name: "Status", choices: ["Draft", "Done"] },
-			{ name: "Status", choices: ["Duplicate"] },
-		]);
+			expect(state.returnedChoices).toEqual(["Draft", "Done"]);
+			expect(state.returnedType).toBe("Single");
+			expect(state.returnedDescription).toBe("Workflow state");
+			expect(state.savedChoices).toEqual(["Draft", "Done"]);
+			expect(state.savedType).toBe("Single");
+			expect(state.savedDescription).toBe("Workflow state");
+			expect(state.invalidMessage).toContain("choices must be an array of strings");
+			expect(state.settingsAfterInvalid).toEqual([
+				{ name: "", choices: [""] },
+				{
+					name: "Status",
+					choices: ["Draft", "Done"],
+					description: "Workflow state",
+					type: "Single",
+				},
+				{ name: "Status", choices: ["Duplicate"] },
+			]);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
@@ -275,6 +333,126 @@ describe("MetaEdit runtime", () => {
 
 		expect(state.events.some(event => event.status === "done" && event.inline === "one")).toBe(true);
 		expect(state.countAfterUnsubscribe).toBe(state.countBeforeUnsubscribe);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("keeps metadata change event data, cache, and properties in the same snapshot", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("metadata-burst.md");
+		await writeLiveFile(obsidian, notePath, "---\nstatus: zero\n---\nbody\n");
+
+		const state = await evalJsonAsync<{
+			events: {
+				dataStatus: string | null;
+				cacheStatus: unknown;
+				propStatus: unknown;
+				previousStatus: unknown;
+			}[];
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const api = plugin?.api;
+				if (!api) throw new Error("MetaEdit API is not available.");
+
+				const notePath = ${JSON.stringify(notePath)};
+				const file = app.vault.getAbstractFileByPath(notePath);
+				const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+				const statusFromData = (data) => data.match(/status:\\s*([^\\n\\r]+)/)?.[1] ?? null;
+				const events = [];
+				const unsubscribe = api.onMetadataChange(async (change) => {
+					if (change.file.path !== notePath) return;
+					events.push({
+						dataStatus: statusFromData(change.data),
+						cacheStatus: change.cache?.frontmatter?.status ?? null,
+						propStatus: change.properties.find((property) => property.key === "status")?.content ?? null,
+						previousStatus: change.previousProperties?.find((property) => property.key === "status")?.content ?? null,
+					});
+					await sleep(150);
+				});
+
+				try {
+					await app.vault.modify(file, "---\\nstatus: one\\n---\\nbody\\n");
+					await sleep(20);
+					await app.vault.modify(file, "---\\nstatus: two\\n---\\nbody\\n");
+
+					const started = Date.now();
+					while (Date.now() - started < 5000 && events.length < 2) {
+						await sleep(100);
+					}
+					await sleep(300);
+					return { events };
+				} finally {
+					unsubscribe();
+				}
+			})()
+		`,
+		);
+
+		expect(state.events).toEqual([
+			{
+				dataStatus: "one",
+				cacheStatus: "one",
+				propStatus: "one",
+				previousStatus: null,
+			},
+			{
+				dataStatus: "two",
+				cacheStatus: "two",
+				propStatus: "two",
+				previousStatus: "one",
+			},
+		]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("metadata change events include a user frontmatter key named position", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("metadata-position.md");
+		await writeLiveFile(obsidian, notePath, "---\nposition: goalkeeper\n---\nbody\n");
+
+		const state = await evalJsonAsync<{ position: unknown; keys: string[] }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const api = plugin?.api;
+				if (!api) throw new Error("MetaEdit API is not available.");
+
+				const notePath = ${JSON.stringify(notePath)};
+				const file = app.vault.getAbstractFileByPath(notePath);
+				const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+				const events = [];
+				const unsubscribe = api.onMetadataChange((change) => {
+					if (change.file.path !== notePath) return;
+					events.push(change.properties);
+				});
+
+				try {
+					await api.update("position", "striker", file);
+					const started = Date.now();
+					while (Date.now() - started < 5000 && events.length === 0) {
+						await sleep(100);
+					}
+
+					const latest = events[events.length - 1] ?? [];
+					const position = latest.find((property) => property.key === "position")?.content ?? null;
+					return {
+						position,
+						keys: latest.map((property) => property.key),
+					};
+				} finally {
+					unsubscribe();
+				}
+			})()
+		`,
+		);
+
+		expect(state.position).toBe("striker");
+		expect(state.keys).toContain("position");
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
@@ -378,6 +556,24 @@ describe("MetaEdit runtime", () => {
 		expect(content).toContain("status:: complete");
 		expect(content).toContain("my-key:: new");
 		expect(content).toContain("progress (%):: done");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("preserves CRLF terminators when updating a full-line inline field", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("inline-crlf.md");
+		await writeLiveFile(obsidian, notePath, "status:: open\r\nother:: keep\r\n");
+
+		await callApi(obsidian, "update", ["status", "closed", notePath]);
+
+		const content = await sandbox.waitForContent(
+			"inline-crlf.md",
+			(value) => value.includes("status:: closed"),
+			WAIT_OPTS,
+		);
+
+		expect(content).toBe("status:: closed\r\nother:: keep\r\n");
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 

--- a/tests/e2e/multi-value.test.ts
+++ b/tests/e2e/multi-value.test.ts
@@ -157,6 +157,23 @@ describe("MetaEdit multi-value editing", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("keeps a YAML scalar scalar when edited through All Multi mode", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("scalar-allmulti.md");
+		await writeLiveFile(obsidian, notePath, "---\nstatus: open\n---\nbody\n");
+
+		const result = await driveListEdit(obsidian, notePath, {
+			mode: "All Multi",
+			key: "status",
+			selectText: "open",
+			enterValue: "closed",
+		});
+
+		expect(result.content).toBe("---\nstatus: closed\n---\nbody\n");
+		expect(result.readBack).toBe("closed");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	// #36: the public API update with an array writes a native YAML list (verifying the
 	// processFrontMatter write path that already fixed this stays fixed).
 	test("api.update with an array writes a native YAML list (#36)", async () => {
@@ -182,6 +199,27 @@ describe("MetaEdit multi-value editing", () => {
 
 		expect(result.content).toBe("---\nfoo:\n  - a\n  - c\n---\nbody\n");
 		expect(result.readBack).toEqual(["a", "c"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("edits a literal add-command sentinel as a normal list element", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("sentinel-value.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nscripts:\n  - cmd:addfirst\n  - keep\n---\nbody\n",
+		);
+
+		const result = await driveListEdit(obsidian, notePath, {
+			mode: "All Single",
+			key: "scripts",
+			selectText: "cmd:addfirst",
+			enterValue: "changed",
+		});
+
+		expect(result.content).toBe("---\nscripts:\n  - changed\n  - keep\n---\nbody\n");
+		expect(result.readBack).toEqual(["changed", "keep"]);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 });


### PR DESCRIPTION
Re-verifies the review-bot findings from PRs #119-#128 on current `master` and fixes the confirmed regressions in one remediation branch.

This keeps the existing `processFrontMatter` write path intact, preserves native YAML-list behavior, and adds live Obsidian regressions for the review cases that depend on runtime behavior.

## Finding verdicts

| Finding | Verdict | Evidence / outcome |
| --- | --- | --- |
| #128 scalar YAML in All Multi writes array | Fixed | Live repro on current master: `status: open` edited in All Multi became `status:\n  - closed`. Fixed by persisting arrays only when the original value was a native YAML array (`src/metaController.ts`). E2E: `keeps a YAML scalar scalar when edited through All Multi mode`. |
| #125 Auto Property cancel falls through | Not a bug on current master | Live refutation: cancelling an existing Auto Property edit resolved with the file unchanged and no generic prompt; cancelling `createNewProperty` returned `null` with no fallback prompt. Source evidence: Auto Properties are intercepted before standard mode and cancellation returns early in `editAutoProperty` / `createNewProperty` (`src/metaController.ts`). |
| #122 thematic break hides inline fields | Fixed | Live repro: Obsidian cache reported no frontmatter range for `---\nstatus:: open`, but MetaEdit returned no inline properties. Parser now skips only confirmed frontmatter ranges and falls back to completed text ranges. Unit + E2E coverage added. |
| #127 CRLF inline write creates mixed line endings | Fixed | Live repro: updating `status:: open\r\n` produced `status:: closed\n` while later lines stayed CRLF. Full-line inline field replacement now preserves trailing `\r`. Unit + E2E coverage added. |
| #123 new explicit Single Auto Property becomes list under All Multi | Fixed | Live repro: adding `status` from a Single Auto Property under All Multi wrote `status:\n  - done`. Add path now honors `isMultiAutoProperty` and keeps explicit Single values scalar. E2E coverage added. |
| #124 bulk conflict count uses stale metadata cache | Fixed | Live repro with a stale cache shim: conflict modal was skipped and the old value remained. Preflight now reads live frontmatter text, handles malformed YAML as non-countable, and no longer depends on metadata cache freshness. E2E coverage added. |
| #120 metadata-change event snapshots mix old event data with new properties | Fixed | Live repro: first callback received `data/cache` for `status: one` while `properties` already said `status: two`, then the real second event was skipped. Event properties now derive from the event’s own `data/cache`, not a fresh file read. E2E coverage added, including a `position` key regression from adversarial review. |
| #128 literal list value collides with `cmd:*` sentinels | Fixed | Live repro: selecting a literal `cmd:addfirst` list value replaced the whole list with one item. The suggester now uses private index-based item IDs, and the old exported `cmd:*` sentinels were removed. E2E coverage added. |

## Other hardening from adversarial review

- `parseFrontmatter` now falls back to live file content when Obsidian metadata cache has not caught up, fixing read-after-write API races.
- The metadata API now preserves Auto Property `type` and `description` through `setAutoProperties` / `getAutoProperties`.
- Bulk malformed-frontmatter preflight no longer aborts the whole flow.
- Singular bulk conflict title now says `has` instead of `have`.

## Validation

Live environment:

- Isolated vault: `metaedit-review-remediation`
- Vault path: `.obsidian-e2e-vaults/metaedit-review-remediation`
- Obsidian: `1.12.7 (installer 1.12.7)`

Commands run:

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run provision:e2e-vault`
- `pnpm run obsidian:e2e -- version`
- Live pre-fix repro/refutation snippets for all eight findings via `pnpm run obsidian:e2e -- eval ...`
- `pnpm run test` (`174` tests passed)
- `pnpm run lint` (passes with existing warnings only)
- `pnpm run build`
- `pnpm run test:e2e` (`39` live Obsidian tests passed)

Adversarial review:

- Ran three Claude reviewer passes (Skeptic, Architect, Minimalist) over the diff.
- Accepted and fixed concrete findings around `position` frontmatter keys, malformed frontmatter in bulk preflight, Auto Property API type preservation, stale cache read-after-write behavior, and dead sentinel exports.
- The installed adversarial-review skill referenced `brain/principles.md`, but that file was missing locally; reviewer prompts used the available reviewer-lens definitions and the full diff.

Release impact: patch-level bug fixes; no settings migration required.