### PR TITLE
feat: hide file tags from the Edit Meta menu (#46, #90)

### DIFF
--- a/scripts/provision-obsidian-e2e-vault.mjs
+++ b/scripts/provision-obsidian-e2e-vault.mjs
@@ -22,7 +22,7 @@ export const METAEDIT_READY_EVAL = `Boolean(app.plugins.plugins[${JSON.stringify
 // string value of the EditMode.AllSingle enum ("All Single").
 export const DEFAULT_METAEDIT_DATA = {
 	ProgressProperties: { enabled: false, properties: [] },
-	IgnoredProperties: { enabled: false, properties: [] },
+	IgnoredProperties: { enabled: false, properties: [], hideFileTags: false },
 	AutoProperties: { enabled: false, properties: [] },
 	EditMode: { mode: "All Single", properties: [] },
 	KanbanHelper: { enabled: false, boards: [] },

--- a/src/Modals/menuFilter.test.ts
+++ b/src/Modals/menuFilter.test.ts
@@ -1,0 +1,105 @@
+import {describe, expect, it} from "vitest";
+import {filterMenuItems} from "./menuFilter";
+import {MetaType} from "../Types/metaType";
+import type {Property} from "../parser";
+
+const tag = (key: string): Property => ({key, content: key, type: MetaType.Tag});
+const yaml = (key: string): Property => ({key, content: "v", type: MetaType.YAML});
+const dataview = (key: string): Property => ({key, content: "v", type: MetaType.Dataview});
+
+const keysOf = (props: Property[]) => props.map(p => p.key);
+
+describe("filterMenuItems", () => {
+    const sample: Property[] = [
+        tag("#project"),
+        tag("#area/work"),
+        yaml("status"),
+        yaml("tags"),
+        dataview("rating"),
+    ];
+
+    it("returns everything untouched when the feature is disabled", () => {
+        const result = filterMenuItems(sample, {
+            enabled: false,
+            ignoredProperties: ["status"],
+            hideFileTags: true,
+        });
+
+        // Even with an ignored key and hideFileTags set, nothing is filtered:
+        // the toggle does exactly what its label promises (regression for the
+        // latent bug where ignored keys were filtered while disabled).
+        expect(keysOf(result)).toEqual(keysOf(sample));
+    });
+
+    it("returns a copy, not the original array", () => {
+        const result = filterMenuItems(sample, {enabled: false, ignoredProperties: [], hideFileTags: false});
+        expect(result).not.toBe(sample);
+        expect(result).toEqual(sample);
+    });
+
+    it("drops exact-match ignored keys when enabled", () => {
+        const result = filterMenuItems(sample, {
+            enabled: true,
+            ignoredProperties: ["status", "rating"],
+            hideFileTags: false,
+        });
+
+        expect(keysOf(result)).toEqual(["#project", "#area/work", "tags"]);
+    });
+
+    it("hides only file tags (MetaType.Tag) when hideFileTags is on", () => {
+        const result = filterMenuItems(sample, {
+            enabled: true,
+            ignoredProperties: [],
+            hideFileTags: true,
+        });
+
+        // Body #tags are gone; the frontmatter `tags` YAML key survives - this is
+        // the #46/#90 contract: edit frontmatter, not the file's tags.
+        expect(keysOf(result)).toEqual(["status", "tags", "rating"]);
+        expect(result.some(p => p.type === MetaType.Tag)).toBe(false);
+        expect(result.find(p => p.key === "tags")?.type).toBe(MetaType.YAML);
+    });
+
+    it("keeps file tags when hideFileTags is off", () => {
+        const result = filterMenuItems(sample, {
+            enabled: true,
+            ignoredProperties: [],
+            hideFileTags: false,
+        });
+
+        expect(result.filter(p => p.type === MetaType.Tag)).toHaveLength(2);
+    });
+
+    it("applies ignored keys and hideFileTags together", () => {
+        const result = filterMenuItems(sample, {
+            enabled: true,
+            ignoredProperties: ["status"],
+            hideFileTags: true,
+        });
+
+        expect(keysOf(result)).toEqual(["tags", "rating"]);
+    });
+
+    it("can still hide a specific tag by its key", () => {
+        const result = filterMenuItems(sample, {
+            enabled: true,
+            ignoredProperties: ["#project"],
+            hideFileTags: false,
+        });
+
+        expect(keysOf(result)).toEqual(["#area/work", "status", "tags", "rating"]);
+    });
+
+    it("handles an empty input", () => {
+        expect(filterMenuItems([], {enabled: true, ignoredProperties: [], hideFileTags: true})).toEqual([]);
+    });
+
+    it("returns an empty list when every entry is a hidden file tag", () => {
+        const tagsOnly = [tag("#a"), tag("#b")];
+        const result = filterMenuItems(tagsOnly, {enabled: true, ignoredProperties: [], hideFileTags: true});
+        // The suggester always prepends its action options, so a fully-filtered
+        // data list still yields a non-empty menu.
+        expect(result).toEqual([]);
+    });
+});

--- a/src/Modals/menuFilter.ts
+++ b/src/Modals/menuFilter.ts
@@ -1,0 +1,39 @@
+import type {Property} from "../parser";
+import {MetaType} from "../Types/metaType";
+
+/**
+ * The controls that decide what the "Edit Meta" menu lists, mirrored from
+ * `settings.IgnoredProperties` but kept as a plain shape so this stays a pure,
+ * Obsidian-free function that unit tests can drive directly.
+ */
+export interface MenuFilterOptions {
+    /** Master toggle for the whole "Edit Meta menu" filtering feature. */
+    enabled: boolean;
+    /** Property keys to hide by exact match. */
+    ignoredProperties: string[];
+    /** Hide body `#tag` occurrences (MetaType.Tag) as a category. */
+    hideFileTags: boolean;
+}
+
+/**
+ * Decide which parsed properties the Edit Meta menu should show.
+ *
+ * When the feature is disabled, nothing is filtered - so the toggle does exactly
+ * what its label promises (the previous implementation filtered ignored keys
+ * even when the feature was off). When enabled, drop exact-match ignored keys
+ * and, if `hideFileTags` is on, the entire file-tag category.
+ *
+ * `hideFileTags` only removes `MetaType.Tag` entries (body `#tags`); a frontmatter
+ * `tags:` key is a `MetaType.YAML` property and stays editable - exactly what
+ * #46/#90 ask for ("I only want to edit frontmatter, not the file's tags").
+ */
+export function filterMenuItems(data: Property[], opts: MenuFilterOptions): Property[] {
+    if (!opts.enabled) return [...data];
+
+    const ignored = new Set(opts.ignoredProperties);
+    return data.filter(item => {
+        if (ignored.has(item.key)) return false;
+        if (opts.hideFileTags && item.type === MetaType.Tag) return false;
+        return true;
+    });
+}

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -4,10 +4,10 @@ import type MetaController from "../metaController";
 import type {Property} from "../parser";
 import {MAIN_SUGGESTER_OPTIONS, newDataView, newYaml} from "../constants";
 import {MetaType} from "../Types/metaType";
