### PR TITLE
feat(api): append Dataview field instances without replacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ This is an asynchronous function, so you should `await` it.
 
 When updating inline Dataview fields, non-string values are stringified. YAML frontmatter properties can preserve richer YAML values such as numbers, booleans, arrays, and objects.
 
+`update` is replace-by-design: when a note has several inline `name:: value` lines with the same name, it rewrites all of them to the new value. To add a new instance instead and leave the existing ones untouched, use [`appendDataviewField`](#appenddataviewfieldpropertyname-string-propertyvalue-unknown-file-tfile--string-options-location-afterlastmatch--end).
+
 ### `createYamlProperty(propertyName: string, propertyValue: unknown, file: TFile | string)`
 Creates a YAML frontmatter property in the given file.
 
@@ -74,6 +76,25 @@ This is an asynchronous function, so you should `await` it.
 Updates an existing property with the given name, or creates a YAML frontmatter property when the property does not exist.
 
 This is an asynchronous function, so you should `await` it.
+
+### `appendDataviewField(propertyName: string, propertyValue: unknown, file: TFile | string, options?: { location?: "afterLastMatch" | "end" })`
+Adds a new inline `name:: value` Dataview field instance to the body of the note, leaving any existing fields with the same name unchanged. This is the add-an-instance counterpart to `update`, which replaces every existing instance.
+
+The field is never inserted into YAML frontmatter or a fenced code block. Non-string values are stringified (arrays are joined with `, `).
+
+`options.location` controls placement:
+- `"afterLastMatch"` (default): right after the last existing `name::` line; if there is none, at the end of the note body.
+- `"end"`: always at the end of the note body.
+
+If the file is a string, it should be the file path. Otherwise, a `TFile` is fine.
+
+This is an asynchronous function, so you should `await` it.
+
+For example, a Dataview/Templater wishlist that appends a new pick without disturbing earlier ones:
+```js
+const {appendDataviewField} = this.app.plugins.plugins["metaedit"].api;
+await appendDataviewField("watch", "[[Dune: Part Two]]", tp.file.path);
+```
 
 ### `getPropertyValue(propertyName: string, file: TFile | string)`
 Gets the value of the given property in the given file.

--- a/src/IMetaEditApi.ts
+++ b/src/IMetaEditApi.ts
@@ -1,5 +1,5 @@
 import type {CachedMetadata, TFile} from "obsidian";
-import type {Property} from "./parser";
+import type {InlineFieldInsertLocation, Property} from "./parser";
 import type {AutoProperty} from "./Types/autoProperty";
 import type {YamlPathSegment} from "./yamlPath";
 
@@ -8,6 +8,10 @@ export type MetaEditUnsubscribe = () => void;
 export type MetaEditYamlPath = string | readonly YamlPathSegment[];
 export type MetaEditYamlPathOptions = {
     createParents?: boolean;
+};
+export type MetaEditAppendDataviewFieldOptions = {
+    // Where to add the new inline field instance. Defaults to "afterLastMatch".
+    location?: InlineFieldInsertLocation;
 };
 
 export interface MetaEditMetadataChange {
@@ -27,6 +31,7 @@ export interface IMetaEditApi {
     getFilesWithProperty: (propertyName: string) => TFile[];
     createYamlProperty: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
     addOrUpdateProperty: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
+    appendDataviewField: (propertyName: string, propertyValue: MetaEditPropertyValue, file: TFile | string, options?: MetaEditAppendDataviewFieldOptions) => Promise<void>;
     getYamlPath: (path: MetaEditYamlPath, file: TFile | string) => Promise<any>;
     updateYamlPath: (path: MetaEditYamlPath, propertyValue: MetaEditPropertyValue, file: TFile | string) => Promise<void>;
     addOrUpdateYamlPath: (path: MetaEditYamlPath, propertyValue: MetaEditPropertyValue, file: TFile | string, options?: MetaEditYamlPathOptions) => Promise<void>;

--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -1,6 +1,7 @@
 import type MetaEdit from "./main";
 import type {
     IMetaEditApi,
+    MetaEditAppendDataviewFieldOptions,
     MetaEditMetadataChangeCallback,
     MetaEditPropertyValue,
     MetaEditYamlPath,
@@ -29,6 +30,7 @@ export class MetaEditApi {
             getFilesWithProperty: this.getGetFilesWithPropertyFunction(),
             createYamlProperty: this.getCreateYamlPropertyFunction(),
             addOrUpdateProperty: this.getAddOrUpdatePropertyFunction(),
+            appendDataviewField: this.getAppendDataviewFieldFunction(),
             getYamlPath: this.getGetYamlPathFunction(),
             updateYamlPath: this.getUpdateYamlPathFunction(),
             addOrUpdateYamlPath: this.getAddOrUpdateYamlPathFunction(),
@@ -113,6 +115,20 @@ export class MetaEditApi {
                 key: propertyName,
                 type: MetaType.YAML,
             }, propertyValue, targetFile);
+        }
+    }
+
+    private getAppendDataviewFieldFunction() {
+        return async (
+            propertyName: string,
+            propertyValue: MetaEditPropertyValue,
+            file: TFile | string,
+            options?: MetaEditAppendDataviewFieldOptions,
+        ) => {
+            const targetFile = this.getFileFromTFileOrPath(file);
+            if (!targetFile) return;
+
+            await this.plugin.controller.appendDataviewField(propertyName, propertyValue, targetFile, options);
         }
     }
 

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -77,7 +77,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
             if (!newProperty) return null;
 
             const {propName, propValue} = newProperty;
-            await this.controller.addDataviewField(propName, propValue, this.file);
+            await this.controller.appendDataviewField(propName, propValue, this.file);
             return;
         }
 
@@ -126,7 +126,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
 
     private async toDataview(property: Property) {
         await this.controller.deleteProperty(property, this.file);
-        await this.controller.addDataviewField(property.key, property.content, this.file);
+        await this.controller.appendDataviewField(property.key, property.content, this.file);
     }
 
     private createButton(el: HTMLElement, content: string, callback: (evt: MouseEvent) => void) {

--- a/src/computeInlineInsertIndex.test.ts
+++ b/src/computeInlineInsertIndex.test.ts
@@ -108,6 +108,16 @@ describe("computeInlineInsertIndex - never inside fenced code blocks", () => {
         // `watch:: fake` sits inside the still-open ``` fence, so it is not a match.
         expect(append(content, "watch", "new")).toBe(["```", "~~~", "watch:: fake", "```", "after", "watch:: new"].join("\n"));
     });
+
+    it("does not close a four-backtick fence on a shorter inner three-backtick fence", () => {
+        const content = ["````md", "```dataview", "watch:: fake", "```", "````", "real:: x"].join("\n");
+
+        // The inner ``` is shorter than the ```` opener, so `watch:: fake` stays inside
+        // the outer block and is not a match; append lands after the real body field.
+        expect(append(content, "watch", "new")).toBe(
+            ["````md", "```dataview", "watch:: fake", "```", "````", "real:: x", "watch:: new"].join("\n"),
+        );
+    });
 });
 
 describe("computeInlineInsertIndex - location: end", () => {

--- a/src/computeInlineInsertIndex.test.ts
+++ b/src/computeInlineInsertIndex.test.ts
@@ -1,0 +1,148 @@
+import {describe, expect, it} from "vitest";
+import MetaEditParser, {type InlineFieldInsertLocation} from "./parser";
+
+// computeInlineInsertIndex is pure: it only reads the content string, so drive it
+// directly with literals. The returned index is into content.split(/\r?\n/), which is
+// exactly what the writer splices into.
+const insertIndex = (content: string, name: string, location?: InlineFieldInsertLocation): number =>
+    new MetaEditParser({} as any).computeInlineInsertIndex(content, name, location);
+
+// Apply the helper the way the writer does, so each case reads as the resulting file.
+const append = (content: string, name: string, value: string, location?: InlineFieldInsertLocation): string => {
+    const newline = content.includes("\r\n") ? "\r\n" : "\n";
+    const lines = content.split(/\r?\n/);
+    lines.splice(insertIndex(content, name, location), 0, `${name}:: ${value}`);
+    return lines.join(newline);
+};
+
+describe("computeInlineInsertIndex - afterLastMatch", () => {
+    it("inserts right after the last existing field, leaving the others untouched (#91)", () => {
+        const content = ["---", "title: Movies", "---", "", "watch:: [[A]]", "watch:: [[B]]", "watch:: [[C]]", ""].join("\n");
+
+        expect(insertIndex(content, "watch")).toBe(7);
+        expect(append(content, "watch", "[[D]]")).toBe(
+            ["---", "title: Movies", "---", "", "watch:: [[A]]", "watch:: [[B]]", "watch:: [[C]]", "watch:: [[D]]", ""].join("\n"),
+        );
+    });
+
+    it("inserts between the last matching field and following content", () => {
+        const content = ["intro", "watch:: a", "watch:: b", "outro"].join("\n");
+
+        expect(append(content, "watch", "c")).toBe(["intro", "watch:: a", "watch:: b", "watch:: c", "outro"].join("\n"));
+    });
+
+    it("falls back to end of body when no field of that name exists", () => {
+        const content = ["---", "title: x", "---", "", "Some body text."].join("\n");
+
+        expect(append(content, "watch", "new")).toBe(
+            ["---", "title: x", "---", "", "Some body text.", "watch:: new"].join("\n"),
+        );
+    });
+
+    it("matches bracketed inline fields", () => {
+        const content = ["intro [watch:: a] tail", "more body"].join("\n");
+
+        expect(insertIndex(content, "watch")).toBe(1);
+    });
+
+    it("only matches the exact key, never a longer key with the same prefix", () => {
+        const content = ["watching:: a", "rewatch:: b", "body"].join("\n");
+
+        // No real `watch` field -> append to end of body, do not anchor on watching/rewatch.
+        expect(append(content, "watch", "x")).toBe(["watching:: a", "rewatch:: b", "body", "watch:: x"].join("\n"));
+    });
+
+    it("treats a key with regex metacharacters literally", () => {
+        const content = ["a.b:: first", "axb:: other", "body"].join("\n");
+
+        // Must anchor on the literal `a.b` line (index 0), not the regex-style match `axb`.
+        expect(insertIndex(content, "a.b")).toBe(1);
+    });
+});
+
+describe("computeInlineInsertIndex - never inside frontmatter", () => {
+    it("does not anchor on a Dataview-looking scalar inside frontmatter", () => {
+        const content = ["---", 'summary: "[watch:: yaml scalar]"', "---", "Body"].join("\n");
+
+        // The frontmatter line must be skipped; with no body field, append to end of body.
+        expect(append(content, "watch", "new")).toBe(
+            ["---", 'summary: "[watch:: yaml scalar]"', "---", "Body", "watch:: new"].join("\n"),
+        );
+    });
+
+    it("appends after frontmatter when the note is frontmatter-only", () => {
+        const content = ["---", "title: x", "---", ""].join("\n");
+
+        expect(append(content, "watch", "new")).toBe(["---", "title: x", "---", "watch:: new", ""].join("\n"));
+    });
+});
+
+describe("computeInlineInsertIndex - never inside fenced code blocks", () => {
+    it("ignores a field inside a fenced code block", () => {
+        const content = ["text", "```js", "watch:: fake", "```", "real:: x"].join("\n");
+
+        // The fenced `watch:: fake` is not a real field; with no body `watch` field,
+        // append after the last body content line.
+        expect(append(content, "watch", "new")).toBe(
+            ["text", "```js", "watch:: fake", "```", "real:: x", "watch:: new"].join("\n"),
+        );
+    });
+
+    it("end places the field after a trailing closed fence, not before it", () => {
+        const content = ["Intro", "```ts", "const x = 1;", "```"].join("\n");
+
+        expect(append(content, "watch", "new", "end")).toBe(
+            ["Intro", "```ts", "const x = 1;", "```", "watch:: new"].join("\n"),
+        );
+    });
+
+    it("inserts before an unclosed trailing fence rather than inside it", () => {
+        const content = ["intro", "```", "code"].join("\n");
+
+        expect(append(content, "watch", "new", "end")).toBe(["intro", "watch:: new", "```", "code"].join("\n"));
+    });
+
+    it("does not close an outer ``` fence on a non-matching ~~~ marker", () => {
+        const content = ["```", "~~~", "watch:: fake", "```", "after"].join("\n");
+
+        // `watch:: fake` sits inside the still-open ``` fence, so it is not a match.
+        expect(append(content, "watch", "new")).toBe(["```", "~~~", "watch:: fake", "```", "after", "watch:: new"].join("\n"));
+    });
+});
+
+describe("computeInlineInsertIndex - location: end", () => {
+    it("appends at end of body even when a matching field exists earlier", () => {
+        const content = ["watch:: a", "body", "more"].join("\n");
+
+        expect(append(content, "watch", "z", "end")).toBe(["watch:: a", "body", "more", "watch:: z"].join("\n"));
+    });
+
+    it("skips trailing blank lines and inserts after the last content line", () => {
+        const content = ["body", "", ""].join("\n");
+
+        expect(append(content, "watch", "x", "end")).toBe(["body", "watch:: x", "", ""].join("\n"));
+    });
+});
+
+describe("computeInlineInsertIndex - edge cases", () => {
+    it("handles an empty file (index 0)", () => {
+        expect(insertIndex("", "watch")).toBe(0);
+        expect(append("", "watch", "x")).toBe("watch:: x\n");
+    });
+
+    it("appends to a single-line note without a trailing newline", () => {
+        expect(append("watch:: a", "watch", "b")).toBe(["watch:: a", "watch:: b"].join("\n"));
+    });
+
+    it("preserves CRLF line endings and does not introduce a bare LF", () => {
+        const content = "Intro\r\nwatch:: old\r\nTail\r\n";
+
+        expect(append(content, "watch", "new")).toBe("Intro\r\nwatch:: old\r\nwatch:: new\r\nTail\r\n");
+    });
+
+    it("recognizes a CRLF frontmatter block and does not anchor inside it", () => {
+        const content = "---\r\nwatch:: yaml\r\n---\r\nBody\r\n";
+
+        expect(append(content, "watch", "new")).toBe("---\r\nwatch:: yaml\r\n---\r\nBody\r\nwatch:: new\r\n");
+    });
+});

--- a/src/metaController.test.ts
+++ b/src/metaController.test.ts
@@ -1,0 +1,95 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {TFile} from "obsidian";
+
+// The controller transitively imports Svelte-backed modals, which the node test
+// environment cannot transform. The append writer never touches them, so replace the
+// modal modules with light stubs to keep this suite jsdom-free.
+vi.mock("./Modals/GenericPrompt/GenericPrompt", () => ({default: {Prompt: vi.fn()}}));
+vi.mock("./Modals/GenericSuggester/GenericSuggester", () => ({default: {Suggest: vi.fn()}}));
+vi.mock("./Modals/AutoPropertyValueModal/AutoPropertyValueModal", () => ({default: {Show: vi.fn()}}));
+
+import MetaController from "./metaController";
+
+const setup = (initial: string) => {
+    const store = {content: initial};
+    const app = {
+        plugins: {plugins: {}},
+        vault: {
+            read: vi.fn(async () => store.content),
+            modify: vi.fn(async (_file: unknown, data: string) => {
+                store.content = data;
+            }),
+        },
+    };
+    const controller = new MetaController(app as never, {} as never);
+    return {controller, file: new TFile("note.md"), store, app};
+};
+
+describe("MetaController.appendDataviewField", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("appends a new instance after the last one, leaving existing fields untouched (#91)", async () => {
+        const {controller, file, store} = setup(
+            ["---", "title: Movies", "---", "", "watch:: [[A]]", "watch:: [[B]]", "watch:: [[C]]", ""].join("\n"),
+        );
+
+        await controller.appendDataviewField("watch", "[[D]]", file);
+
+        expect(store.content).toBe(
+            ["---", "title: Movies", "---", "", "watch:: [[A]]", "watch:: [[B]]", "watch:: [[C]]", "watch:: [[D]]", ""].join("\n"),
+        );
+    });
+
+    it("inserts at line index 0 instead of silently no-opping (the index-0 bug)", async () => {
+        const {controller, file, store} = setup("");
+
+        await controller.appendDataviewField("watch", "[[A]]", file);
+
+        expect(store.content).toBe("watch:: [[A]]\n");
+    });
+
+    it("never inserts inside frontmatter", async () => {
+        const {controller, file, store} = setup(["---", 'summary: "[watch:: yaml]"', "---", "Body"].join("\n"));
+
+        await controller.appendDataviewField("watch", "new", file);
+
+        expect(store.content).toBe(["---", 'summary: "[watch:: yaml]"', "---", "Body", "watch:: new"].join("\n"));
+    });
+
+    it("respects location: end", async () => {
+        const {controller, file, store} = setup(["watch:: a", "body"].join("\n"));
+
+        await controller.appendDataviewField("watch", "z", file, {location: "end"});
+
+        expect(store.content).toBe(["watch:: a", "body", "watch:: z"].join("\n"));
+    });
+
+    it("stringifies array values", async () => {
+        const {controller, file, store} = setup("body");
+
+        await controller.appendDataviewField("genres", ["action", "drama"], file);
+
+        expect(store.content).toBe(["body", "genres:: action, drama"].join("\n"));
+    });
+
+    it("preserves CRLF line endings", async () => {
+        const {controller, file, store} = setup("Intro\r\nwatch:: old\r\nTail\r\n");
+
+        await controller.appendDataviewField("watch", "new", file);
+
+        expect(store.content).toBe("Intro\r\nwatch:: old\r\nwatch:: new\r\nTail\r\n");
+    });
+
+    it("serializes concurrent appends so neither write is lost", async () => {
+        const {controller, file, store} = setup("body");
+
+        await Promise.all([
+            controller.appendDataviewField("watch", "1", file),
+            controller.appendDataviewField("watch", "2", file),
+        ]);
+
+        expect(store.content).toBe(["body", "watch:: 1", "watch:: 2"].join("\n"));
+    });
+});

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -1,4 +1,4 @@
-import MetaEditParser, {type Property} from "./parser";
+import MetaEditParser, {type InlineFieldInsertLocation, type Property} from "./parser";
 import type {App, TFile} from "obsidian";
 import type MetaEdit from "./main";
 import GenericPrompt from "./Modals/GenericPrompt/GenericPrompt";
@@ -73,24 +73,36 @@ export default class MetaController {
         }
     }
 
