### PR TITLE
feat: support nested YAML path editing

### DIFF
--- a/src/IMetaEditApi.ts
+++ b/src/IMetaEditApi.ts
@@ -1,9 +1,14 @@
 import type {CachedMetadata, TFile} from "obsidian";
 import type {Property} from "./parser";
 import type {AutoProperty} from "./Types/autoProperty";
+import type {YamlPathSegment} from "./yamlPath";
 
 export type MetaEditPropertyValue = unknown;
 export type MetaEditUnsubscribe = () => void;
+export type MetaEditYamlPath = string | readonly YamlPathSegment[];
+export type MetaEditYamlPathOptions = {
+    createParents?: boolean;
+};
 
 export interface MetaEditMetadataChange {
     file: TFile;
@@ -22,6 +27,9 @@ export interface IMetaEditApi {
     getFilesWithProperty: (propertyName: string) => TFile[];
     createYamlProperty: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
     addOrUpdateProperty: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
+    getYamlPath: (path: MetaEditYamlPath, file: TFile | string) => Promise<any>;
+    updateYamlPath: (path: MetaEditYamlPath, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
+    addOrUpdateYamlPath: (path: MetaEditYamlPath, propertyValue: MetaEditPropertyValue, file: TFile | string, options?: MetaEditYamlPathOptions) => Promise<void>;
     getPropertiesInFile: (file: TFile | string) => Promise<Property[]>;
     getAutoProperties: () => AutoProperty[];
     setAutoProperties: (autoProperties: AutoProperty[]) => Promise<void>;

--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -3,6 +3,8 @@ import type {
     IMetaEditApi,
     MetaEditMetadataChangeCallback,
     MetaEditPropertyValue,
+    MetaEditYamlPath,
+    MetaEditYamlPathOptions,
     MetaEditUnsubscribe,
 } from "./IMetaEditApi";
 import MetaEditParser, {type Property} from "./parser";
@@ -27,6 +29,9 @@ export class MetaEditApi {
             getFilesWithProperty: this.getGetFilesWithPropertyFunction(),
             createYamlProperty: this.getCreateYamlPropertyFunction(),
             addOrUpdateProperty: this.getAddOrUpdatePropertyFunction(),
+            getYamlPath: this.getGetYamlPathFunction(),
+            updateYamlPath: this.getUpdateYamlPathFunction(),
+            addOrUpdateYamlPath: this.getAddOrUpdateYamlPathFunction(),
             getPropertiesInFile: this.getGetPropertiesInFile(),
             getAutoProperties: this.getGetAutoPropertiesFunction(),
             setAutoProperties: this.getSetAutoPropertiesFunction(),
@@ -108,6 +113,38 @@ export class MetaEditApi {
                 key: propertyName,
                 type: MetaType.YAML,
             }, propertyValue, targetFile);
+        }
+    }
+
+    private getGetYamlPathFunction() {
+        return async (path: MetaEditYamlPath, file: TFile | string) => {
+            const targetFile = this.getFileFromTFileOrPath(file);
+            if (!targetFile) return;
+
+            return await this.plugin.controller.getYamlPath(path, targetFile);
+        }
+    }
+
+    private getUpdateYamlPathFunction() {
+        return async (path: MetaEditYamlPath, propertyValue: MetaEditPropertyValue, file: TFile | string) => {
+            const targetFile = this.getFileFromTFileOrPath(file);
+            if (!targetFile) return;
+
+            await this.plugin.controller.updateYamlPath(path, propertyValue, targetFile);
+        }
+    }
+
+    private getAddOrUpdateYamlPathFunction() {
+        return async (
+            path: MetaEditYamlPath,
+            propertyValue: MetaEditPropertyValue,
+            file: TFile | string,
+            options?: MetaEditYamlPathOptions,
+        ) => {
+            const targetFile = this.getFileFromTFileOrPath(file);
+            if (!targetFile) return;
+
+            await this.plugin.controller.addOrUpdateYamlPath(path, propertyValue, targetFile, options);
         }
     }
 
@@ -220,7 +257,8 @@ export class MetaEditApi {
 
     private async getPropertyInFile(propertyName: string, file: TFile): Promise<Property | undefined> {
         const propsInFile: Property[] = await this.plugin.controller.getPropertiesInFile(file);
-        return propsInFile.find(prop => prop.key === propertyName);
+        return propsInFile.find(prop => prop.key === propertyName && !prop.isVirtual) ??
+            propsInFile.find(prop => prop.key === propertyName && prop.isVirtual && prop.type === MetaType.YAML);
     }
 
     private cloneAutoProperties(autoProperties: AutoProperty[]): AutoProperty[] {
@@ -278,11 +316,18 @@ export class MetaEditApi {
     }
 
     private cloneProperties(properties: Property[]): Property[] {
-        return properties.map(property => ({
-            key: property.key,
-            type: property.type,
-            content: this.cloneValue(property.content),
-        }));
+        return properties.map(property => {
+            const clone: Property = {
+                key: property.key,
+                type: property.type,
+                content: this.cloneValue(property.content),
+            };
+            if (property.path) clone.path = [...property.path];
+            if (property.rootKey !== undefined) clone.rootKey = property.rootKey;
+            if (property.isNested !== undefined) clone.isNested = property.isNested;
+            if (property.isVirtual !== undefined) clone.isVirtual = property.isVirtual;
+            return clone;
+        });
     }
 
     private getPropertiesFromEvent(data: string, cache: CachedMetadata): Property[] {
@@ -325,6 +370,10 @@ export class MetaEditApi {
             key: property.key,
             type: property.type,
             content: property.content,
+            path: property.path,
+            rootKey: property.rootKey,
+            isNested: property.isNested,
+            isVirtual: property.isVirtual,
         })));
     }
 }

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -8,6 +8,7 @@ import type {AutoProperty} from "../Types/autoProperty";
 import {getKnownPropertyNames} from "./GenericPrompt/valueSuggest";
 import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
 import {filterMenuItems} from "./menuFilter";
+import {isPlainYamlObject} from "../yamlPath";
 
 export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     public app: App;
@@ -28,7 +29,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
             enabled: ignored.enabled,
             ignoredProperties: ignored.properties,
             hideFileTags: ignored.hideFileTags,
-        });
+        }).filter(item => !MetaEditSuggester.isYamlParentContainer(item));
         this.controller = controller;
         this.options = MAIN_SUGGESTER_OPTIONS;
 
@@ -46,8 +47,10 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
         if (Object.values(this.options).find(v => v === item.item)) {
             el.style.fontWeight = "bold";
         } else {
-            this.createButton(el,"❌", this.deleteItem(item));
-            this.createButton(el, "🔃", this.transformProperty(item))
+            if (MetaEditSuggester.canStructureEdit(item.item)) {
+                this.createButton(el,"❌", this.deleteItem(item));
+                this.createButton(el, "🔃", this.transformProperty(item))
+            }
         }
     }
 
@@ -78,6 +81,8 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
             return;
         }
 
+        if (MetaEditSuggester.isYamlParentContainer(item)) return;
+
         // Hand the prompt the property it is editing so it can offer value
         // autocomplete and a native date picker, without routing UI concerns
         // through the controller's write/parse core. Cleared in finally so it