-import {concat} from "svelte-preprocess/dist/modules/utils";
 import type {AutoProperty} from "../Types/autoProperty";
 import {getKnownPropertyNames} from "./GenericPrompt/valueSuggest";
 import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
+import {filterMenuItems} from "./menuFilter";
 
 export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     public app: App;
@@ -23,7 +23,12 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
         this.file = file;
         this.app = app;
         this.plugin = plugin;
-        this.data = this.removeIgnored(data);
+        const ignored = plugin.settings.IgnoredProperties;
+        this.data = filterMenuItems(data, {
+            enabled: ignored.enabled,
+            ignoredProperties: ignored.properties,
+            hideFileTags: ignored.hideFileTags,
+        });
         this.controller = controller;
         this.options = MAIN_SUGGESTER_OPTIONS;
 
@@ -51,7 +56,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     }
 
     getItems(): Property[] {
-        return concat(this.options, this.data);
+        return [...this.options, ...this.data];
     }
 
     async onChooseItem(item: Property, _evt: MouseEvent | KeyboardEvent): Promise<void> {
@@ -124,18 +129,6 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
         itemButton.style.float = "right";
         itemButton.style.marginRight = "4px";
         itemButton.addEventListener("click", callback);
-    }
-
-    private removeIgnored(data: Property[]): Property[] {
-        const ignored = this.plugin.settings.IgnoredProperties.properties;
-        const purged: Property[] = [];
-
-        for (const item in data) {
-            if (!ignored.contains(data[item].key))
-                purged.push(data[item]);
-        }
-
-        return purged;
     }
 
     private setSuggestValues() {

--- a/src/Settings/defaultSettings.ts
+++ b/src/Settings/defaultSettings.ts
@@ -8,7 +8,8 @@ export const DEFAULT_SETTINGS: MetaEditSettings = Object.freeze({
     },
     IgnoredProperties: {
         enabled: false,
-        properties: []
+        properties: [],
+        hideFileTags: false
     },
     AutoProperties: {
         enabled: false,

--- a/src/Settings/metaEditSettings.ts
+++ b/src/Settings/metaEditSettings.ts
@@ -8,6 +8,9 @@ export interface MetaEditSettings {
         enabled: boolean,
         properties: ProgressProperty[]
     },
+    // Storage key for the "Edit Meta menu" settings section (its displayed name).
+    // `enabled` gates both controls: `properties` (hide keys by exact match) and
+    // `hideFileTags` (hide the whole body-#tag category).
     IgnoredProperties: {
         enabled: boolean,
         properties: string[],

--- a/src/Settings/metaEditSettings.ts
+++ b/src/Settings/metaEditSettings.ts
@@ -10,7 +10,8 @@ export interface MetaEditSettings {
     },
     IgnoredProperties: {
         enabled: boolean,
-        properties: string[]
+        properties: string[],
+        hideFileTags: boolean
     },
     AutoProperties: {
         enabled: boolean,

--- a/src/Settings/metaEditSettingsTab.ts
+++ b/src/Settings/metaEditSettingsTab.ts
@@ -124,7 +124,7 @@ export class MetaEditSettingsTab extends PluginSettingTab {
         let modal: SingleValueTableEditorContent, div: HTMLDivElement, hidden = true;
         const setting = new Setting(containerEl)
             .setName("Edit Meta menu")
-            .setDesc("Control what the 'Edit Meta' menu lists: hide specific properties by name, or hide all of a note's file tags. Click the gear to configure.")
+            .setDesc("Control what the 'Edit Meta' menu lists. Enable it, then use the gear to hide specific properties by name or all of a note's file tags.")
             .addToggle(toggle => {
                 toggle
                     .setTooltip("Toggle menu filtering")

--- a/src/Settings/metaEditSettingsTab.ts
+++ b/src/Settings/metaEditSettingsTab.ts
@@ -39,7 +39,7 @@ export class MetaEditSettingsTab extends PluginSettingTab {
 
         this.addProgressPropertiesSetting(containerEl);
         this.addAutoPropertiesSetting(containerEl);
-        this.addIgnorePropertiesSetting(containerEl);
+        this.addEditMetaMenuSetting(containerEl);
         this.addEditModeSetting(containerEl);
         this.addKanbanHelperSetting(containerEl);
         this.addUIElementsSetting(containerEl);
@@ -120,14 +120,14 @@ export class MetaEditSettingsTab extends PluginSettingTab {
         this.svelteElements.push(modal);
     }
 
-    private addIgnorePropertiesSetting(containerEl: HTMLElement) {
+    private addEditMetaMenuSetting(containerEl: HTMLElement) {
         let modal: SingleValueTableEditorContent, div: HTMLDivElement, hidden = true;
         const setting = new Setting(containerEl)
-            .setName("Ignore Properties")
-            .setDesc("Hide these properties from the menu.")
+            .setName("Edit Meta menu")
+            .setDesc("Control what the 'Edit Meta' menu lists: hide specific properties by name, or hide all of a note's file tags. Click the gear to configure.")
             .addToggle(toggle => {
                 toggle
-                    .setTooltip("Toggle Ignored Properties")
+                    .setTooltip("Toggle menu filtering")
                     .setValue(this.plugin.settings.IgnoredProperties.enabled)
                     .onChange(async value => {
                         if (value === this.plugin.settings.IgnoredProperties.enabled) return;
@@ -143,6 +143,24 @@ export class MetaEditSettingsTab extends PluginSettingTab {
             div = setting.settingEl.createDiv();
             setting.settingEl.style.display = "block";
             div.style.display = "none";
+
+            new Setting(div)
+                .setName("Hide file tags")
+                .setDesc("Hide the note's #tags from the menu, leaving only frontmatter and inline fields. A frontmatter 'tags' property stays editable.")
+                .addToggle(toggle => {
+                    toggle
+                        .setTooltip("Toggle hiding file tags")
+                        .setValue(this.plugin.settings.IgnoredProperties.hideFileTags)
+                        .onChange(async value => {
+                            if (value === this.plugin.settings.IgnoredProperties.hideFileTags) return;
+
+                            this.plugin.settings.IgnoredProperties.hideFileTags = value;
+                            await this.plugin.saveSettings();
+                        });
+                });
+
+            const tableLabel = div.createEl("p", {text: "Hide specific properties by name:"});
+            tableLabel.style.marginBottom = "0";
 
             modal = new SingleValueTableEditorContent({
                 target: div,

--- a/src/Settings/settingsMigration.test.ts
+++ b/src/Settings/settingsMigration.test.ts
@@ -1,0 +1,110 @@
+import {describe, expect, it} from "vitest";
+import {mergeSettings, migrateIgnoredEnabled} from "./settingsMigration";
+import {DEFAULT_SETTINGS} from "./defaultSettings";
+import {EditMode} from "../Types/editMode";
+
+describe("mergeSettings", () => {
+    it("returns the defaults for a fresh install (null)", () => {
+        expect(mergeSettings(null)).toEqual(DEFAULT_SETTINGS);
+    });
+
+    it("does not return the frozen default objects by reference", () => {
+        const merged = mergeSettings(null);
+        expect(merged).not.toBe(DEFAULT_SETTINGS);
+        expect(merged.IgnoredProperties).not.toBe(DEFAULT_SETTINGS.IgnoredProperties);
+        // Frozen defaults must not leak through: the result must be writable.
+        expect(() => {
+            merged.IgnoredProperties.hideFileTags = true;
+        }).not.toThrow();
+    });
+
+    it("backfills a new nested field (hideFileTags) absent from stored data", () => {
+        const loaded = {
+            IgnoredProperties: {enabled: true, properties: ["foo"]},
+        };
+
+        const merged = mergeSettings(loaded);
+
+        expect(merged.IgnoredProperties.hideFileTags).toBe(false);
+        // Stored values still win.
+        expect(merged.IgnoredProperties.enabled).toBe(true);
+        expect(merged.IgnoredProperties.properties).toEqual(["foo"]);
+    });
+
+    it("backfills an entire section missing from stored data", () => {
+        const loaded = {
+            IgnoredProperties: {enabled: true, properties: [], hideFileTags: true},
+        };
+
+        const merged = mergeSettings(loaded);
+
+        expect(merged.KanbanHelper).toEqual(DEFAULT_SETTINGS.KanbanHelper);
+        expect(merged.AutoProperties).toEqual(DEFAULT_SETTINGS.AutoProperties);
+    });
+
+    it("lets stored scalars and arrays win wholesale", () => {
+        const loaded = {
+            EditMode: {mode: EditMode.AllMulti, properties: ["a", "b"]},
+        };
+
+        const merged = mergeSettings(loaded);
+
+        expect(merged.EditMode.mode).toBe(EditMode.AllMulti);
+        expect(merged.EditMode.properties).toEqual(["a", "b"]);
+    });
+
+    it("preserves an explicit hideFileTags value", () => {
+        const loaded = {
+            IgnoredProperties: {enabled: true, properties: [], hideFileTags: true},
+        };
+
+        expect(mergeSettings(loaded).IgnoredProperties.hideFileTags).toBe(true);
+    });
+});
+
+describe("migrateIgnoredEnabled", () => {
+    it("enables the feature for pre-version data with a non-empty ignored list", () => {
+        const loaded = {IgnoredProperties: {enabled: false, properties: ["foo"]}};
+        const settings = mergeSettings(loaded);
+
+        const changed = migrateIgnoredEnabled(loaded, settings);
+
+        expect(changed).toBe(true);
+        expect(settings.IgnoredProperties.enabled).toBe(true);
+    });
+
+    it("does not change pre-version data with an empty ignored list", () => {
+        const loaded = {IgnoredProperties: {enabled: false, properties: []}};
+        const settings = mergeSettings(loaded);
+
+        const changed = migrateIgnoredEnabled(loaded, settings);
+
+        expect(changed).toBe(false);
+        expect(settings.IgnoredProperties.enabled).toBe(false);
+    });
+
+    it("does not change pre-version data that is already enabled", () => {
+        const loaded = {IgnoredProperties: {enabled: true, properties: ["foo"]}};
+        const settings = mergeSettings(loaded);
+
+        expect(migrateIgnoredEnabled(loaded, settings)).toBe(false);
+        expect(settings.IgnoredProperties.enabled).toBe(true);
+    });
+
+    it("never fires again once data has the hideFileTags field (post-version)", () => {
+        // The user migrated, then deliberately disabled the feature while keeping
+        // their list. hideFileTags is present, so the flip must NOT re-trigger.
+        const loaded = {IgnoredProperties: {enabled: false, properties: ["foo"], hideFileTags: false}};
+        const settings = mergeSettings(loaded);
+
+        const changed = migrateIgnoredEnabled(loaded, settings);
+
+        expect(changed).toBe(false);
+        expect(settings.IgnoredProperties.enabled).toBe(false);
+    });
+
+    it("does nothing for a fresh install (null)", () => {
+        const settings = mergeSettings(null);
+        expect(migrateIgnoredEnabled(null, settings)).toBe(false);
+    });
+});

--- a/src/Settings/settingsMigration.test.ts
+++ b/src/Settings/settingsMigration.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest";
-import {mergeSettings, migrateIgnoredEnabled} from "./settingsMigration";
+import {mergeSettings, migrateIgnoredProperties} from "./settingsMigration";
 import {DEFAULT_SETTINGS} from "./defaultSettings";
 import {EditMode} from "../Types/editMode";
 
@@ -16,6 +16,28 @@ describe("mergeSettings", () => {
         expect(() => {
             merged.IgnoredProperties.hideFileTags = true;
         }).not.toThrow();
+    });
+
+    it("never aliases the mutable default arrays (UIs mutate them in place)", () => {
+        const merged = mergeSettings(null);
+        // A fresh install must not hand back the module-level default arrays;
+        // pushing into them via the settings UI would poison DEFAULT_SETTINGS.
+        expect(merged.IgnoredProperties.properties).not.toBe(DEFAULT_SETTINGS.IgnoredProperties.properties);
+        expect(merged.AutoProperties.properties).not.toBe(DEFAULT_SETTINGS.AutoProperties.properties);
+        expect(merged.KanbanHelper.boards).not.toBe(DEFAULT_SETTINGS.KanbanHelper.boards);
+
+        merged.IgnoredProperties.properties.push("status");
+        expect(DEFAULT_SETTINGS.IgnoredProperties.properties).toEqual([]);
+    });
+
+    it("preserves unknown top-level keys from stored data", () => {
+        const loaded = {
+            IgnoredProperties: {enabled: true, properties: [], hideFileTags: false},
+            SomeFutureSection: {foo: 1},
+        };
+
+        const merged = mergeSettings(loaded) as typeof loaded & Record<string, unknown>;
+        expect(merged.SomeFutureSection).toEqual({foo: 1});
     });
 
     it("backfills a new nested field (hideFileTags) absent from stored data", () => {
@@ -62,49 +84,52 @@ describe("mergeSettings", () => {
     });
 });
 
-describe("migrateIgnoredEnabled", () => {
+describe("migrateIgnoredProperties", () => {
     it("enables the feature for pre-version data with a non-empty ignored list", () => {
         const loaded = {IgnoredProperties: {enabled: false, properties: ["foo"]}};
         const settings = mergeSettings(loaded);
 
-        const changed = migrateIgnoredEnabled(loaded, settings);
+        const needsSave = migrateIgnoredProperties(loaded, settings);
 
-        expect(changed).toBe(true);
+        expect(needsSave).toBe(true);
         expect(settings.IgnoredProperties.enabled).toBe(true);
     });
 
-    it("does not change pre-version data with an empty ignored list", () => {
+    it("normalizes (saves once) pre-version data with an empty list without flipping enabled", () => {
         const loaded = {IgnoredProperties: {enabled: false, properties: []}};
         const settings = mergeSettings(loaded);
 
-        const changed = migrateIgnoredEnabled(loaded, settings);
+        // Returns true so the normalized shape (now with hideFileTags) is persisted
+        // once, but the disabled state is preserved.
+        const needsSave = migrateIgnoredProperties(loaded, settings);
 
-        expect(changed).toBe(false);
+        expect(needsSave).toBe(true);
         expect(settings.IgnoredProperties.enabled).toBe(false);
+        expect(settings.IgnoredProperties.hideFileTags).toBe(false);
     });
 
-    it("does not change pre-version data that is already enabled", () => {
+    it("does not flip pre-version data that is already enabled (but still normalizes)", () => {
         const loaded = {IgnoredProperties: {enabled: true, properties: ["foo"]}};
         const settings = mergeSettings(loaded);
 
-        expect(migrateIgnoredEnabled(loaded, settings)).toBe(false);
+        expect(migrateIgnoredProperties(loaded, settings)).toBe(true);
         expect(settings.IgnoredProperties.enabled).toBe(true);
     });
 
     it("never fires again once data has the hideFileTags field (post-version)", () => {
         // The user migrated, then deliberately disabled the feature while keeping
-        // their list. hideFileTags is present, so the flip must NOT re-trigger.
+        // their list. hideFileTags is present, so the migration must NOT re-trigger.
         const loaded = {IgnoredProperties: {enabled: false, properties: ["foo"], hideFileTags: false}};
         const settings = mergeSettings(loaded);
 
-        const changed = migrateIgnoredEnabled(loaded, settings);
+        const needsSave = migrateIgnoredProperties(loaded, settings);
 
-        expect(changed).toBe(false);
+        expect(needsSave).toBe(false);
         expect(settings.IgnoredProperties.enabled).toBe(false);
     });
 
     it("does nothing for a fresh install (null)", () => {
         const settings = mergeSettings(null);
-        expect(migrateIgnoredEnabled(null, settings)).toBe(false);
+        expect(migrateIgnoredProperties(null, settings)).toBe(false);
     });
 });

--- a/src/Settings/settingsMigration.ts
+++ b/src/Settings/settingsMigration.ts
@@ -16,17 +16,23 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * reads back `undefined` for existing users instead of its default. Merging each
  * section with a spread backfills new fields while letting stored values win.
  *
+ * The defaults are deep-cloned first: `DEFAULT_SETTINGS` is only shallowly
+ * frozen, and several settings UIs mutate the section arrays (`properties`,
+ * `boards`) in place. Sharing those arrays by reference would let edits leak
+ * back into the module-level default and poison later merges, so every section
+ * the result returns is fully owned. Unknown top-level keys the stored data
+ * carried (e.g. settings from a newer version) are preserved, matching the old
+ * Object.assign behavior so a later save never silently drops them.
+ *
  * This relies on every top-level setting being a flat object whose only nested
- * values are scalars or arrays, and on every default array being an empty
- * sentinel (so wholesale array-replacement never drops a default entry). A
- * future nested-object sub-field, or a non-empty default array, would need its
- * own migration. `DEFAULT_SETTINGS` is frozen, so each section is spread into a
- * fresh object rather than mutated.
+ * values are scalars or arrays. A future nested-object sub-field would need its
+ * own merge logic.
  */
 export function mergeSettings(loaded: Loaded): MetaEditSettings {
-    const defaults = DEFAULT_SETTINGS as unknown as Record<string, unknown>;
+    const defaults = structuredClone(DEFAULT_SETTINGS) as unknown as Record<string, unknown>;
     const stored = (loaded ?? {}) as Record<string, unknown>;
-    const merged: Record<string, unknown> = {};
+
+    const merged: Record<string, unknown> = {...stored};
 
     for (const key of Object.keys(defaults)) {
         const def = defaults[key];
@@ -34,27 +40,28 @@ export function mergeSettings(loaded: Loaded): MetaEditSettings {
 
         merged[key] = isPlainObject(def) && isPlainObject(value)
             ? {...def, ...value}
-            : {...(def as object)};
+            : def;
     }
 
     return merged as unknown as MetaEditSettings;
 }
 
 /**
- * One-time migration of the IgnoredProperties "enabled" flag.
+ * One-time migration of the IgnoredProperties section.
  *
  * Older versions filtered ignored keys regardless of `enabled` (a bug). Now that
  * the toggle is honored, a user who had built up an ignored-key list and then
  * left the feature "off" would silently lose their always-on filtering. Preserve
  * their observed behavior by enabling the feature for them.
  *
- * It runs only for data written before `hideFileTags` existed (detected by its
- * absence in the raw stored section), so once settings are saved with the new
- * field present it never fires again - which means a user can later disable the
+ * Pre-`hideFileTags` data is detected by that field's absence in the raw stored
+ * section. For all such data this returns `true` so the caller persists the
+ * normalized shape (now including `hideFileTags`) exactly once; afterwards the
+ * field is present and this never fires again - so a user can later disable the
  * feature with a non-empty list without it flipping back on. Mutates the passed
- * settings and returns whether anything changed (so the caller can persist).
+ * settings; returns whether the caller should save.
  */
-export function migrateIgnoredEnabled(loaded: Loaded, settings: MetaEditSettings): boolean {
+export function migrateIgnoredProperties(loaded: Loaded, settings: MetaEditSettings): boolean {
     const rawIgnored = loaded?.IgnoredProperties;
     const isPreVersionData = isPlainObject(rawIgnored) && rawIgnored.hideFileTags === undefined;
     if (!isPreVersionData) return false;
@@ -62,8 +69,7 @@ export function migrateIgnoredEnabled(loaded: Loaded, settings: MetaEditSettings
     const ignored = settings.IgnoredProperties;
     if (!ignored.enabled && ignored.properties.length > 0) {
         ignored.enabled = true;
-        return true;
     }
 
-    return false;
+    return true;
 }

--- a/src/Settings/settingsMigration.ts
+++ b/src/Settings/settingsMigration.ts
@@ -1,0 +1,69 @@
+import {DEFAULT_SETTINGS} from "./defaultSettings";
+import type {MetaEditSettings} from "./metaEditSettings";
+
+type Loaded = Partial<Record<keyof MetaEditSettings, unknown>> | null | undefined;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Merge stored settings onto the defaults, one level deep.
+ *
+ * `Object.assign({}, DEFAULT_SETTINGS, loaded)` (the old approach) is a shallow
+ * merge: a stored section object replaces the default section wholesale, so any
+ * field added to an existing section (e.g. `IgnoredProperties.hideFileTags`)
+ * reads back `undefined` for existing users instead of its default. Merging each
+ * section with a spread backfills new fields while letting stored values win.
+ *
+ * This relies on every top-level setting being a flat object whose only nested
+ * values are scalars or arrays, and on every default array being an empty
+ * sentinel (so wholesale array-replacement never drops a default entry). A
+ * future nested-object sub-field, or a non-empty default array, would need its
+ * own migration. `DEFAULT_SETTINGS` is frozen, so each section is spread into a
+ * fresh object rather than mutated.
+ */
+export function mergeSettings(loaded: Loaded): MetaEditSettings {
+    const defaults = DEFAULT_SETTINGS as unknown as Record<string, unknown>;
+    const stored = (loaded ?? {}) as Record<string, unknown>;
+    const merged: Record<string, unknown> = {};
+
+    for (const key of Object.keys(defaults)) {
+        const def = defaults[key];
+        const value = stored[key];
+
+        merged[key] = isPlainObject(def) && isPlainObject(value)
+            ? {...def, ...value}
+            : {...(def as object)};
+    }
+
+    return merged as unknown as MetaEditSettings;
+}
+
+/**
+ * One-time migration of the IgnoredProperties "enabled" flag.
+ *
+ * Older versions filtered ignored keys regardless of `enabled` (a bug). Now that
+ * the toggle is honored, a user who had built up an ignored-key list and then
+ * left the feature "off" would silently lose their always-on filtering. Preserve
+ * their observed behavior by enabling the feature for them.
+ *
+ * It runs only for data written before `hideFileTags` existed (detected by its
+ * absence in the raw stored section), so once settings are saved with the new
+ * field present it never fires again - which means a user can later disable the
+ * feature with a non-empty list without it flipping back on. Mutates the passed
+ * settings and returns whether anything changed (so the caller can persist).
+ */
+export function migrateIgnoredEnabled(loaded: Loaded, settings: MetaEditSettings): boolean {
+    const rawIgnored = loaded?.IgnoredProperties;
+    const isPreVersionData = isPlainObject(rawIgnored) && rawIgnored.hideFileTags === undefined;
+    if (!isPreVersionData) return false;
+
+    const ignored = settings.IgnoredProperties;
+    if (!ignored.enabled && ignored.properties.length > 0) {
+        ignored.enabled = true;
+        return true;
+    }
+
+    return false;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import MetaEditSuggester from "./Modals/metaEditSuggester";
 import MetaController from "./metaController";
 import {BulkMetadataEditor} from "./bulk/bulkMetadataEditor";
 import type {MetaEditSettings} from "./Settings/metaEditSettings";
-import {DEFAULT_SETTINGS} from "./Settings/defaultSettings";
+import {mergeSettings, migrateIgnoredEnabled} from "./Settings/settingsMigration";
 import {LinkMenu} from "./Modals/LinkMenu";
 import type {Property} from "./parser";
 import type {IMetaEditApi} from "./IMetaEditApi";
@@ -99,7 +99,14 @@ export default class MetaEdit extends Plugin {
     }
 
     async loadSettings() {
-        this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+        const loaded = await this.loadData();
+        this.settings = mergeSettings(loaded);
+
+        // Persist only when a migration actually changed something, so a normal
+        // load stays read-only.
+        if (migrateIgnoredEnabled(loaded, this.settings)) {
+            await this.saveSettings();
+        }
     }
 
     async saveSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import MetaEditSuggester from "./Modals/metaEditSuggester";
 import MetaController from "./metaController";
 import {BulkMetadataEditor} from "./bulk/bulkMetadataEditor";
 import type {MetaEditSettings} from "./Settings/metaEditSettings";
-import {mergeSettings, migrateIgnoredEnabled} from "./Settings/settingsMigration";
+import {mergeSettings, migrateIgnoredProperties} from "./Settings/settingsMigration";
 import {LinkMenu} from "./Modals/LinkMenu";
 import type {Property} from "./parser";
 import type {IMetaEditApi} from "./IMetaEditApi";
@@ -102,9 +102,9 @@ export default class MetaEdit extends Plugin {
         const loaded = await this.loadData();
         this.settings = mergeSettings(loaded);
 
-        // Persist only when a migration actually changed something, so a normal
-        // load stays read-only.
-        if (migrateIgnoredEnabled(loaded, this.settings)) {
+        // Persist only when a migration needs to normalize stored data, so a
+        // normal load stays read-only.
+        if (migrateIgnoredProperties(loaded, this.settings)) {
             await this.saveSettings();
         }
     }

--- a/tests/e2e/menu-filter.test.ts
+++ b/tests/e2e/menu-filter.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest";
+import {
+	createMetaEditE2EHarness,
+	evalJsonAsync,
+	PLUGIN_ID,
+} from "./harness";
+
+const getContext = createMetaEditE2EHarness("metaedit-menu-filter");
+
+// Open the real "Edit Meta" suggester (plugin.runMetaEditForFile) against a note
+// and read back the keys it lists, under three IgnoredProperties configurations.
+// This is the user-visible menu: the same FuzzySuggestModal a right-click "Edit
+// Meta" opens. Returns the rendered keys so the test can assert on them.
+async function captureMenuKeys(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	opts: { notePath: string; noteBody: string },
+): Promise<{ hideTags: string[]; showTags: string[]; disabled: string[] }> {
+	return await evalJsonAsync(
+		obsidian,
+		`
+		(async () => {
+			const plugin = app.plugins.plugins.${PLUGIN_ID};
+			const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+			const waitFor = async (pred, timeout = 5000) => {
+				const start = Date.now();
+				while (Date.now() - start < timeout) {
+					if (pred()) return true;
+					await sleep(60);
+				}
+				return false;
+			};
+
+			const snapshot = JSON.parse(JSON.stringify(plugin.settings.IgnoredProperties));
+			const path = ${JSON.stringify(opts.notePath)};
+			const existing = app.vault.getAbstractFileByPath(path);
+			if (existing) await app.vault.delete(existing);
+			const file = await app.vault.create(path, ${JSON.stringify(opts.noteBody)});
+			await sleep(400);
+
+			const setIgnored = async (enabled, hideFileTags, properties) => {
+				plugin.settings.IgnoredProperties.enabled = enabled;
+				plugin.settings.IgnoredProperties.hideFileTags = hideFileTags;
+				plugin.settings.IgnoredProperties.properties = properties;
+				await plugin.saveSettings();
+			};
+
+			const captureMenu = async () => {
+				await plugin.runMetaEditForFile(file);
+				await waitFor(() => document.querySelector(".suggestion-item"));
+				await sleep(120);
+				const keys = Array.from(document.querySelectorAll(".suggestion-item")).map((el) => {
+					const t = el.querySelector(".suggestion-item-text") || el;
+					return (t.textContent || "").replace(/[❌🔃]/g, "").trim();
+				});
+				// Close the suggester and wait until it is gone, so the next capture
+				// reads a fresh menu rather than a stacked one.
+				document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+				await waitFor(() => !document.querySelector(".suggestion-item"));
+				await sleep(60);
+				return keys;
+			};
+
+			try {
+				await setIgnored(true, true, []);
+				const hideTags = await captureMenu();
+
+				await setIgnored(true, false, []);
+				const showTags = await captureMenu();
+
+				// Feature off, yet hideFileTags + an ignored key are set: nothing must
+				// be filtered (the toggle does what it says).
+				await setIgnored(false, true, ["status"]);
+				const disabled = await captureMenu();
+
+				return { hideTags, showTags, disabled };
+			} finally {
+				plugin.settings.IgnoredProperties = snapshot;
+				await plugin.saveSettings();
+				const orphan = app.vault.getAbstractFileByPath(path);
+				if (orphan) await app.vault.delete(orphan);
+			}
+		})()
+	`,
+	);
+}
+
+describe("Edit Meta menu - file tag filtering (#46, #90)", () => {
+	test("hides body #tags while keeping frontmatter, inline, and the tags: key", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const { hideTags, showTags, disabled } = await captureMenuKeys(obsidian, {
+			notePath: sandbox.path("menu-filter.md"),
+			noteBody:
+				"---\ntags: [alpha, beta]\nstatus: open\n---\n\n# Note\n\nBody has #bodytag here.\n\nrating:: 5\n",
+		});
+
+		// hideFileTags ON: no body #tag survives, but the frontmatter `tags:` key,
+		// `status`, and the inline `rating` field stay editable.
+		expect(hideTags).not.toContain("#bodytag");
+		expect(hideTags.some((k) => k.startsWith("#"))).toBe(false);
+		expect(hideTags).toContain("tags");
+		expect(hideTags).toContain("status");
+		expect(hideTags).toContain("rating");
+		// The action options are always present, so the menu is never empty.
+		expect(hideTags).toContain("New YAML property");
+		expect(hideTags).toContain("New Dataview field");
+
+		// hideFileTags OFF: the body tag comes back.
+		expect(showTags).toContain("#bodytag");
+		expect(showTags).toContain("tags");
+
+		// Feature disabled: nothing filtered even though hideFileTags and an
+		// ignored key were set (regression for the latent enabled bug).
+		expect(disabled).toContain("#bodytag");
+		expect(disabled).toContain("status");
+	});
+});


### PR DESCRIPTION
## Summary

The "Edit Meta" right-click menu listed every body `#tag` in a note alongside its frontmatter and inline fields. Many users only want to edit frontmatter/inline metadata there and never the file's tags (#46, #90). This adds a **"Hide file tags"** toggle that drops the file-tag category from the menu while keeping a frontmatter `tags:` property fully editable.

The work reframes the existing "Ignore Properties" feature as the single place that controls **what the Edit Meta menu lists**, so the section is renamed to **"Edit Meta menu"** and now holds both controls: hide specific properties by name, and hide all file tags - under one enable toggle.

Closes #46
Closes #90

## What changed

- **Hide file tags** (`IgnoredProperties.hideFileTags`, default off): drops `MetaType.Tag` entries from the menu. Body `#tags` are hidden; a frontmatter `tags:` key (a YAML property) stays editable - exactly the ask.
- **Pure, unit-tested filter**: menu filtering moved into `filterMenuItems` (`src/Modals/menuFilter.ts`), keeping Obsidian out of the testable core.
- **Bug fix - honor `enabled`**: the old `removeIgnored` filtered ignored keys even when the feature was toggled *off*. The toggle now does what its label says.
- **Settings migration** (`src/Settings/settingsMigration.ts`): a per-section deep-merge backfills the new `hideFileTags` field for existing users (the old shallow `Object.assign` left new nested fields `undefined`), preserves unknown top-level keys, and deep-clones the (shallowly-frozen) defaults so the settings UIs can't mutate them by reference. A one-time, idempotent migration enables the feature for users who had a non-empty ignored list saved while it was off, preserving their de-facto always-on filtering instead of silently dropping it.
- **Section rename**: "Ignore Properties" -> "Edit Meta menu" (display + description only; the storage key stays `IgnoredProperties` to avoid a data-shape rename).

## Scope decision: #82 declined (with evidence)

#82 asked for native-key shortcuts (tags/aliases/cssclass/publish) in the menu. Live in a vault, Obsidian's `metadataTypeManager` already registers `tags`, `aliases`, and `cssclasses` as known property names by default, so the existing "New YAML property" prompt (shipped in #123/#125) already autocompletes 3 of the 4 keys - type `al` -> `aliases`. Only `publish` (Publish-only) and the legacy `cssclass` aren't covered. A dedicated shortcut would add a settings section + menu entries + real hazards (a `publish` string-vs-boolean bug, shared-array mutation, cssclass/cssclasses aliasing) for ~1 saved keystroke on keys that mostly already autocomplete. Declined as low-value; the remaining `publish`/legacy-`cssclass` gap can be revisited if requested.

## Validation

- `pnpm run lint` (0 errors), `pnpm run build` (no TS diagnostics), `pnpm run test` (172 unit tests incl. new `filterMenuItems` + migration suites).
- `pnpm run test:e2e` against an isolated Obsidian instance: **25/25**, including a new `tests/e2e/menu-filter.test.ts` that opens the real suggester and asserts the rendered keys.
- **Live in an isolated Obsidian vault** (DOM eval on the actual right-click menu):
  - hide-tags ON: a note with `tags: [alpha,beta]` + body `#bodytag` shows `tags`/`status`/inline but **not** `#bodytag`; a tags-only note shows just the action options (menu never empty).
  - hide-tags OFF / feature OFF: tags reappear; with the feature off nothing is filtered even when `hideFileTags` and an ignored key are set (the bug-fix).
  - Migration: a realistic pre-version `data.json` round-trips **every** section with no data loss, flips `enabled` for a non-empty list, persists once (no re-trigger after the user later disables), and preserves an unknown future section across the migration save.

## Release / migration impact

`feat:` -> minor release. Existing users: the new `hideFileTags` field is backfilled to `false`; anyone who had ignored keys saved with the feature toggled *off* will have it auto-enabled once (preserving the filtering they were actually getting). No action required.

## Review

Hardened per an adversarial review on the opposing model (3 lenses) - the array-aliasing, unknown-key-drop, and strictly-one-time-migration fixes in the second commit came from that pass.