-    public async addDataviewField(propName: string, propValue: unknown, file: TFile): Promise<void> {
+    /**
+     * Append a NEW inline `name:: value` field instance, leaving any existing
+     * same-named fields untouched. This is the add-an-instance counterpart to
+     * {@link updatePropertyInFile}, which replaces every existing instance.
+     *
+     * Placement is computed by {@link MetaEditParser.computeInlineInsertIndex} so the
+     * field is never inserted inside frontmatter or a fenced code block. The write goes
+     * through the per-file queue, so it serializes with other MetaEdit writes instead of
+     * racing them (the previous implementation read and wrote outside the queue, and
+     * silently no-opped when the chosen line index was 0).
+     */
+    public async appendDataviewField(
+        propName: string,
+        propValue: unknown,
+        file: TFile,
+        options: {location?: InlineFieldInsertLocation} = {},
+    ): Promise<void> {
         const valueStr = Array.isArray(propValue) ? propValue.join(", ") : String(propValue);
-        const fileContent: string = await this.app.vault.read(file);
-        const lines = fileContent.split("\n").reduce((obj: {[key: string]: string}, line: string, idx: number) => {
-            obj[idx] = !!line ? line : "";
-            return obj;
-        }, {});
+        const location = options.location ?? "afterLastMatch";
 
-        const appendAfter: string = await GenericSuggester.Suggest(this.app, Object.values(lines), Object.keys(lines));
-        if (!appendAfter) return;
+        await this.enqueueFileWrite(file, async () => {
+            const content = await this.app.vault.read(file);
+            // Preserve the file's existing newline so a CRLF note does not gain a stray LF.
+            const newline = content.includes("\r\n") ? "\r\n" : "\n";
+            const lines = content.split(/\r?\n/);
+            const insertIndex = this.parser.computeInlineInsertIndex(content, propName, location);
+            lines.splice(insertIndex, 0, `${propName}:: ${valueStr}`);
 
-        const splitContent: string[] = fileContent.split("\n");
-        if (typeof appendAfter === "number" || parseInt(appendAfter)) {
-            splitContent.splice(parseInt(appendAfter), 0, `${propName}:: ${valueStr}`);
-        }
-        const newFileContent = splitContent.join("\n");
-
-        await this.app.vault.modify(file, newFileContent);
+            await this.app.vault.modify(file, lines.join(newline));
+        });
     }
 
     public async editMetaElement(property: Property, meta: Property[], file: TFile): Promise<void> {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -398,6 +398,24 @@ describe("MetaEditParser inline field parsing", () => {
         ]);
     });
 