@@ -102,6 +107,8 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
         return async (evt: MouseEvent | KeyboardEvent) => {
             evt.stopPropagation();
             const {item: property} = item;
+            if (!MetaEditSuggester.canStructureEdit(property)) return;
+
             if (property.type === MetaType.YAML) {
                 await this.toDataview(property);
             } else {
@@ -129,6 +136,18 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
         itemButton.style.float = "right";
         itemButton.style.marginRight = "4px";
         itemButton.addEventListener("click", callback);
+    }
+
+    private static canStructureEdit(property: Property): boolean {
+        return !property.isNested && !property.isVirtual;
+    }
+
+    private static isYamlParentContainer(property: Property): boolean {
+        if (property.type !== MetaType.YAML || property.isVirtual) return false;
+        if (isPlainYamlObject(property.content)) return true;
+        if (!Array.isArray(property.content)) return false;
+
+        return property.content.some(item => isPlainYamlObject(item) || Array.isArray(item));
     }
 
     private setSuggestValues() {

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -8,7 +8,7 @@ import type {AutoProperty} from "../Types/autoProperty";
 import {getKnownPropertyNames} from "./GenericPrompt/valueSuggest";
 import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
 import {filterMenuItems} from "./menuFilter";
-import {isPlainYamlObject} from "../yamlPath";
+import {isYamlParentContainerValue} from "../yamlPath";
 
 export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     public app: App;
@@ -144,10 +144,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
 
     private static isYamlParentContainer(property: Property): boolean {
         if (property.type !== MetaType.YAML || property.isVirtual) return false;
-        if (isPlainYamlObject(property.content)) return true;
-        if (!Array.isArray(property.content)) return false;
-
-        return property.content.some(item => isPlainYamlObject(item) || Array.isArray(item));
+        return isYamlParentContainerValue(property.content);
     }
 
     private setSuggestValues() {

--- a/src/automators/onFileModifyAutomators/kanbanHelper.ts
+++ b/src/automators/onFileModifyAutomators/kanbanHelper.ts
@@ -115,7 +115,7 @@ export class KanbanHelper extends OnFileModifyAutomator {
 
     private async updateFileInBoard(linkFile: TFile, board: KanbanProperty, lane: string): Promise<void> {
         const fileProperties: Property[] = await this.plugin.controller.getPropertiesInFile(linkFile);
-        const targetProperty = fileProperties.find(prop => prop.key === board.property);
+        const targetProperty = fileProperties.find(prop => prop.key === board.property && !prop.isVirtual);
         if (!targetProperty) {
             // Only real card notes reach this point, so the warning is now actionable.
             const message = `'${board.property}' not found in "${linkFile.basename}" (Kanban board '${board.boardName}').`;

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -13,7 +13,7 @@ import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoProperty
 import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
-import {getYamlPath, isPlainYamlObject, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
+import {getYamlPath, isYamlParentContainerValue, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
 const ADD_FIRST_SELECTION = "metaedit:multi-value:add-first";
@@ -148,7 +148,7 @@ export default class MetaController {
         }
 
         if (newValue) {
-            await this.updatePropertyInFile(property, newValue, file);
+            await this.updatePropertyFromUi(property, newValue, file);
         }
     }
 
@@ -238,7 +238,7 @@ export default class MetaController {
         const newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`, property.content, property.content);
 
         if (newValue) {
-            await this.updatePropertyInFile(property, newValue, file);
+            await this.updatePropertyFromUi(property, newValue, file);
         }
     }
 
@@ -309,8 +309,7 @@ export default class MetaController {
         // scalars routed here by EditMode stay scalar strings.
         const newValue: unknown = editsArray ? newList : newList.join(", ");
 
-        await this.updatePropertyInFile(property, newValue, file);
-        return true;
+        return await this.updatePropertyFromUi(property, newValue, file);
     }
 
     private getActiveAutoProperty(propertyName: string): AutoProperty | undefined {
@@ -344,7 +343,7 @@ export default class MetaController {
         const newValue: unknown =
             Array.isArray(result) && property.type !== MetaType.YAML ? result.join(", ") : result;
 
-        await this.updatePropertyInFile(property, newValue, file);
+        await this.updatePropertyFromUi(property, newValue, file);
     }
 
     private async persistAutoPropertyChoices(autoProp: AutoProperty, values: string[]): Promise<void> {
@@ -373,7 +372,12 @@ export default class MetaController {
             if (property.type === MetaType.YAML) {
                 await this.processFrontMatter(file, (frontmatter) => {
                     if (property.path && property.path.length > 1) {
-                        setYamlPath(frontmatter, property.path, newValue, {createParents: false});
+                        setYamlPath(frontmatter, property.path, newValue, {
+                            createParents: false,
+                            createLeaf: false,
+                            expectedValue: property.content,
+                            validateExpectedValue: true,
+                        });
                     } else {
                         frontmatter[property.key] = newValue;
                     }
@@ -490,12 +494,21 @@ export default class MetaController {
         return toValueArray(property.content);
     }
 
+    private async updatePropertyFromUi(property: Property, newValue: unknown, file: TFile): Promise<boolean> {
+        try {
+            await this.updatePropertyInFile(property, newValue, file);
+            return true;
+        } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            new Notice(`MetaEdit could not update '${property.key}': ${reason}`);
+            log.logMessage(`MetaEdit could not update '${property.key}': ${reason}`);
+            return false;
+        }
+    }
+
     private isYamlParentContainer(property: Property): boolean {
         if (property.type !== MetaType.YAML || property.isVirtual) return false;
-        if (isPlainYamlObject(property.content)) return true;
-        if (!Array.isArray(property.content)) return false;
-
-        return property.content.some(item => isPlainYamlObject(item) || Array.isArray(item));
+        return isYamlParentContainerValue(property.content);
     }
 
     public async getYamlPath(path: string | readonly YamlPathSegment[], file: TFile): Promise<unknown> {
@@ -516,7 +529,7 @@ export default class MetaController {
 
         await this.enqueueFileWrite(file, async () => {
             await this.processFrontMatter(file, (frontmatter) => {
-                setYamlPath(frontmatter, resolvedPath, value, {createParents: false});
+                setYamlPath(frontmatter, resolvedPath, value, {createParents: false, createLeaf: false});
             });
         });
     }

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -13,7 +13,7 @@ import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoProperty
 import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
-import {getYamlPath, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
+import {getYamlPath, isPlainYamlObject, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
 const ADD_FIRST_SELECTION = "metaedit:multi-value:add-first";
@@ -96,6 +96,11 @@ export default class MetaController {
     public async editMetaElement(property: Property, meta: Property[], file: TFile): Promise<void> {
         if (property.type === MetaType.Tag) {
             await this.editTag(property, file);
+            return;
+        }
+
+        if (this.isYamlParentContainer(property)) {
+            new Notice(`Nested YAML parent '${property.key}' cannot be edited as a text value.`);
             return;
         }
 
@@ -188,7 +193,7 @@ export default class MetaController {
     }
 
     public async deleteProperty(property: Property, file: TFile): Promise<void> {
-        if (property.type === MetaType.YAML && property.isNested) {
+        if (property.type === MetaType.YAML && (property.isNested || property.isVirtual)) {
             new Notice(`Nested YAML property '${property.key}' cannot be deleted by MetaEdit yet.`);
             return;
         }
@@ -483,6 +488,14 @@ export default class MetaController {
 
     private splitMultiValue(property: Partial<Property>): string[] {
         return toValueArray(property.content);
+    }
+
+    private isYamlParentContainer(property: Property): boolean {
+        if (property.type !== MetaType.YAML || property.isVirtual) return false;
+        if (isPlainYamlObject(property.content)) return true;
+        if (!Array.isArray(property.content)) return false;
+
+        return property.content.some(item => isPlainYamlObject(item) || Array.isArray(item));
     }
 
     public async getYamlPath(path: string | readonly YamlPathSegment[], file: TFile): Promise<unknown> {

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -13,6 +13,7 @@ import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoProperty
 import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
+import {getYamlPath, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
 const ADD_FIRST_SELECTION = "metaedit:multi-value:add-first";
@@ -187,6 +188,11 @@ export default class MetaController {
     }
 
     public async deleteProperty(property: Property, file: TFile): Promise<void> {
+        if (property.type === MetaType.YAML && property.isNested) {
+            new Notice(`Nested YAML property '${property.key}' cannot be deleted by MetaEdit yet.`);
+            return;
+        }
+
         const fileContent = await this.app.vault.read(file);
         const splitContent = fileContent.split("\n");
         const regexp = new RegExp(`^\s*${property.key}:`);
@@ -361,7 +367,11 @@ export default class MetaController {
         await this.enqueueFileWrite(file, async () => {
             if (property.type === MetaType.YAML) {
                 await this.processFrontMatter(file, (frontmatter) => {
-                    frontmatter[property.key] = newValue;
+                    if (property.path && property.path.length > 1) {
+                        setYamlPath(frontmatter, property.path, newValue, {createParents: false});
+                    } else {
+                        frontmatter[property.key] = newValue;
+                    }
                 });
                 return;
             }
@@ -436,7 +446,7 @@ export default class MetaController {
 
     private async updateMultipleInFile(properties: Property[], file: TFile): Promise<void> {
         await this.enqueueFileWrite(file, async () => {
-            const yamlProperties = properties.filter(prop => prop.type === MetaType.YAML);
+            const yamlProperties = properties.filter(prop => prop.type === MetaType.YAML && !prop.isVirtual);
             const textProperties = properties.filter(prop => prop.type !== MetaType.YAML);
 
             if (yamlProperties.length > 0) {
@@ -473,6 +483,45 @@ export default class MetaController {
 
     private splitMultiValue(property: Partial<Property>): string[] {
         return toValueArray(property.content);
+    }
+
+    public async getYamlPath(path: string | readonly YamlPathSegment[], file: TFile): Promise<unknown> {
+        const resolvedPath = parseYamlPath(path);
+        const frontmatter = await this.parser.parseFrontmatterObject(file);
+        if (!frontmatter) return undefined;
+
+        try {
+            return getYamlPath(frontmatter, resolvedPath);
+        } catch (error) {
+            if (error instanceof YamlPathError) return undefined;
+            throw error;
+        }
+    }
+
+    public async updateYamlPath(path: string | readonly YamlPathSegment[], value: unknown, file: TFile): Promise<void> {
+        const resolvedPath = parseYamlPath(path);
+
+        await this.enqueueFileWrite(file, async () => {
+            await this.processFrontMatter(file, (frontmatter) => {
+                setYamlPath(frontmatter, resolvedPath, value, {createParents: false});
+            });
+        });
+    }
+
+    public async addOrUpdateYamlPath(
+        path: string | readonly YamlPathSegment[],
+        value: unknown,
+        file: TFile,
+        options: SetYamlPathOptions = {},
+    ): Promise<void> {
+        const resolvedPath = parseYamlPath(path);
+        const createParents = options.createParents ?? true;
+
+        await this.enqueueFileWrite(file, async () => {
+            await this.processFrontMatter(file, (frontmatter) => {
+                setYamlPath(frontmatter, resolvedPath, value, {createParents});
+            });
+        });
     }
 
     private async processFrontMatter(file: TFile, update: (frontmatter: Record<string, unknown>) => void): Promise<void> {

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -455,13 +455,17 @@ export default class MetaController {
 
     private async updateMultipleInFile(properties: Property[], file: TFile): Promise<void> {
         await this.enqueueFileWrite(file, async () => {
-            const yamlProperties = properties.filter(prop => prop.type === MetaType.YAML && !prop.isVirtual);
+            const yamlProperties = properties.filter(prop => prop.type === MetaType.YAML && !prop.path);
+            const yamlPathProperties = properties.filter(prop => prop.type === MetaType.YAML && prop.path);
             const textProperties = properties.filter(prop => prop.type !== MetaType.YAML);
 
-            if (yamlProperties.length > 0) {
+            if (yamlProperties.length > 0 || yamlPathProperties.length > 0) {
                 await this.processFrontMatter(file, (frontmatter) => {
                     for (const prop of yamlProperties) {
                         frontmatter[prop.key] = prop.content;
+                    }
+                    for (const prop of yamlPathProperties) {
+                        setYamlPath(frontmatter, prop.path, prop.content, {createParents: false, createLeaf: false});
                     }
                 });
             }

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -97,6 +97,101 @@ describe("MetaEditParser frontmatter parsing", () => {
         ]);
     });
 
+    it("keeps root YAML rows and adds virtual nested scalar leaf rows", async () => {
+        const file = new TFile("nested.md");
+        const parser = createParser(
+            {
+                frontmatter: {
+                    metadata: {description: "old"},
+                    attributes: {one: "something", two: 12345},
+                    contributors: [
+                        {name: "Ada", role: "Writer"},
+                        {name: "Bob", role: "Editor"},
+                    ],
+                    tags: ["alpha", "beta"],
+                },
+            },
+            "",
+        );
+
+        await expect(parser.parseFrontmatter(file)).resolves.toEqual([
+            {key: "metadata", content: {description: "old"}, type: MetaType.YAML},
+            {key: "attributes", content: {one: "something", two: 12345}, type: MetaType.YAML},
+            {
+                key: "contributors",
+                content: [
+                    {name: "Ada", role: "Writer"},
+                    {name: "Bob", role: "Editor"},
+                ],
+                type: MetaType.YAML,
+            },
+            {key: "tags", content: ["alpha", "beta"], type: MetaType.YAML},
+            {
+                key: "metadata.description",
+                content: "old",
+                type: MetaType.YAML,
+                path: ["metadata", "description"],
+                rootKey: "metadata",
+                isNested: true,
+                isVirtual: true,
+            },
+            {
+                key: "attributes.one",
+                content: "something",
+                type: MetaType.YAML,
+                path: ["attributes", "one"],
+                rootKey: "attributes",
+                isNested: true,
+                isVirtual: true,
+            },
+            {
+                key: "attributes.two",
+                content: 12345,
+                type: MetaType.YAML,
+                path: ["attributes", "two"],
+                rootKey: "attributes",
+                isNested: true,
+                isVirtual: true,
+            },
+            {
+                key: "contributors[0].name",
+                content: "Ada",
+                type: MetaType.YAML,
+                path: ["contributors", 0, "name"],
+                rootKey: "contributors",
+                isNested: true,
+                isVirtual: true,
+            },
+            {
+                key: "contributors[0].role",
+                content: "Writer",
+                type: MetaType.YAML,
+                path: ["contributors", 0, "role"],
+                rootKey: "contributors",
+                isNested: true,
+                isVirtual: true,
+            },
+            {
+                key: "contributors[1].name",
+                content: "Bob",
+                type: MetaType.YAML,
+                path: ["contributors", 1, "name"],
+                rootKey: "contributors",
+                isNested: true,
+                isVirtual: true,
+            },
+            {
+                key: "contributors[1].role",
+                content: "Editor",
+                type: MetaType.YAML,
+                path: ["contributors", 1, "role"],
+                rootKey: "contributors",
+                isNested: true,
+                isVirtual: true,
+            },
+        ]);
+    });
+
     // #85: `tags:value` (and other non-mapping frontmatter) must not be walked
     // with `for..in`, which would surface string/array indices like `0:value`.
     it("ignores non-mapping frontmatter instead of emitting index keys (#85)", async () => {
@@ -177,6 +272,12 @@ describe("MetaEditParser inline field parsing", () => {
             {key: "progress (%)", content: "old", type: MetaType.Dataview},
             {key: "my-key", content: "value", type: MetaType.Dataview},
             {key: "status", content: "complete", type: MetaType.Dataview},
+        ]);
+    });
+
+    it("keeps dotted inline keys as exact Dataview keys, not YAML paths", () => {
+        expect(new MetaEditParser({} as any).parseInlineContent("author.name:: inline old")).toEqual([
+            {key: "author.name", content: "inline old", type: MetaType.Dataview},
         ]);
     });
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,8 +1,17 @@
 import type {App, CachedMetadata, Loc, TFile} from "obsidian";
 import {parseYaml} from "obsidian";
 import {MetaType} from "./Types/metaType";
+import {formatYamlPath, isPlainYamlObject, isYamlScalarLeaf, type YamlPath, type YamlPathSegment} from "./yamlPath";
 
-export type Property = {key: string, content: any, type: MetaType};
+export type Property = {
+	key: string,
+	content: any,
+	type: MetaType,
+	path?: YamlPath,
+	rootKey?: string,
+	isNested?: boolean,
+	isVirtual?: boolean,
+};
 export type FrontmatterPosition = {start: Loc, end: Loc};
 // `start`/`end` are the field's span in the line; `sepEnd` is the offset just
 // after `::`; `valueEnd` is where the value content ends (the closing bracket
@@ -45,16 +54,10 @@ export default class MetaEditParser {
     }
 
     public async parseFrontmatter(file: TFile): Promise<Property[]> {
-        const fileCache = this.app.metadataCache.getFileCache(file);
-        const frontmatterPosition = this.getFrontmatterPosition(fileCache);
-        const filecontent = await this.app.vault.cachedRead(file);
-        const parsedYaml = this.parseFrontmatterContent(filecontent, frontmatterPosition);
-        if (parsedYaml !== null) return this.objectToYamlProperties(parsedYaml);
-
-        const frontmatter = fileCache?.frontmatter;
+        const frontmatter = await this.parseFrontmatterObject(file);
         if (!frontmatter) return [];
 
-        return this.objectToYamlProperties(frontmatter, true);
+        return this.objectToYamlProperties(frontmatter);
     }
 
     public parseFrontmatterCache(fileCache: CachedMetadata | null | undefined): Property[] {
@@ -62,6 +65,19 @@ export default class MetaEditParser {
         if (!frontmatter) return [];
 
         return this.objectToYamlProperties(frontmatter, true);
+    }
+
+    public async parseFrontmatterObject(file: TFile): Promise<Record<string, unknown> | null> {
+        const fileCache = this.app.metadataCache.getFileCache(file);
+        const frontmatterPosition = this.getFrontmatterPosition(fileCache);
+        const filecontent = await this.app.vault.cachedRead(file);
+        const parsedYaml = this.parseFrontmatterContent(filecontent, frontmatterPosition);
+        if (this.isFrontmatterObject(parsedYaml)) return parsedYaml;
+
+        const frontmatter = fileCache?.frontmatter;
+        if (this.isFrontmatterObject(frontmatter)) return this.omitInternalFrontmatterPosition(frontmatter);
+
+        return null;
     }
 
     public getFrontmatterPosition(fileCache: CachedMetadata | null | undefined): FrontmatterPosition | null {
@@ -92,22 +108,69 @@ export default class MetaEditParser {
             typeof candidate.offset === "number";
     }
 
+    private isFrontmatterObject(value: unknown): value is Record<string, unknown> {
+        return isPlainYamlObject(value);
+    }
+
+    private omitInternalFrontmatterPosition(frontmatter: Record<string, unknown>): Record<string, unknown> {
+        if (!this.isFrontmatterPosition(frontmatter.position)) return frontmatter;
+
+        const cleaned = {...frontmatter};
+        delete cleaned.position;
+        return cleaned;
+    }
+
     private objectToYamlProperties(parsedYaml: unknown, omitInternalPosition: boolean = false): Property[] {
         // Frontmatter is only meaningful as a mapping. Malformed YAML (a bare
         // scalar, a top-level sequence, null) must not be walked with `for..in`,
         // which would surface array/string indices like `0:value` (#85).
-        if (!parsedYaml || typeof parsedYaml !== "object" || Array.isArray(parsedYaml)) return [];
+        if (!this.isFrontmatterObject(parsedYaml)) return [];
 
-        const metaYaml: Property[] = [];
+        const rootProperties: Property[] = [];
+        const nestedProperties: Property[] = [];
 
         for (const key in parsedYaml as Record<string, unknown>) {
             const value = (parsedYaml as Record<string, unknown>)[key];
             if (omitInternalPosition && key === "position" && this.isFrontmatterPosition(value)) continue;
 
-            metaYaml.push({key, content: value, type: MetaType.YAML});
+            rootProperties.push({key, content: value, type: MetaType.YAML});
+            this.collectNestedYamlProperties(value, [key], nestedProperties);
         }
 
-        return metaYaml;
+        return [...rootProperties, ...nestedProperties];
+    }
+
+    private collectNestedYamlProperties(value: unknown, path: YamlPath, properties: Property[]): void {
+        if (isYamlScalarLeaf(value)) {
+            if (path.length > 1 && !this.isRootArrayScalarItem(path)) {
+                const rootKey = String(path[0]);
+                properties.push({
+                    key: formatYamlPath(path),
+                    content: value,
+                    type: MetaType.YAML,
+                    path: [...path],
+                    rootKey,
+                    isNested: true,
+                    isVirtual: true,
+                });
+            }
+            return;
+        }
+
+        if (Array.isArray(value)) {
+            value.forEach((item, idx) => this.collectNestedYamlProperties(item, [...path, idx], properties));
+            return;
+        }
+
+        if (isPlainYamlObject(value)) {
+            for (const key in value) {
+                this.collectNestedYamlProperties(value[key], [...path, key], properties);
+            }
+        }
+    }
+
+    private isRootArrayScalarItem(path: readonly YamlPathSegment[]): boolean {
+        return path.length === 2 && typeof path[1] === "number";
     }
 
     public async parseInlineFields(file: TFile): Promise<Property[]> {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import type {App, CachedMetadata, Loc, TFile} from "obsidian";
 import {parseYaml} from "obsidian";
 import {MetaType} from "./Types/metaType";
-import {formatYamlPath, isPlainYamlObject, isYamlScalarLeaf, type YamlPath, type YamlPathSegment} from "./yamlPath";
+import {formatYamlPath, isPlainYamlObject, isYamlScalarLeaf, type YamlPath} from "./yamlPath";
 
 export type Property = {
 	key: string,
@@ -142,7 +142,7 @@ export default class MetaEditParser {
 
     private collectNestedYamlProperties(value: unknown, path: YamlPath, properties: Property[]): void {
         if (isYamlScalarLeaf(value)) {
-            if (path.length > 1 && !this.isRootArrayScalarItem(path)) {
+            if (path.length > 1 && typeof path[path.length - 1] !== "number") {
                 const rootKey = String(path[0]);
                 properties.push({
                     key: formatYamlPath(path),
@@ -167,10 +167,6 @@ export default class MetaEditParser {
                 this.collectNestedYamlProperties(value[key], [...path, key], properties);
             }
         }
-    }
-
-    private isRootArrayScalarItem(path: readonly YamlPathSegment[]): boolean {
-        return path.length === 2 && typeof path[1] === "number";
     }
 
     public async parseInlineFields(file: TFile): Promise<Property[]> {

--- a/src/yamlPath.test.ts
+++ b/src/yamlPath.test.ts
@@ -2,7 +2,6 @@ import {describe, expect, it} from "vitest";
 import {
 	formatYamlPath,
 	getYamlPath,
-	hasYamlPath,
 	parseYamlPath,
 	setYamlPath,
 	YamlPathError,
@@ -27,8 +26,7 @@ describe("YAML path helpers", () => {
 
 		expect(getYamlPath(root, "metadata.description")).toBe("old");
 		expect(getYamlPath(root, ["contributors", 1, "role"])).toBe("Editor");
-		expect(hasYamlPath(root, "contributors[0].name")).toBe(true);
-		expect(hasYamlPath(root, "contributors[2].name")).toBe(false);
+		expect(() => getYamlPath(root, "contributors[2].name")).toThrow(YamlPathError);
 	});
 
 	it("updates existing paths without replacing siblings", () => {
@@ -63,6 +61,36 @@ describe("YAML path helpers", () => {
 		setYamlPath(root, "publisher.name", "Meta House", {createParents: true});
 
 		expect(root).toEqual({publisher: {name: "Meta House"}});
+	});
+
+	it("can require an existing leaf for update-style writes", () => {
+		const root = {
+			metadata: {description: "old"},
+		};
+
+		expect(() => setYamlPath(root, "metadata.descrption", "typo", {createLeaf: false}))
+			.toThrow("does not exist");
+
+		setYamlPath(root, "metadata.description", "new", {createLeaf: false});
+
+		expect(root).toEqual({metadata: {description: "new"}});
+	});
+
+	it("rejects stale update-style writes when the current value changed", () => {
+		const root = {
+			contributors: [
+				{name: "Ada", role: "Writer"},
+				{name: "Bob", role: "Editor"},
+			],
+		};
+
+		expect(() => setYamlPath(root, "contributors[1].role", "Proofreader", {
+			createLeaf: false,
+			expectedValue: "Writer",
+			validateExpectedValue: true,
+		})).toThrow("current value changed");
+
+		expect(root.contributors[1].role).toBe("Editor");
 	});
 
 	it("rejects scalar parents and out-of-range array writes", () => {

--- a/src/yamlPath.test.ts
+++ b/src/yamlPath.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, it} from "vitest";
+import {
+	formatYamlPath,
+	getYamlPath,
+	hasYamlPath,
+	parseYamlPath,
+	setYamlPath,
+	YamlPathError,
+} from "./yamlPath";
+
+describe("YAML path helpers", () => {
+	it("parses and formats dotted object paths with numeric array indexes", () => {
+		const path = parseYamlPath("contributors[1].role");
+
+		expect(path).toEqual(["contributors", 1, "role"]);
+		expect(formatYamlPath(path)).toBe("contributors[1].role");
+	});
+
+	it("reads existing object and array paths", () => {
+		const root = {
+			metadata: {description: "old"},
+			contributors: [
+				{name: "Ada", role: "Writer"},
+				{name: "Bob", role: "Editor"},
+			],
+		};
+
+		expect(getYamlPath(root, "metadata.description")).toBe("old");
+		expect(getYamlPath(root, ["contributors", 1, "role"])).toBe("Editor");
+		expect(hasYamlPath(root, "contributors[0].name")).toBe(true);
+		expect(hasYamlPath(root, "contributors[2].name")).toBe(false);
+	});
+
+	it("updates existing paths without replacing siblings", () => {
+		const root = {
+			metadata: {description: "old", scope: "personal"},
+			attributes: {one: "something", two: 12345},
+			contributors: [
+				{name: "Ada", role: "Writer"},
+				{name: "Bob", role: "Editor"},
+			],
+		};
+
+		setYamlPath(root, "metadata.description", "test");
+		setYamlPath(root, "attributes.one", "changed");
+		setYamlPath(root, ["contributors", 1, "role"], "Proofreader");
+
+		expect(root).toEqual({
+			metadata: {description: "test", scope: "personal"},
+			attributes: {one: "changed", two: 12345},
+			contributors: [
+				{name: "Ada", role: "Writer"},
+				{name: "Bob", role: "Proofreader"},
+			],
+		});
+	});
+
+	it("creates missing object parents only when requested", () => {
+		const root: Record<string, unknown> = {};
+
+		expect(() => setYamlPath(root, "publisher.name", "Meta House")).toThrow(YamlPathError);
+
+		setYamlPath(root, "publisher.name", "Meta House", {createParents: true});
+
+		expect(root).toEqual({publisher: {name: "Meta House"}});
+	});
+
+	it("rejects scalar parents and out-of-range array writes", () => {
+		const root = {
+			rating: "4",
+			contributors: [{name: "Ada"}],
+		};
+
+		expect(() => setYamlPath(root, "rating.stars", 5, {createParents: true}))
+			.toThrow("rating");
+		expect(() => setYamlPath(root, "contributors[1].role", "Editor", {createParents: true}))
+			.toThrow("out of range");
+	});
+
+	it("does not create arrays from missing parents", () => {
+		const root: Record<string, unknown> = {};
+
+		expect(() => setYamlPath(root, "contributors[0].role", "Writer", {createParents: true}))
+			.toThrow("Array creation is not supported");
+		expect(root).toEqual({});
+	});
+
+	it("supports literal dotted segment names through array paths", () => {
+		const root: Record<string, unknown> = {
+			metadata: {"child.with.dot": "old"},
+		};
+
+		setYamlPath(root, ["metadata", "child.with.dot"], "new");
+
+		expect(getYamlPath(root, ["metadata", "child.with.dot"])).toBe("new");
+		expect(root).toEqual({metadata: {"child.with.dot": "new"}});
+	});
+});

--- a/src/yamlPath.ts
+++ b/src/yamlPath.ts
@@ -3,6 +3,9 @@ export type YamlPath = YamlPathSegment[];
 
 export interface SetYamlPathOptions {
 	createParents?: boolean;
+	createLeaf?: boolean;
+	expectedValue?: unknown;
+	validateExpectedValue?: boolean;
 }
 
 export class YamlPathError extends Error {
@@ -36,16 +39,6 @@ export function formatYamlPath(path: readonly YamlPathSegment[]): string {
 	}, "");
 }
 
-export function hasYamlPath(root: unknown, path: string | readonly YamlPathSegment[]): boolean {
-	const resolvedPath = parseYamlPath(path);
-	try {
-		getYamlPath(root, resolvedPath);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 export function getYamlPath(root: unknown, path: string | readonly YamlPathSegment[]): unknown {
 	const resolvedPath = parseYamlPath(path);
 	let current = root;
@@ -77,6 +70,7 @@ export function setYamlPath(
 			}
 
 			if (isLeaf) {
+				validateLeafWrite(current, segment, resolvedPath, options);
 				current[segment] = value;
 				return;
 			}
@@ -97,6 +91,7 @@ export function setYamlPath(
 		}
 
 		if (isLeaf) {
+			validateLeafWrite(current, segment, resolvedPath, options);
 			current[segment] = value;
 			return;
 		}
@@ -114,18 +109,11 @@ export function isYamlScalarLeaf(value: unknown): boolean {
 	return !isPlainYamlObject(value) && !Array.isArray(value);
 }
 
-export function hasNestedYamlLeaves(value: unknown): boolean {
-	if (isYamlScalarLeaf(value)) return false;
+export function isYamlParentContainerValue(value: unknown): boolean {
+	if (isPlainYamlObject(value)) return true;
+	if (!Array.isArray(value)) return false;
 
-	if (Array.isArray(value)) {
-		return value.some(item => isYamlScalarLeaf(item) || hasNestedYamlLeaves(item));
-	}
-
-	if (isPlainYamlObject(value)) {
-		return Object.values(value).some(item => isYamlScalarLeaf(item) || hasNestedYamlLeaves(item));
-	}
-
-	return false;
+	return value.some(item => isPlainYamlObject(item) || Array.isArray(item));
 }
 
 function readPathPart(part: string, originalPath: string, segments: YamlPath): void {
@@ -184,4 +172,32 @@ function createMissingParent(options: SetYamlPathOptions, nextSegment: YamlPathS
 
 function arrayIndexExists(array: unknown[], index: number): boolean {
 	return index >= 0 && index < array.length && Object.prototype.hasOwnProperty.call(array, index);
+}
+
+function validateLeafWrite(
+	current: Record<string, unknown> | unknown[],
+	segment: YamlPathSegment,
+	path: readonly YamlPathSegment[],
+	options: SetYamlPathOptions,
+): void {
+	const exists = typeof segment === "number"
+		? arrayIndexExists(current as unknown[], segment)
+		: Object.prototype.hasOwnProperty.call(current, segment);
+	const label = formatYamlPath(path);
+
+	if (!exists && options.createLeaf === false) {
+		throw new YamlPathError(`Cannot write YAML path '${label}': path does not exist.`);
+	}
+
+	const currentValue = typeof segment === "number"
+		? (current as unknown[])[segment]
+		: (current as Record<string, unknown>)[segment];
+	if (exists && options.validateExpectedValue && !yamlValuesEqual(currentValue, options.expectedValue)) {
+		throw new YamlPathError(`Cannot write YAML path '${label}': current value changed before update.`);
+	}
+}
+
+function yamlValuesEqual(left: unknown, right: unknown): boolean {
+	if (left instanceof Date && right instanceof Date) return left.getTime() === right.getTime();
+	return Object.is(left, right);
 }

--- a/src/yamlPath.ts
+++ b/src/yamlPath.ts
@@ -30,7 +30,7 @@ export function parseYamlPath(path: string | readonly YamlPathSegment[]): YamlPa
 
 export function formatYamlPath(path: readonly YamlPathSegment[]): string {
 	const validated = validateYamlPath(path);
-	return validated.reduce((label, segment) => {
+	return validated.reduce<string>((label, segment) => {
 		if (typeof segment === "number") return `${label}[${segment}]`;
 		return label ? `${label}.${segment}` : segment;
 	}, "");
@@ -148,7 +148,6 @@ function validateYamlPath(path: readonly YamlPathSegment[]): YamlPath {
 	return path.map(segment => {
 		if (typeof segment === "string") {
 			if (!segment) throw new YamlPathError("YAML path string segments cannot be empty.");
-			if (segment.includes(".")) throw new YamlPathError(`YAML path segment '${segment}' cannot contain dots.`);
 			return segment;
 		}
 

--- a/src/yamlPath.ts
+++ b/src/yamlPath.ts
@@ -1,0 +1,188 @@
+export type YamlPathSegment = string | number;
+export type YamlPath = YamlPathSegment[];
+
+export interface SetYamlPathOptions {
+	createParents?: boolean;
+}
+
+export class YamlPathError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "YamlPathError";
+	}
+}
+
+export function parseYamlPath(path: string | readonly YamlPathSegment[]): YamlPath {
+	if (Array.isArray(path)) return validateYamlPath(path);
+	if (typeof path !== "string") throw new YamlPathError("YAML path must be a string or path segment array.");
+
+	const trimmed = path.trim();
+	if (!trimmed) throw new YamlPathError("YAML path cannot be empty.");
+
+	const segments: YamlPath = [];
+	for (const part of trimmed.split(".")) {
+		if (!part) throw new YamlPathError(`Invalid YAML path '${path}'. Empty path segments are not supported.`);
+		readPathPart(part, path, segments);
+	}
+
+	return validateYamlPath(segments);
+}
+
+export function formatYamlPath(path: readonly YamlPathSegment[]): string {
+	const validated = validateYamlPath(path);
+	return validated.reduce((label, segment) => {
+		if (typeof segment === "number") return `${label}[${segment}]`;
+		return label ? `${label}.${segment}` : segment;
+	}, "");
+}
+
+export function hasYamlPath(root: unknown, path: string | readonly YamlPathSegment[]): boolean {
+	const resolvedPath = parseYamlPath(path);
+	try {
+		getYamlPath(root, resolvedPath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function getYamlPath(root: unknown, path: string | readonly YamlPathSegment[]): unknown {
+	const resolvedPath = parseYamlPath(path);
+	let current = root;
+
+	for (const segment of resolvedPath) {
+		current = readYamlPathSegment(current, segment, formatYamlPath(resolvedPath));
+	}
+
+	return current;
+}
+
+export function setYamlPath(
+	root: Record<string, unknown>,
+	path: string | readonly YamlPathSegment[],
+	value: unknown,
+	options: SetYamlPathOptions = {},
+): void {
+	const resolvedPath = parseYamlPath(path);
+	let current: unknown = root;
+
+	for (let idx = 0; idx < resolvedPath.length; idx++) {
+		const segment = resolvedPath[idx];
+		const isLeaf = idx === resolvedPath.length - 1;
+		const location = formatYamlPath(resolvedPath.slice(0, idx + 1));
+
+		if (typeof segment === "string") {
+			if (!isPlainYamlObject(current)) {
+				throw new YamlPathError(`Cannot write YAML path '${formatYamlPath(resolvedPath)}': '${location}' is not an object.`);
+			}
+
+			if (isLeaf) {
+				current[segment] = value;
+				return;
+			}
+
+			if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+				current[segment] = createMissingParent(options, resolvedPath[idx + 1], location);
+			}
+
+			current = current[segment];
+			continue;
+		}
+
+		if (!Array.isArray(current)) {
+			throw new YamlPathError(`Cannot write YAML path '${formatYamlPath(resolvedPath)}': '${location}' is not an array.`);
+		}
+		if (!arrayIndexExists(current, segment)) {
+			throw new YamlPathError(`Cannot write YAML path '${formatYamlPath(resolvedPath)}': array index ${segment} is out of range.`);
+		}
+
+		if (isLeaf) {
+			current[segment] = value;
+			return;
+		}
+
+		current = current[segment];
+	}
+}
+
+export function isPlainYamlObject(value: unknown): value is Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+export function isYamlScalarLeaf(value: unknown): boolean {
+	return !isPlainYamlObject(value) && !Array.isArray(value);
+}
+
+export function hasNestedYamlLeaves(value: unknown): boolean {
+	if (isYamlScalarLeaf(value)) return false;
+
+	if (Array.isArray(value)) {
+		return value.some(item => isYamlScalarLeaf(item) || hasNestedYamlLeaves(item));
+	}
+
+	if (isPlainYamlObject(value)) {
+		return Object.values(value).some(item => isYamlScalarLeaf(item) || hasNestedYamlLeaves(item));
+	}
+
+	return false;
+}
+
+function readPathPart(part: string, originalPath: string, segments: YamlPath): void {
+	const keyMatch = part.match(/^([^\[\]]+)/);
+	if (!keyMatch) throw new YamlPathError(`Invalid YAML path '${originalPath}'. Bracket paths must follow a property name.`);
+
+	segments.push(keyMatch[1]);
+	let rest = part.substring(keyMatch[1].length);
+	while (rest.length > 0) {
+		const indexMatch = rest.match(/^\[(\d+)\]/);
+		if (!indexMatch) throw new YamlPathError(`Invalid YAML path '${originalPath}'. Only numeric array indexes are supported.`);
+		segments.push(Number(indexMatch[1]));
+		rest = rest.substring(indexMatch[0].length);
+	}
+}
+
+function validateYamlPath(path: readonly YamlPathSegment[]): YamlPath {
+	if (path.length === 0) throw new YamlPathError("YAML path cannot be empty.");
+
+	return path.map(segment => {
+		if (typeof segment === "string") {
+			if (!segment) throw new YamlPathError("YAML path string segments cannot be empty.");
+			if (segment.includes(".")) throw new YamlPathError(`YAML path segment '${segment}' cannot contain dots.`);
+			return segment;
+		}
+
+		if (!Number.isInteger(segment) || segment < 0) {
+			throw new YamlPathError(`YAML path array index '${segment}' must be a non-negative integer.`);
+		}
+		return segment;
+	});
+}
+
+function readYamlPathSegment(current: unknown, segment: YamlPathSegment, pathLabel: string): unknown {
+	if (typeof segment === "string") {
+		if (!isPlainYamlObject(current) || !Object.prototype.hasOwnProperty.call(current, segment)) {
+			throw new YamlPathError(`YAML path '${pathLabel}' does not exist.`);
+		}
+		return current[segment];
+	}
+
+	if (!Array.isArray(current) || !arrayIndexExists(current, segment)) {
+		throw new YamlPathError(`YAML path '${pathLabel}' does not exist.`);
+	}
+	return current[segment];
+}
+
+function createMissingParent(options: SetYamlPathOptions, nextSegment: YamlPathSegment, location: string): Record<string, unknown> {
+	if (!options.createParents) {
+		throw new YamlPathError(`Cannot write YAML path: '${location}' does not exist.`);
+	}
+	if (typeof nextSegment === "number") {
+		throw new YamlPathError(`Cannot create array parent at '${location}'. Array creation is not supported.`);
+	}
+	return {};
+}
+
+function arrayIndexExists(array: unknown[], index: number): boolean {
+	return index >= 0 && index < array.length && Object.prototype.hasOwnProperty.call(array, index);
+}

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -498,6 +498,61 @@ describe("MetaEdit runtime", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("rejects stale in-range array path writes instead of updating the wrong item", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("nested-stale-array.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\ncontributors:\n  - name: Ada\n    role: Writer\n  - name: Bob\n    role: Editor\n---\nbody\n",
+		);
+
+		const result = await evalJsonAsync<{
+			errorMessage: string;
+			cache: Record<string, unknown>;
+			content: string;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				const props = await plugin.controller.getPropertiesInFile(file);
+				const staleBobRole = props.find((prop) => prop.key === "contributors[1].role");
+				if (!staleBobRole) throw new Error("contributors[1].role was not parsed.");
+
+				await app.fileManager.processFrontMatter(file, (frontmatter) => {
+					frontmatter.contributors.unshift({ name: "Carol", role: "Reviewer" });
+				});
+
+				let errorMessage = "";
+				try {
+					await plugin.controller.updatePropertyInFile(staleBobRole, "Proofreader", file);
+				} catch (error) {
+					errorMessage = error.message;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 600));
+
+				return {
+					errorMessage,
+					cache: app.metadataCache.getFileCache(file)?.frontmatter ?? {},
+					content: await app.vault.read(file),
+				};
+			})()
+		`,
+		);
+
+		expect(result.errorMessage).toContain("current value changed");
+		expect(result.cache.contributors).toEqual([
+			{ name: "Carol", role: "Reviewer" },
+			{ name: "Ada", role: "Writer" },
+			{ name: "Bob", role: "Editor" },
+		]);
+		expect(result.content).not.toContain("Proofreader");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("edits nested YAML leaf rows through the real MetaEdit suggester", async () => {
 		const { obsidian, sandbox } = getContext();
 

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -28,15 +28,18 @@ describe("MetaEdit runtime", () => {
 		expect(state.hasRunCommand).toBe(true);
 		expect(state.apiMethods).toEqual([
 			"addOrUpdateProperty",
+			"addOrUpdateYamlPath",
 			"autoprop",
 			"createYamlProperty",
 			"getAutoProperties",
 			"getFilesWithProperty",
 			"getPropertiesInFile",
 			"getPropertyValue",
+			"getYamlPath",
 			"onMetadataChange",
 			"setAutoProperties",
 			"update",
+			"updateYamlPath",
 		]);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
@@ -233,6 +236,402 @@ describe("MetaEdit runtime", () => {
 		expect(content).toContain("outdoor: 1");
 		expect(content).toContain("reading: 0");
 		expect(content).not.toContain("reading: 1");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("reads and updates existing nested YAML leaves through public APIs (#33, #76)", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("nested-api.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			[
+				"---",
+				"metadata:",
+				"  description: old",
+				"  scope: personal",
+				"attributes:",
+				"  one: something",
+				"  two: 12345",
+				"contributors:",
+				"  - name: Ada",
+				"    role: Writer",
+				"  - name: Bob",
+				"    role: Editor",
+				"---",
+				"body",
+			].join("\n"),
+		);
+
+		const result = await evalJsonAsync<{
+			properties: {
+				key: string;
+				content: unknown;
+				path?: Array<string | number>;
+				rootKey?: string;
+				isNested?: boolean;
+				isVirtual?: boolean;
+			}[];
+			descriptionBefore: unknown;
+			descriptionAfter: unknown;
+			contributorRole: unknown;
+			publisherName: unknown;
+			content: string;
+			cache: Record<string, unknown>;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const api = plugin?.api;
+				if (!api) throw new Error("MetaEdit API is not available.");
+				const notePath = ${JSON.stringify(notePath)};
+				const file = app.vault.getAbstractFileByPath(notePath);
+				const properties = (await api.getPropertiesInFile(file)).map((prop) => ({
+					key: prop.key,
+					content: prop.content,
+					path: prop.path,
+					rootKey: prop.rootKey,
+					isNested: prop.isNested,
+					isVirtual: prop.isVirtual,
+				}));
+				const descriptionBefore = await api.getPropertyValue("metadata.description", file);
+
+				await api.update("metadata.description", "test", file);
+				await api.addOrUpdateProperty("attributes.one", "changed", file);
+				await api.updateYamlPath("contributors[1].role", "Proofreader", file);
+				await api.addOrUpdateYamlPath(["publisher", "name"], "Meta House", file);
+				await new Promise((resolve) => setTimeout(resolve, 600));
+
+				return {
+					properties,
+					descriptionBefore,
+					descriptionAfter: await api.getPropertyValue("metadata.description", file),
+					contributorRole: await api.getYamlPath(["contributors", 1, "role"], file),
+					publisherName: await api.getYamlPath("publisher.name", file),
+					content: await app.vault.read(file),
+					cache: app.metadataCache.getFileCache(file)?.frontmatter ?? {},
+				};
+			})()
+		`,
+		);
+
+		expect(result.properties).toContainEqual({
+			key: "metadata.description",
+			content: "old",
+			path: ["metadata", "description"],
+			rootKey: "metadata",
+			isNested: true,
+			isVirtual: true,
+		});
+		expect(result.descriptionBefore).toBe("old");
+		expect(result.descriptionAfter).toBe("test");
+		expect(result.contributorRole).toBe("Proofreader");
+		expect(result.publisherName).toBe("Meta House");
+		expect(result.cache.metadata).toEqual({ description: "test", scope: "personal" });
+		expect(result.cache.attributes).toEqual({ one: "changed", two: 12345 });
+		expect(result.cache.contributors).toEqual([
+			{ name: "Ada", role: "Writer" },
+			{ name: "Bob", role: "Proofreader" },
+		]);
+		expect(result.cache.publisher).toEqual({ name: "Meta House" });
+		expect(result.content).not.toContain("attributes.one:");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("keeps exact dotted YAML keys and inline dotted fields ahead of virtual nested YAML", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const literalPath = sandbox.path("literal-dotted-precedence.md");
+		const inlinePath = sandbox.path("inline-dotted-precedence.md");
+		await writeLiveFile(
+			obsidian,
+			literalPath,
+			"---\nauthor.name: literal old\nauthor:\n  name: YAML Author\n---\nbody\n",
+		);
+		await writeLiveFile(
+			obsidian,
+			inlinePath,
+			"---\nauthor:\n  name: YAML Author\n---\nauthor.name:: inline old\n",
+		);
+
+		const result = await evalJsonAsync<{
+			literalCache: Record<string, unknown>;
+			inlineContent: string;
+			inlineCache: Record<string, unknown>;
+			literalReadBack: unknown;
+			inlineReadBack: unknown;
+			forcedNestedReadBack: unknown;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const api = plugin?.api;
+				if (!api) throw new Error("MetaEdit API is not available.");
+				const literalFile = app.vault.getAbstractFileByPath(${JSON.stringify(literalPath)});
+				const inlineFile = app.vault.getAbstractFileByPath(${JSON.stringify(inlinePath)});
+
+				await api.update("author.name", "literal new", literalFile);
+				await api.update("author.name", "inline new", inlineFile);
+				await api.updateYamlPath("author.name", "YAML forced", inlineFile);
+				await new Promise((resolve) => setTimeout(resolve, 600));
+
+				return {
+					literalCache: app.metadataCache.getFileCache(literalFile)?.frontmatter ?? {},
+					inlineContent: await app.vault.read(inlineFile),
+					inlineCache: app.metadataCache.getFileCache(inlineFile)?.frontmatter ?? {},
+					literalReadBack: await api.getPropertyValue("author.name", literalFile),
+					inlineReadBack: await api.getPropertyValue("author.name", inlineFile),
+					forcedNestedReadBack: await api.getYamlPath("author.name", inlineFile),
+				};
+			})()
+		`,
+		);
+
+		expect(result.literalCache["author.name"]).toBe("literal new");
+		expect(result.literalCache.author).toEqual({ name: "YAML Author" });
+		expect(result.literalReadBack).toBe("literal new");
+		expect(result.inlineContent).toContain("author.name:: inline new");
+		expect(result.inlineCache.author).toEqual({ name: "YAML forced" });
+		expect(result.inlineReadBack).toBe("inline new");
+		expect(result.forcedNestedReadBack).toBe("YAML forced");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("keeps missing dotted legacy addOrUpdateProperty literal but explicit path writes can create parents", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("missing-dotted.md");
+		await writeLiveFile(obsidian, notePath, "---\nstatus: draft\n---\nbody\n");
+
+		const result = await evalJsonAsync<{
+			cache: Record<string, unknown>;
+			nestedValue: unknown;
+			literalValue: unknown;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const api = plugin?.api;
+				if (!api) throw new Error("MetaEdit API is not available.");
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+
+				await api.addOrUpdateProperty("missing.path", "literal", file);
+				await api.addOrUpdateYamlPath("created.path", "nested", file);
+				await new Promise((resolve) => setTimeout(resolve, 600));
+
+				return {
+					cache: app.metadataCache.getFileCache(file)?.frontmatter ?? {},
+					nestedValue: await api.getYamlPath("created.path", file),
+					literalValue: await api.getPropertyValue("missing.path", file),
+				};
+			})()
+		`,
+		);
+
+		expect(result.cache["missing.path"]).toBe("literal");
+		expect(result.cache.missing).toBeUndefined();
+		expect(result.cache.created).toEqual({ path: "nested" });
+		expect(result.nestedValue).toBe("nested");
+		expect(result.literalValue).toBe("literal");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("rejects scalar-parent and stale array nested writes without data loss", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("nested-rejections.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nrating: '4'\ncontributors:\n  - name: Ada\n    role: Writer\n---\nbody\n",
+		);
+
+		const result = await evalJsonAsync<{
+			scalarError: string;
+			arrayError: string;
+			cache: Record<string, unknown>;
+			content: string;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const api = plugin?.api;
+				if (!api) throw new Error("MetaEdit API is not available.");
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				let scalarError = "";
+				let arrayError = "";
+
+				try {
+					await api.addOrUpdateYamlPath("rating.stars", 5, file);
+				} catch (error) {
+					scalarError = error.message;
+				}
+
+				try {
+					await api.updateYamlPath("contributors[1].role", "Editor", file);
+				} catch (error) {
+					arrayError = error.message;
+				}
+
+				await new Promise((resolve) => setTimeout(resolve, 600));
+				return {
+					scalarError,
+					arrayError,
+					cache: app.metadataCache.getFileCache(file)?.frontmatter ?? {},
+					content: await app.vault.read(file),
+				};
+			})()
+		`,
+		);
+
+		expect(result.scalarError).toContain("rating");
+		expect(result.arrayError).toContain("out of range");
+		expect(result.cache.rating).toBe("4");
+		expect(result.cache.contributors).toEqual([{ name: "Ada", role: "Writer" }]);
+		expect(result.content).not.toContain("stars:");
+		expect(result.content).not.toContain("Editor");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("edits nested YAML leaf rows through the real MetaEdit suggester", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("nested-picker.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			[
+				"---",
+				"status: draft",
+				"attributes:",
+				"  one: something",
+				"  two: 12345",
+				"contributors:",
+				"  - name: Ada",
+				"    role: Writer",
+				"  - name: Bob",
+				"    role: Editor",
+				"---",
+				"body",
+			].join("\n"),
+		);
+
+		const menuResult = await evalJsonAsync<{
+			keys: string[];
+			nestedButtonCount: number;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+				const waitFor = async (selector, predicate = () => true) => {
+					const start = Date.now();
+					while (Date.now() - start < 5000) {
+						const found = Array.from(document.querySelectorAll(selector)).find(predicate);
+						if (found) return found;
+						await sleep(80);
+					}
+					throw new Error("Timed out waiting for " + selector);
+				};
+				const itemText = (item) => {
+					const textEl = item.querySelector(".suggestion-item-text") || item;
+					return (textEl.textContent || "").trim();
+				};
+
+				await plugin.runMetaEditForFile(file);
+				await waitFor(".suggestion-item");
+				await sleep(150);
+
+				const items = Array.from(document.querySelectorAll(".suggestion-item"));
+				const keys = items.map(itemText);
+				const nestedItem = items.find((item) => itemText(item) === "attributes.one");
+				if (!nestedItem) throw new Error("Nested attributes.one row was not rendered.");
+				const nestedButtonCount = nestedItem.querySelectorAll("button").length;
+
+				app.workspace.activeModal?.close?.();
+				for (const button of Array.from(document.querySelectorAll(".modal-close-button"))) {
+					button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+				}
+				await sleep(150);
+
+				return {
+					keys,
+					nestedButtonCount,
+				};
+			})()
+		`,
+		);
+
+		const editResult = await evalJsonAsync<{
+			cache: Record<string, unknown>;
+			content: string;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+				const waitFor = async (selector, predicate = () => true) => {
+					const start = Date.now();
+					while (Date.now() - start < 5000) {
+						const found = Array.from(document.querySelectorAll(selector)).find(predicate);
+						if (found) return found;
+						await sleep(80);
+					}
+					throw new Error("Timed out waiting for " + selector);
+				};
+
+				for (const button of Array.from(document.querySelectorAll(".modal-close-button"))) {
+					button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+				}
+				await sleep(100);
+
+				const props = await plugin.controller.getPropertiesInFile(file);
+				const property = props.find((prop) => prop.key === "attributes.one");
+				if (!property) throw new Error("Nested attributes.one property was not parsed.");
+				const editPromise = plugin.controller.editMetaElement(property, props, file);
+				const input = await waitFor(".metaEditPromptInput");
+				input.value = "edited";
+				input.dispatchEvent(new Event("input", { bubbles: true }));
+				input.dispatchEvent(new KeyboardEvent("keydown", {
+					key: "Enter",
+					code: "Enter",
+					keyCode: 13,
+					which: 13,
+					bubbles: true,
+					cancelable: true,
+				}));
+				await editPromise;
+				await waitFor("body", () => !document.querySelector(".metaEditPromptInput"));
+				await waitFor("body", () => {
+					const cache = app.metadataCache.getFileCache(file)?.frontmatter ?? {};
+					return cache.attributes?.one === "edited";
+				});
+
+				return {
+					cache: app.metadataCache.getFileCache(file)?.frontmatter ?? {},
+					content: await app.vault.read(file),
+				};
+			})()
+		`,
+		);
+
+		expect(menuResult.keys).toContain("attributes.one");
+		expect(menuResult.keys).toContain("attributes.two");
+		expect(menuResult.keys).toContain("contributors[1].role");
+		expect(menuResult.keys).not.toContain("attributes");
+		expect(menuResult.keys).not.toContain("contributors");
+		expect(menuResult.nestedButtonCount).toBe(0);
+		expect(editResult.cache.attributes).toEqual({ one: "edited", two: 12345 });
+		expect(editResult.content).not.toContain("attributes.one:");
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -1184,6 +1184,44 @@ describe("MetaEdit runtime", () => {
 		expect(content).not.toContain("Body line should stay literal: readProgress: 2");
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
+
+	test("progress properties update nested YAML leaf paths", async () => {
+		const { obsidian, sandbox } = getContext();
+
+		const notePath = sandbox.path("progress-nested.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\ntasks:\n  total: 0\n---\n# Tasks\n- [ ] one\n- [x] two\n",
+		);
+
+		const content = await evalJsonAsync<string>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				plugin.settings.ProgressProperties.enabled = true;
+				plugin.settings.ProgressProperties.properties = [{ name: "tasks.total", type: "Total Tasks" }];
+				const props = await plugin.controller.getPropertiesInFile(file);
+
+				try {
+					await plugin.controller.handleProgressProps(props, file);
+					await new Promise((resolve) => setTimeout(resolve, 300));
+					return await app.vault.read(file);
+				}
+				finally {
+					plugin.settings.ProgressProperties.enabled = false;
+					plugin.settings.ProgressProperties.properties = [];
+				}
+			})()
+		`,
+		);
+
+		expect(content).toMatch(/tasks:\n  total: "?2"?/);
+		expect(content).not.toContain("tasks.total:");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
 });
 
 // Invoke a MetaEdit public-API method inside the running app and return its

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -614,7 +614,10 @@ describe("MetaEdit runtime", () => {
 				for (const button of Array.from(document.querySelectorAll(".modal-close-button"))) {
 					button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 				}
-				await sleep(150);
+				for (const element of Array.from(document.querySelectorAll(".suggestion-container, .suggestion-item"))) {
+					element.remove();
+				}
+				await sleep(50);
 
 				return {
 					keys,


### PR DESCRIPTION
Adds path-aware nested YAML editing while preserving MetaEdit's existing flat-key and inline-field behavior.

Nested YAML scalar leaves are now exposed as virtual path rows, so existing paths such as `metadata.description`, `attributes.one`, and `contributors[1].role` can be read and updated without replacing their parent objects. Root YAML rows are still returned for compatibility, exact non-virtual keys resolve before virtual nested rows, and inline fields like `author.name:: value` stay exact Dataview fields.

The write path stays on Obsidian `processFrontMatter`. Nested updates go through a guarded path setter that refuses scalar-parent descent, out-of-range array indexes, missing update leaves, and stale parsed values before writing. Explicit scripted APIs are added for deterministic nested access: `getYamlPath`, `updateYamlPath`, and `addOrUpdateYamlPath`.

The Edit Meta picker lists nested leaf rows and hides object/array parent rows from text editing. Nested delete and transform remain disabled at the controller/UI boundary for this MVP.

Deferred by design:
- no nested delete or transform-to-Dataview
- no object/array parent editing through a text prompt
- no array-item creation, append, or sparse-array creation
- no object-predicate array addressing such as `contributors[name=Bob].role`
- no escaped-dot grammar for typed string paths; exact dotted top-level keys still win, and array path APIs/path metadata carry literal dotted segments
- missing dotted legacy `addOrUpdateProperty` calls still create literal top-level keys unless using explicit YAML path APIs

Validation:
- `pnpm install`
- `pnpm run lint` (passes with 11 pre-existing warnings in unrelated files)
- `pnpm run build`
- `pnpm run test` (14 files, 211 tests)
- `pnpm run provision:e2e-vault`
- baseline live repro in isolated vault confirmed prior behavior: nested `metadata.description` update no-op, `attributes.one` created as literal top-level key, inline `author.name::` updated exactly
- `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/metaedit-runtime.test.ts` (22 tests)
- clean-state `pnpm run test:e2e` in isolated worktree vault (6 files, 47 tests)
- `pnpm run stop:e2e-obsidian`
- adversarial review via Claude CLI; accepted and fixed stale in-range array write risk, update-style missing-leaf behavior, duplicated parent-container predicate, scalar-array row noise, and UI write error surfacing

Refs #76, #33