### PR TITLE
fix: tolerate malformed YAML frontmatter when parsing note metadata

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it, vi} from "vitest";
+import * as obsidian from "obsidian";
 import {TFile} from "obsidian";
 import MetaEditParser from "./parser";
 import {MetaType} from "./Types/metaType";
@@ -104,6 +105,63 @@ describe("MetaEditParser frontmatter parsing", () => {
 
         const arrayFm = createParser({frontmatter: ["item1", "item2"]}, "");
         await expect(arrayFm.parseFrontmatter(new TFile("array-fm.md"))).resolves.toEqual([]);
+    });
+
+    // #130 follow-up: a note opening with `---` but holding malformed YAML gives
+    // Obsidian no usable frontmatter cache, so the live-parse path is hit. When
+    // `parseYaml` throws there, the parser must swallow it (like the bulk
+    // preflight) instead of aborting the whole note's metadata parse. The shared
+    // obsidian stub's parseYaml is permissive and never throws, so the real
+    // runtime's throw is simulated here to exercise the catch.
+    it("tolerates malformed YAML frontmatter instead of throwing", async () => {
+        const spy = vi.spyOn(obsidian, "parseYaml").mockImplementation(() => {
+            throw new Error("Nested mappings are not allowed in compact mappings");
+        });
+        try {
+            const parser = createParser(null, "---\nstatus: : :\n---\nfoo:: bar\n");
+            await expect(parser.parseFrontmatter(new TFile("malformed-fm.md"))).resolves.toEqual([]);
+            expect(spy).toHaveBeenCalled();
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    // The catch returns null (non-parseable) rather than [] so the existing cache
+    // fallback still runs: if the live text is momentarily unparseable mid-edit
+    // but Obsidian's cache holds the prior valid frontmatter, surface that instead
+    // of dropping the metadata entirely.
+    it("falls back to cached frontmatter when the live parse throws", async () => {
+        const spy = vi.spyOn(obsidian, "parseYaml").mockImplementation(() => {
+            throw new Error("bad yaml");
+        });
+        try {
+            const parser = createParser(
+                {frontmatter: {status: "cached"}},
+                "---\nstatus: : :\n---\nfoo:: bar\n",
+            );
+            await expect(parser.parseFrontmatter(new TFile("malformed-with-cache.md"))).resolves.toEqual([
+                {key: "status", content: "cached", type: MetaType.YAML},
+            ]);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    // The whole point of tolerating bad frontmatter: inline metadata after it must
+    // still surface rather than being lost to the aborted parse. Inline parsing
+    // never calls parseYaml, so the permissive stub is sufficient here.
+    it("still surfaces inline fields when the frontmatter is malformed", async () => {
+        const parser = createParser(null, "---\nstatus: : :\n---\nfoo:: bar\n");
+        await expect(parser.parseInlineFields(new TFile("malformed-fm.md"))).resolves.toEqual([
+            {key: "foo", content: "bar", type: MetaType.Dataview},
+        ]);
+    });
+
+    it("still surfaces inline fields when the malformed frontmatter uses CRLF", async () => {
+        const parser = createParser(null, "---\r\nstatus: : :\r\n---\r\nfoo:: bar\r\n");
+        await expect(parser.parseInlineFields(new TFile("malformed-crlf.md"))).resolves.toEqual([
+            {key: "foo", content: "bar", type: MetaType.Dataview},
+        ]);
     });
 });
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -193,7 +193,15 @@ export default class MetaEditParser {
         if (!frontmatterRange || frontmatterRange.startLine !== 0) return null;
 
         const yamlContent = lines.slice(frontmatterRange.startLine + 1, frontmatterRange.endLine).join("\n");
-        return parseYaml(yamlContent);
+        // Malformed YAML must not abort the whole note's metadata parse: treat it
+        // as non-parseable so parseFrontmatter falls back (to the cache, then to
+        // an empty result) and inline/tag parsing still runs. Mirrors the bulk
+        // preflight's BulkMetadataEditor.readLiveFrontmatter.
+        try {
+            return parseYaml(yamlContent);
+        } catch {
+            return null;
+        }
     }
 
     private parseLineFields(line: string): InlineField[] {

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -160,6 +160,58 @@ describe("MetaEdit runtime", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	// #130 follow-up: a note opening with `---` but holding malformed YAML gives
+	// Obsidian no usable frontmatter cache, so the parser's live-parse fallback is
+	// hit and `parseYaml` throws on the real runtime (the unit stub's parseYaml is
+	// permissive and cannot reproduce this). The throw must not abort the note's
+	// parse: inline `foo:: bar` and the `#mytag` tag still surface.
+	test("surfaces inline and tag metadata when frontmatter YAML is malformed", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("malformed-frontmatter.md");
+		await writeLiveFile(obsidian, notePath, "---\nstatus: : :\n---\nfoo:: bar\n#mytag\n");
+
+		const state = await evalJsonAsync<{
+			frontmatter: unknown;
+			frontmatterPosition: unknown;
+			properties: { key: string; content: unknown; type: number }[];
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				// Tags come from the metadata cache, which Obsidian populates
+				// asynchronously after the file write. Wait until the tag is indexed
+				// so the assertion does not race a slow indexing pass.
+				for (let i = 0; i < 50; i++) {
+					const tags = app.metadataCache.getFileCache(file)?.tags;
+					if (tags?.some((entry) => entry.tag === "#mytag")) break;
+					await new Promise((resolve) => setTimeout(resolve, 100));
+				}
+				const cache = app.metadataCache.getFileCache(file);
+				const props = await plugin.controller.getPropertiesInFile(file);
+				return {
+					frontmatter: cache?.frontmatter ?? null,
+					frontmatterPosition: cache?.frontmatterPosition ?? cache?.frontmatter?.position ?? null,
+					properties: props.map((prop) => ({ key: prop.key, content: prop.content, type: prop.type })),
+				};
+			})()
+		`,
+		);
+
+		// Obsidian reports no usable frontmatter for the malformed block, which is
+		// exactly what routes the parser into the throwing live-parse fallback.
+		expect(state.frontmatter).toBeNull();
+		// The malformed YAML yields no frontmatter properties, but the inline field
+		// and the tag are still surfaced rather than lost to an aborted parse.
+		expect(state.properties).toEqual([
+			{ key: "#mytag", content: "#mytag", type: 2 },
+			{ key: "foo", content: "bar", type: 1 },
+		]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("updates one numeric YAML property without changing its sibling", async () => {
 		const { obsidian, sandbox } = getContext();
 


### PR DESCRIPTION
Tolerate malformed YAML frontmatter so a note's metadata parse never aborts on bad frontmatter; inline `key:: value` fields and tags still surface.

## Why
PR #130 added a live-parse fallback in `parseFrontmatterContent` (`src/parser.ts`) for notes whose frontmatter range Obsidian's metadata cache doesn't report (e.g. a read-after-write race). That path called `parseYaml` **unguarded**. A note starting with `---` whose YAML is malformed - for example:

```
---
status: : :
---
foo:: bar
```

gives Obsidian no usable frontmatter cache, so the live-parse path runs and `parseYaml` throws. The throw propagated out of `parseFrontmatter` -> `controller.getPropertiesInFile()` -> the **Run MetaEdit** command, aborting the parse for the whole note and dropping its inline/tag metadata. The post-merge Codex review on #130 flagged exactly this.

## Fix
Wrap the live `parseYaml` call in `try/catch` and treat malformed YAML as non-parseable (`return null`), mirroring the bulk preflight's `BulkMetadataEditor.readLiveFrontmatter`, which already catches the identical failure. Returning `null` (rather than `[]`) preserves the existing cache fallback chain, so a note that is only momentarily unparseable mid-edit still surfaces its last-known-good cached frontmatter instead of dropping it - consistent with how `parseFrontmatter` already degrades when there is no live frontmatter range.

## Tests
- **Unit** (`src/parser.test.ts`): asserts `parseFrontmatter` swallows a thrown `parseYaml` and resolves to `[]`; that it falls back to cached frontmatter when the live parse throws; and that inline fields still surface (incl. CRLF). The shared obsidian test stub's `parseYaml` is a permissive line parser that never throws, so the throw is simulated with `vi.spyOn`.
- **Live E2E** (`tests/e2e/metaedit-runtime.test.ts`): reproduces the **real** Obsidian throw with `status: : :` and asserts `getPropertiesInFile` returns the inline `foo:: bar` and the `#mytag` tag with no runtime errors. Polls the metadata cache for the tag to avoid an indexing-timing flake.

## Verification
Reproduced live first in an isolated Obsidian E2E vault (Obsidian 1.x): pre-fix `getPropertiesInFile` threw `Nested mappings are not allowed in compact mappings`; post-fix it returns `[#mytag, foo:: bar]` and the Run MetaEdit command opens the suggester without error. Live edge-case sweep (empty frontmatter, only-malformed-key, bad indentation, tab indentation, CRLF, and a valid-frontmatter control) all pass.

Commands run: `pnpm run lint` (0 errors), `pnpm run build`, `pnpm run test` (178 passed), full `tests/e2e` suite (40 passed).

Refs #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)