+    it("keeps a shorter inner fence from closing a longer outer fence", () => {
+        const content = [
+            "real:: yes",
+            "````md",
+            "```dataview",
+            "fake:: no",
+            "```",
+            "````",
+            "real2:: yes",
+        ].join("\n");
+        // The inner ``` is shorter than the ```` opener, so it does not close the outer
+        // block; `fake:: no` stays an example, not metadata.
+        expect(parseInline(content)).toEqual([
+            {key: "real", content: "yes"},
+            {key: "real2", content: "yes"},
+        ]);
+    });
+
     it("does not read fields inside the YAML frontmatter block", () => {
         const content = ["---", "title:: not inline", "---", "body:: yes"].join("\n");
         expect(parseInline(content)).toEqual([{key: "body", content: "yes"}]);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -44,6 +44,32 @@ const FULL_LINE_PREFIX = /^\s*(?:>\s+)*(?:[-*+]\s+|\d+[.)]\s+)?/;
 // spaces. Inline fields inside code blocks are examples, not metadata.
 const CODE_FENCE = /^\s{0,3}(`{3,}|~{3,})/;
 
+type OpenFence = {char: string, len: number};
+
+// A potential fence line: the run's character, its length, and whether the run is
+// followed only by whitespace. A closing fence must be "bare" (no info string);
+// an opening fence may carry an info string (e.g. ```dataview).
+function matchFenceLine(line: string): {char: string, len: number, bare: boolean} | null {
+    const match = line.match(CODE_FENCE);
+    if (!match) return null;
+    const run = match[1];
+    return {char: run[0], len: run.length, bare: line.slice(match[0].length).trim() === ""};
+}
+
+// Advance fenced-code state by one line. A block closes only on a run of the SAME
+// character at least as long as the opener, followed by whitespace - so a shorter
+// inner fence (e.g. ``` shown inside a ```` block) does not close the outer block
+// early and leak its example fields as metadata.
+function nextFenceState(openFence: OpenFence | null, line: string): {open: OpenFence | null, boundary: "open" | "close" | null} {
+    const fence = matchFenceLine(line);
+    if (!fence) return {open: openFence, boundary: null};
+    if (openFence === null) return {open: {char: fence.char, len: fence.len}, boundary: "open"};
+    if (fence.char === openFence.char && fence.len >= openFence.len && fence.bare) {
+        return {open: null, boundary: "close"};
+    }
+    return {open: openFence, boundary: null};
+}
+
 export default class MetaEditParser {
     private app: App;
 
@@ -184,7 +210,7 @@ export default class MetaEditParser {
         const properties: Property[] = [];
         const lines = this.splitContentLines(content);
         const frontmatterInfo = this.getFrontmatterInfo(content);
-        let openFence: string | null = null;
+        let openFence: OpenFence | null = null;
 
         for (const {text: line, start} of lines) {
 
@@ -194,19 +220,10 @@ export default class MetaEditParser {
             }
 
             // Skip fenced code blocks so example fields are not treated as metadata.
-            const fence = line.match(CODE_FENCE);
-            if (fence) {
-                const marker = fence[1][0];
-                if (openFence === null) {
-                    openFence = marker;
-                    continue;
-                }
-                if (openFence === marker) {
-                    openFence = null;
-                    continue;
-                }
-            }
-            if (openFence !== null) continue;
+            const {open, boundary} = nextFenceState(openFence, line);
+            openFence = open;
+            if (boundary) continue;       // an opening or closing fence marker line
+            if (openFence !== null) continue; // inside a fenced code block
 
             if (!line.includes("::")) continue;
 
@@ -428,7 +445,7 @@ export default class MetaEditParser {
         const lines = this.splitContentLines(content);
         const frontmatterInfo = this.getFrontmatterInfo(content);
 
-        let openFence: string | null = null;
+        let openFence: OpenFence | null = null;
         let lastMatchIdx = -1;   // last body line that declares `name`
         let lastAnchorIdx = -1;  // last line we may insert AFTER (body content or a closing fence)
         let firstBodyIdx = -1;   // first line at/after the frontmatter block
@@ -440,19 +457,14 @@ export default class MetaEditParser {
             if (frontmatterInfo?.exists && start < frontmatterInfo.contentStart) continue;
             if (firstBodyIdx === -1) firstBodyIdx = i;
 
-            const fence = line.match(CODE_FENCE);
-            if (fence) {
-                const marker = fence[1][0];
-                if (openFence === null) {
-                    openFence = marker;   // opening marker: inserting after it would land inside the fence
-                    continue;
-                }
-                if (openFence === marker) {
-                    openFence = null;     // closing marker: inserting after it is outside the fence
-                    lastAnchorIdx = i;
-                    continue;
-                }
-                // A fence-looking line of a different marker while inside a fence is interior content.
+            const {open, boundary} = nextFenceState(openFence, line);
+            openFence = open;
+            // An opening marker is not a valid anchor (inserting after it lands inside the fence);
+            // a closing marker is (inserting after it is outside the fence).
+            if (boundary === "open") continue;
+            if (boundary === "close") {
+                lastAnchorIdx = i;
+                continue;
             }
             if (openFence !== null) continue; // fence interior - never a target
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -12,6 +12,11 @@ export type Property = {
 	isNested?: boolean,
 	isVirtual?: boolean,
 };
+// Where to insert a newly appended inline field instance.
+// - "afterLastMatch": right after the last existing `name::` line, else end of body.
+// - "end": always at the end of the body (after the last content, after a trailing
+//   closed code fence), never inside frontmatter or a fenced code block.
+export type InlineFieldInsertLocation = "afterLastMatch" | "end";
 // `start`/`end` are the field's span in the line; `sepEnd` is the offset just
 // after `::`; `valueEnd` is where the value content ends (the closing bracket
 // for a bracketed field, or end-of-line for a full-line field). The latter two
@@ -401,6 +406,65 @@ export default class MetaEditParser {
             result = result.slice(0, field.sepEnd) + " " + newValue + result.slice(field.valueEnd);
         }
         return result;
+    }
+
+    /**
+     * Compute the line index at which to splice a new `name:: value` inline field.
+     *
+     * This is the write-placement counterpart to {@link parseInlineContent}: it walks
+     * the content with the SAME frontmatter, fenced-code, and inline-field detection so
+     * the insertion point is always consistent with what MetaEdit reads as a field. The
+     * returned index is into `content.split(/\r?\n/)` (the same split
+     * {@link splitContentLines} performs), so a caller can splice directly.
+     *
+     * Guarantees: the index is never inside YAML frontmatter or a fenced code block.
+     * - "afterLastMatch": just after the last body line that declares `name` (full-line
+     *   or bracketed), falling back to "end" when there is no such field.
+     * - "end": just after the last body content line or trailing closing code fence.
+     * When the note has no body content (empty or frontmatter-only), the field is placed
+     * at the start of the body, or at the very end when the whole file is frontmatter.
+     */
+    public computeInlineInsertIndex(content: string, name: string, location: InlineFieldInsertLocation = "afterLastMatch"): number {
+        const lines = this.splitContentLines(content);
+        const frontmatterInfo = this.getFrontmatterInfo(content);
+
+        let openFence: string | null = null;
+        let lastMatchIdx = -1;   // last body line that declares `name`
+        let lastAnchorIdx = -1;  // last line we may insert AFTER (body content or a closing fence)
+        let firstBodyIdx = -1;   // first line at/after the frontmatter block
+
+        for (let i = 0; i < lines.length; i++) {
+            const {text: line, start} = lines[i];
+
+            // Inside the YAML frontmatter block - never a valid target (mirrors parseInlineContent).
+            if (frontmatterInfo?.exists && start < frontmatterInfo.contentStart) continue;
+            if (firstBodyIdx === -1) firstBodyIdx = i;
+
+            const fence = line.match(CODE_FENCE);
+            if (fence) {
+                const marker = fence[1][0];
+                if (openFence === null) {
+                    openFence = marker;   // opening marker: inserting after it would land inside the fence
+                    continue;
+                }
+                if (openFence === marker) {
+                    openFence = null;     // closing marker: inserting after it is outside the fence
+                    lastAnchorIdx = i;
+                    continue;
+                }
+                // A fence-looking line of a different marker while inside a fence is interior content.
+            }
+            if (openFence !== null) continue; // fence interior - never a target
+
+            if (line.trim() !== "") lastAnchorIdx = i;
+            if (line.includes("::") && this.parseLineFields(line).some(field => field.key === name)) {
+                lastMatchIdx = i;
+            }
+        }
+
+        if (location === "afterLastMatch" && lastMatchIdx !== -1) return lastMatchIdx + 1;
+        if (lastAnchorIdx !== -1) return lastAnchorIdx + 1;
+        return firstBodyIdx !== -1 ? firstBodyIdx : lines.length;
     }
 
 }


### PR DESCRIPTION
Fixes #91

## Summary
`update()` is replace-by-design: when a note has several inline `watch:: value` lines, updating `watch` rewrites all of them to one value. Users (e.g. a Dataview movie-wishlist template) need to **append** a new instance and leave the existing ones alone. There was no first-class append callable from templates/Dataview/QuickAdd.

This adds `appendDataviewField(name, value, file, options?)` to the public API and fixes the long-standing index-0 silent no-op in the UI-only append primitive by refactoring it onto a shared, queue-serialized writer built on a pure placement helper.

## What changed
- **`parser.computeInlineInsertIndex(content, name, location)`** - a pure, jsdom-free helper that computes where to splice a new inline field. It reuses the parser's own frontmatter, fenced-code, and inline-field detection, so placement is always consistent with what MetaEdit reads as a field and is **never** inside frontmatter or a fenced code block. Supports `afterLastMatch` (default, with end-of-body fallback) and `end`.
- **`MetaController.appendDataviewField`** (renamed from `addDataviewField`) - now goes through the per-file write queue (`enqueueFileWrite`) and computes placement via the helper, instead of a line-picker. This fixes:
  - the **index-0 silent no-op** (the old `parseInt("0")` guard skipped the insert), and
  - the **unqueued read/modify** that could race other MetaEdit writes.
  It also preserves the file's existing newline (no stray LF in CRLF notes).
- **`parser.parseInlineContent` fenced-code handling** - now tracks the fence run length, not just the marker character, so a shorter inner fence (e.g. ``` shown inside a ```` block) cannot close the outer block early and leak example fields as metadata. Shared with the new placement helper.
- **Public API** `appendDataviewField` (`IMetaEditApi` + `MetaEditApi`) delegating to the shared controller writer.
- **README** documents append-vs-update (replace every instance vs add a new instance) and the new method.

The "New Dataview field" command and the YAML→Dataview transform share this one writer + helper (single source of truth). They now place the new field automatically (after the last same-named field, else end of body) instead of via the broken line-picker.

## Design validation
Before coding, the design was challenged by an adversarial panel on the opposing model (Codex; skeptic/architect/minimalist lenses, told to refute). Their high-severity findings reshaped the implementation: **reuse the parser's detection instead of a second hand-rolled scanner/regex** (prevents inserting into frontmatter/fences and anchoring on prose), **preserve CRLF**, and **anchor `end` after a trailing closed fence**. The fence-run-length hardening also resolves the Codex review comment on this PR.

## Tests
- `src/computeInlineInsertIndex.test.ts` - 19 pure unit tests (afterLastMatch, end, frontmatter/fence safety incl. nested fences, bracketed fields, regex-metacharacter keys, CRLF, empty/frontmatter-only files).
- `src/metaController.test.ts` - 7 jsdom-free writer regression tests (the index-0 fix, frontmatter/fence safety, array stringification, CRLF preservation, and concurrent-write serialization).
- `src/parser.test.ts` - added nested-fence read coverage.
- `pnpm run lint`, `pnpm run build` (svelte-check 0 errors), `pnpm run test` (243 passing) all green.

## Live verification (isolated Obsidian E2E vault)
Built, ran in an isolated worktree vault, called the API, read back exact content:
- A note with frontmatter (incl. `aliases: "[watch:: ...]"`), three `watch::` lines, and a ```` ```dataview ```` fence containing `watch:: in-code-fence`: the 4th `watch::` landed **right after the last existing one**; the three existing lines, the frontmatter line, and the fenced line were **all untouched**.
- Empty file → `watch:: [[First]]` inserted at index 0 (**index-0 bug fixed**).
- `location: "end"` appended at the bottom past an earlier match.
- A frontmatter block whose close delimiter has trailing whitespace (`--- `): Obsidian itself does not treat it as frontmatter (`metadataCache` reports no frontmatter), and placement stayed consistent with that reading - confirming we never insert into what Obsidian considers frontmatter.

## Pre-existing issues surfaced (not fixed here - out of scope for #91)
The adversarial review flagged two pre-existing bugs in `MetaController.deleteProperty` (reached by the delete and YAML→Dataview transform paths, which this PR does not otherwise touch):
1. `deleteProperty` builds its match regex without escaping the key, so a key with regex metacharacters (e.g. `a.b`) can delete the wrong line.
2. `deleteProperty` performs an unqueued `read`/`modify`, so the transform's delete-then-add is not a single serialized transaction.

Happy to open follow-up issues for these.

## Release / migration impact
Additive public API method; no settings or storage changes. The only behavior change is that the "New Dataview field" command and the YAML→Dataview transform now auto-place the field (after the last same-named field, else end of body) instead of showing the line-picker.
