### PR TITLE
test: add mobile debug harness

### DIFF
--- a/MOBILE_FINDINGS.md
+++ b/MOBILE_FINDINGS.md
@@ -1,6 +1,8 @@
 # MetaEdit Mobile Findings
 
-Status: harness and repro probes prepared; real-device verification pending.
+Status: issue #99 failure modes did not reproduce on a real current iPhone with
+the post-#119/#136 build; broader iPhone smoke passed. Android was not run in
+this session.
 
 ## Scope
 
@@ -8,9 +10,13 @@ This investigation starts from issue #99, where MetaEdit failed on Obsidian
 mobile because desktop exposed newer frontmatter range APIs while mobile still
 surfaced the older `frontmatter.position` shape. PR #119 replaced YAML writes
 with `app.fileManager.processFrontMatter`, and PR #136 moved frontmatter reads to
-Obsidian's `getFrontMatterInfo(content)`. Those changes are plausible root
-fixes, but they are not a real-mobile verdict until the probes below pass on an
-actual device.
+Obsidian's `getFrontMatterInfo(content)`.
+
+The real-device result below supports the root-fix hypothesis for iOS: the issue
+#99 read/write failures did not reproduce with the post-#119/#136 MetaEdit build
+on current Obsidian iOS. This run does not reproduce the original iOS 1.4.7 /
+API 1.3.7 environment, so it proves current real-iPhone behavior rather than a
+same-runtime before/after control.
 
 ## Current Evidence
 
@@ -24,7 +30,7 @@ actual device.
 - PR #136 was merged on 2026-06-28 and changed frontmatter reads to
   `getFrontMatterInfo(content)`, with a modern Obsidian runtime floor.
 - Desktop/local isolated Obsidian E2E coverage exists for frontmatter reads and
-  writes, but that does not prove the behavior inside Obsidian iOS or Android.
+  writes, but the iPhone result below is the mobile runtime proof.
 
 ## Harness Added
 
@@ -34,142 +40,169 @@ actual device.
 - `scripts/mobile/probes/issue99_frontmatter.js`
 - `scripts/mobile/probes/core_smoke.js`
 
-The iOS deploy path requires `--confirm-real-vault`, creates a local backup of
-the existing phone plugin folder before writing, byte-verifies pushed artifacts,
+The iOS harness follows the `/Users/christian/Developer/safdeb` pattern:
+House Arrest AFC for Obsidian's Documents container plus Web Inspector eval for
+runtime state, plugin enable/reload, probes, and console/error streaming.
+
+The deploy path requires `--confirm-real-vault`, creates a local backup of the
+existing phone plugin folder before writing, byte-verifies pushed artifacts,
 verifies the backup before writing, asserts that the AFC target vault matches the
 vault open in Obsidian, and supports restore.
 
-## Device-Independent Repro Plan
+## iPhone Environment
 
-Build the local plugin artifacts first:
+- Device/runtime: iPhone WebView, `navigator.platform` = `iPhone`
+- User agent: `Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148  obsidian`
+- Obsidian iOS app: `1.13.1` build `339` (`md.obsidian`)
+- `window.apiVersion`: `null`
+- Vault: `notes`
+- AFC vault path: `/Documents/notes`
+- MetaEdit under test: local `1.8.4` build from this worktree
+- Web Inspector target: `<Obsidian(15176) TYPE:WIRTypeWebPage URL:capacitor://localhost>`
+- Pre-deploy phone state: MetaEdit installed but disabled, `manifest.json`
+  `minAppVersion: 1.4.1`
+
+## Snapshot And Deploy
+
+Command:
 
 ```bash
-pnpm run build
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py deploy --vault notes --confirm-real-vault
 ```
 
-The issue #99 probe is committed at
-`scripts/mobile/probes/issue99_frontmatter.js`. It creates a scratch note named:
+Snapshot:
 
 ```text
-MetaEdit Mobile Debug/issue-99-frontmatter.md
+~/.metaedit-mobile-backups/metaedit/<device>/notes/20260628T160849Z
 ```
 
-The scratch note begins with YAML frontmatter that includes:
+The snapshot was created before any write to the phone and covered the existing
+`/Documents/notes/.obsidian/plugins/metaedit` folder, including
+`main.js`, `manifest.json`, `styles.css`, and `data.json`.
 
-```yaml
-mobile_status: initial
-mobile_empty:
-mobile_keep: stay
-```
+Deploy result:
 
-The probe then runs these MetaEdit API operations inside Obsidian mobile:
+- Target: `/Documents/notes/.obsidian/plugins/metaedit`
+- `main.js`: 339923 bytes, SHA-256 verified
+  `3f39253ca69b0f48f54dc0b530c14ea6c42ce20d8e9431e3d423de080afba35b`
+- `manifest.json`: 253 bytes, SHA-256 verified
+  `7f93db770dfb3385c28cac356edf355edad3f15807727afa9af2493458e1002e`
+- `styles.css`: 1231 bytes, SHA-256 verified
+  `1834d22e99ebedb9df5112e80bdcbe1e3afc324d6ad8d2e1c87b0f6b5702be29`
+- `.hotreload`: 0 bytes, SHA-256 verified
+  `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+- Runtime after deploy: `enabled: true`, `instantiated: true`,
+  `loadedVersion: 1.8.4`, `apiReady: true`
 
-- read `mobile_empty`;
-- create `mobile_new` with value `created-on-mobile`;
-- update `mobile_status` to `updated-on-mobile`;
-- create `mobile_clear` and then set it to JavaScript `null`;
-- read all values back through MetaEdit;
-- inspect MetaEdit's parsed property keys;
-- read the raw note content.
+## Issue #99 Probe
 
-The probe fails if any of the two issue #99 mobile regressions appear:
-
-- `mobile_empty` or `mobile_clear` read back as the literal string `"null"`
-  instead of JavaScript `null`;
-- MetaEdit exposes `position` as a parsed property key or writes a top-level
-  `position:` line into the note.
-
-It also fails if the normal read/write assertions do not hold:
-
-- `mobile_status` must read back as `updated-on-mobile`;
-- `mobile_new` must read back as `created-on-mobile`;
-- `mobile_keep` must remain `stay`.
-
-Obsidian's raw frontmatter cache keys are returned only as diagnostics because
-older mobile APIs may keep an internal cache key named `position`. The failure is
-MetaEdit surfacing that key to users or writing it into the note.
-
-The scratch note is deleted after the probe collects the evidence returned in
-JSON.
-
-## Core Smoke Plan
-
-The broader smoke probe is committed at
-`scripts/mobile/probes/core_smoke.js`. It creates scratch files under:
-
-```text
-MetaEdit Mobile Debug/core-smoke/
-```
-
-It checks:
-
-- the Edit Meta command opens and lists YAML and inline fields;
-- an inline `key:: value` field updates through the public API;
-- the Auto Properties value prompt opens and writes a selected value;
-- Progress Properties update YAML without rewriting matching body text;
-- the Kanban helper updates a linked note when a card moves lanes.
-
-The smoke probe keeps settings mutations in memory, restores the in-memory
-settings snapshot in `finally`, and deletes the scratch files it created after
-collecting evidence.
-
-## Planned iPhone Commands
-
-Prerequisites:
-
-- iPhone connected over USB, unlocked, and trusted by this Mac.
-- Obsidian open on the phone.
-- Settings > Apps > Safari > Advanced > Web Inspector enabled.
-- A clearly named scratch vault is open on the phone when possible.
-- Christian explicitly approves the vault target for this session.
-
-Read-only diagnosis first:
+Command:
 
 ```bash
-uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose --vault MetaEditMobileScratch
-```
-
-After Christian explicitly approves deployment to that target vault:
-
-```bash
-uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py deploy --vault MetaEditMobileScratch --confirm-real-vault
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --file scripts/mobile/probes/issue99_frontmatter.js
-uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --file scripts/mobile/probes/core_smoke.js
-uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py logs --seconds 60
-uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py restore
 ```
 
-If no scratch vault is available and Christian approves using the primary
-`notes` vault instead, omit `--vault MetaEditMobileScratch`. That path still
-snapshots and restores the real `notes/.obsidian/plugins/metaedit` folder.
+Result: `ok: true`.
 
-## Planned Android Commands
+Evidence returned by the probe:
 
-Android is secondary for this investigation. The Android harness requires `adb`,
-an Android emulator or device, Obsidian running, and a scratch vault open.
+- Scratch note:
+  `MetaEdit Mobile Debug/issue-99-frontmatter.md`
+- `mobile_status` read back as `updated-on-mobile`.
+- `mobile_new` read back as `created-on-mobile`.
+- `mobile_empty` read back as JavaScript `null`.
+- `mobile_clear` read back as JavaScript `null`.
+- Parsed MetaEdit property keys were `mobile_status`, `mobile_empty`,
+  `mobile_keep`, `mobile_new`, `mobile_clear`, and `inline_mobile`.
+- Raw note content contained no top-level `position:` line.
+- Scratch note cleanup deleted
+  `MetaEdit Mobile Debug/issue-99-frontmatter.md` without errors.
+
+Verdict for #99 on this iPhone: the two reported mobile regressions did not
+reproduce in the post-#119/#136 build. Blank/cleared YAML values did not become
+the literal string `"null"`, and no `position` property appeared in MetaEdit's
+parsed properties or the note text.
+
+## Core Smoke Probe
+
+Command:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --timeout 180 --file scripts/mobile/probes/core_smoke.js
+```
+
+Result: `ok: true`.
+
+Evidence returned by the probe:
+
+- Scratch root:
+  `MetaEdit Mobile Debug/core-smoke-20260628160922`
+- Edit Meta listed `status` and `inline_status`.
+- Inline field content became `inline_status:: published`.
+- Auto Properties wrote `ap_status: done`.
+- Progress Properties wrote `readProgress: "2"` and left the matching body text
+  `readProgress: 0` unchanged.
+- Kanban helper changed the linked note to `status: In Progress`.
+- Scratch file cleanup deleted all created smoke files without errors.
+
+The approved run used a unique `core-smoke-<timestamp>` folder. That matters
+because MetaEdit's automator manager caches the last content by file path;
+rerunning the Kanban smoke against the same path and identical board content can
+correctly suppress a duplicate modify event. After the approved run, the
+committed probe was hardened further to use a unique Kanban board basename too,
+so the temporary automator cannot match an existing board name in the real vault
+during the test window.
+
+## Console Check
+
+Commands:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval '(()=>{console.clear(); return "cleared";})()'
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py logs --seconds 10
+```
+
+Fresh post-probe result: no console errors or uncaught errors streamed.
+
+## Restore
+
+Command:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py restore --backup ~/.metaedit-mobile-backups/metaedit/<device>/notes/20260628T160849Z
+```
+
+Restore result:
+
+- `/Documents/notes/.obsidian/plugins/metaedit` restored from the local backup.
+- MetaEdit enabled state restored to disabled.
+- Final diagnosis showed `enabled: false`, `instantiated: false`,
+  `loadedVersion: null`, `apiReady: false`, and plugin files `styles.css`,
+  `data.json`, `main.js`, `manifest.json`.
+- Final diagnosis showed `manifest.json` metadata back to `minAppVersion: 1.4.1`
+  and no `.hotreload` file.
+
+## Android
+
+Android is secondary for this investigation and was not run in this session. The
+Android harness is committed for a future pass where `adb`, an emulator/device,
+and an open disposable scratch Obsidian vault are available. Android deploy has
+no backup/restore path, so it requires an explicit scratch-vault confirmation:
 
 ```bash
 uv run --no-project --with websockets python scripts/mobile/metaedit_android.py diagnose
-uv run --no-project --with websockets python scripts/mobile/metaedit_android.py deploy
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py deploy --confirm-scratch-vault
 uv run --no-project --with websockets python scripts/mobile/metaedit_android.py eval --file scripts/mobile/probes/issue99_frontmatter.js
 uv run --no-project --with websockets python scripts/mobile/metaedit_android.py eval --file scripts/mobile/probes/core_smoke.js
 ```
 
-## Verdict Criteria
+## Conclusion
 
-Issue #99 is fixed on real mobile only if `issue99_frontmatter.js` returns
-`ok: true` on an actual iPhone or Android device/emulator after deploying the
-local MetaEdit build.
+On the approved real iPhone run, issue #99's two reported failure modes are
+fixed/not reproducible in the post-#119/#136 build. The run exercises the current
+read/write paths introduced by #119/#136 and found no real iOS product bug
+requiring a root-cause code fix. It does not prove a same-runtime before/after
+against the original Obsidian iOS 1.4.7 / API 1.3.7 environment.
 
-The broader mobile smoke test is clean only if `core_smoke.js` returns `ok: true`
-on the same mobile runtime.
-
-Until that happens, this report deliberately does not conclude that #99 is fixed
-on real mobile.
-
-## Pending iPhone Verification
-
-Do not deploy or run the write probes on an iPhone until Christian connects it
-and gives explicit per-session approval to touch the target vault. The harness
-will snapshot and restore the target vault's real `metaedit` plugin folder
-around the test.
+Christian should decide whether and when to close #99. No issue comments or
+closures were made by this investigation.

--- a/MOBILE_FINDINGS.md
+++ b/MOBILE_FINDINGS.md
@@ -1,6 +1,6 @@
 # MetaEdit Mobile Findings
 
-Status: Android emulator verification passed; iPhone verification pending.
+Status: harness and repro probes prepared; real-device verification pending.
 
 ## Scope
 
@@ -8,8 +8,9 @@ This investigation starts from issue #99, where MetaEdit failed on Obsidian
 mobile because desktop exposed newer frontmatter range APIs while mobile still
 surfaced the older `frontmatter.position` shape. PR #119 replaced YAML writes
 with `app.fileManager.processFrontMatter`, and PR #136 moved frontmatter reads to
-Obsidian's `getFrontMatterInfo(content)`. Those changes are plausible root fixes,
-but they are not a mobile verdict until the probes below pass on a real device.
+Obsidian's `getFrontMatterInfo(content)`. Those changes are plausible root
+fixes, but they are not a real-mobile verdict until the probes below pass on an
+actual device.
 
 ## Current Evidence
 
@@ -18,14 +19,12 @@ but they are not a mobile verdict until the probes below pass on a real device.
 - The issue comment by xt0rted identified two concrete old-mobile failure modes:
   unset values could surface as the literal string `"null"`, and Obsidian's
   legacy `frontmatter.position` data could leak into MetaEdit as a real property.
-- PR #119 was merged on 2026-06-27 and removed raw frontmatter substring writes in
-  favor of `processFrontMatter`.
+- PR #119 was merged on 2026-06-27 and removed raw frontmatter substring writes
+  in favor of `processFrontMatter`.
 - PR #136 was merged on 2026-06-28 and changed frontmatter reads to
   `getFrontMatterInfo(content)`, with a modern Obsidian runtime floor.
 - Desktop/local isolated Obsidian E2E coverage exists for frontmatter reads and
-  writes, but that does not prove the behavior inside Obsidian iOS.
-- Android emulator verification on 2026-06-28 passed the issue #99 probe and the
-  broader core smoke probe using Obsidian Android 1.12.7 and MetaEdit 1.8.4.
+  writes, but that does not prove the behavior inside Obsidian iOS or Android.
 
 ## Harness Added
 
@@ -35,66 +34,119 @@ but they are not a mobile verdict until the probes below pass on a real device.
 - `scripts/mobile/probes/issue99_frontmatter.js`
 - `scripts/mobile/probes/core_smoke.js`
 
-The harness deploy path requires `--confirm-real-vault`, creates a local backup
-of the existing phone plugin folder before writing, byte-verifies pushed
-artifacts, verifies the backup before writing, asserts that the AFC target vault
-matches the vault open in Obsidian, and supports restore.
+The iOS deploy path requires `--confirm-real-vault`, creates a local backup of
+the existing phone plugin folder before writing, byte-verifies pushed artifacts,
+verifies the backup before writing, asserts that the AFC target vault matches the
+vault open in Obsidian, and supports restore.
 
-## Planned On-Device Commands
+## Device-Independent Repro Plan
 
-Prerequisites:
+Build the local plugin artifacts first:
 
 ```bash
 pnpm run build
 ```
 
+The issue #99 probe is committed at
+`scripts/mobile/probes/issue99_frontmatter.js`. It creates a scratch note named:
+
+```text
+MetaEdit Mobile Debug/issue-99-frontmatter.md
+```
+
+The scratch note begins with YAML frontmatter that includes:
+
+```yaml
+mobile_status: initial
+mobile_empty:
+mobile_keep: stay
+```
+
+The probe then runs these MetaEdit API operations inside Obsidian mobile:
+
+- read `mobile_empty`;
+- create `mobile_new` with value `created-on-mobile`;
+- update `mobile_status` to `updated-on-mobile`;
+- create `mobile_clear` and then set it to JavaScript `null`;
+- read all values back through MetaEdit;
+- inspect MetaEdit's parsed property keys;
+- read the raw note content.
+
+The probe fails if any of the two issue #99 mobile regressions appear:
+
+- `mobile_empty` or `mobile_clear` read back as the literal string `"null"`
+  instead of JavaScript `null`;
+- MetaEdit exposes `position` as a parsed property key or writes a top-level
+  `position:` line into the note.
+
+It also fails if the normal read/write assertions do not hold:
+
+- `mobile_status` must read back as `updated-on-mobile`;
+- `mobile_new` must read back as `created-on-mobile`;
+- `mobile_keep` must remain `stay`.
+
+Obsidian's raw frontmatter cache keys are returned only as diagnostics because
+older mobile APIs may keep an internal cache key named `position`. The failure is
+MetaEdit surfacing that key to users or writing it into the note.
+
+The scratch note is deleted after the probe collects the evidence returned in
+JSON.
+
+## Core Smoke Plan
+
+The broader smoke probe is committed at
+`scripts/mobile/probes/core_smoke.js`. It creates scratch files under:
+
+```text
+MetaEdit Mobile Debug/core-smoke/
+```
+
+It checks:
+
+- the Edit Meta command opens and lists YAML and inline fields;
+- an inline `key:: value` field updates through the public API;
+- the Auto Properties value prompt opens and writes a selected value;
+- Progress Properties update YAML without rewriting matching body text;
+- the Kanban helper updates a linked note when a card moves lanes.
+
+The smoke probe keeps settings mutations in memory, restores the in-memory
+settings snapshot in `finally`, and deletes the scratch files it created after
+collecting evidence.
+
+## Planned iPhone Commands
+
+Prerequisites:
+
+- iPhone connected over USB, unlocked, and trusted by this Mac.
+- Obsidian open on the phone.
+- Settings > Apps > Safari > Advanced > Web Inspector enabled.
+- A clearly named scratch vault is open on the phone when possible.
+- Christian explicitly approves the vault target for this session.
+
 Read-only diagnosis first:
 
 ```bash
-uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose --vault MetaEditMobileScratch
 ```
 
-After Christian explicitly approves deployment to the real `notes` vault:
+After Christian explicitly approves deployment to that target vault:
 
 ```bash
-uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py deploy --confirm-real-vault
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py deploy --vault MetaEditMobileScratch --confirm-real-vault
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --file scripts/mobile/probes/issue99_frontmatter.js
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --file scripts/mobile/probes/core_smoke.js
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py logs --seconds 60
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py restore
 ```
 
-## Android Emulator Result
+If no scratch vault is available and Christian approves using the primary
+`notes` vault instead, omit `--vault MetaEditMobileScratch`. That path still
+snapshots and restores the real `notes/.obsidian/plugins/metaedit` folder.
 
-Environment:
+## Planned Android Commands
 
-- Emulator: `MetaEditMobileApi35`
-- Android: 15 / SDK 35
-- Device model: `sdk_gphone64_arm64`
-- ABI: `arm64-v8a`
-- WebView user agent: Chrome/124 Android WebView
-- Obsidian APK: official `Obsidian-1.12.7.apk`
-- Vault: `/sdcard/Documents/MetaEditMobile`
-- MetaEdit: local 1.8.4 build from this worktree
-
-Setup summary:
-
-```bash
-brew install android-platform-tools android-commandlinetools
-yes | ANDROID_HOME=/opt/homebrew/share/android-commandlinetools sdkmanager --licenses
-ANDROID_HOME=/opt/homebrew/share/android-commandlinetools sdkmanager \
-  "emulator" \
-  "platform-tools" \
-  "platforms;android-35" \
-  "system-images;android-35;google_apis;arm64-v8a"
-printf 'no\n' | ANDROID_HOME=/opt/homebrew/share/android-commandlinetools avdmanager create avd \
-  --force \
-  --name MetaEditMobileApi35 \
-  --package "system-images;android-35;google_apis;arm64-v8a" \
-  --device pixel_7
-```
-
-Commands run against the booted emulator:
+Android is secondary for this investigation. The Android harness requires `adb`,
+an Android emulator or device, Obsidian running, and a scratch vault open.
 
 ```bash
 uv run --no-project --with websockets python scripts/mobile/metaedit_android.py diagnose
@@ -103,69 +155,21 @@ uv run --no-project --with websockets python scripts/mobile/metaedit_android.py 
 uv run --no-project --with websockets python scripts/mobile/metaedit_android.py eval --file scripts/mobile/probes/core_smoke.js
 ```
 
-Issue #99 probe result: `ok: true`.
+## Verdict Criteria
 
-- `mobile_status` read back as `updated-on-mobile`.
-- `mobile_new` read back as `created-on-mobile`.
-- `mobile_empty` read back as `null`.
-- `mobile_clear` read back as `null`.
-- Parsed property keys were `mobile_status`, `mobile_empty`, `mobile_keep`,
-  `mobile_new`, `mobile_clear`, and `inline_mobile`.
-- Raw note content had no top-level `position:` line.
-- Scratch note cleanup deleted
-  `MetaEdit Mobile Debug/issue-99-frontmatter.md` without errors.
+Issue #99 is fixed on real mobile only if `issue99_frontmatter.js` returns
+`ok: true` on an actual iPhone or Android device/emulator after deploying the
+local MetaEdit build.
 
-Core smoke result: `ok: true`.
+The broader mobile smoke test is clean only if `core_smoke.js` returns `ok: true`
+on the same mobile runtime.
 
-- Edit Meta listed `status` and `inline_status`.
-- Inline field content became `inline_status:: published`.
-- Auto Properties wrote `ap_status: done`.
-- Progress Properties wrote `readProgress: "2"` and left the matching body text
-  `readProgress: 0` unchanged.
-- Kanban helper changed the linked note to `status: In Progress`.
-- Scratch file cleanup deleted all created smoke files without errors.
-
-Log check:
-
-- `adb logcat -d -t 1000` filtered for Obsidian/WebView/fatal/crash/exception
-  showed no MetaEdit or Obsidian fatal errors. The remaining lines were expected
-  IME, frame timing, media scanner, and MediaProvider cleanup noise.
-
-## Issue #99 Verdict Criteria
-
-Fixed on real mobile only if `issue99_frontmatter.js` returns `ok: true` on an
-actual iPhone after deploying the local MetaEdit build. The returned evidence
-must show:
-
-- `mobile_status` changes from `initial` to `updated-on-mobile`;
-- `mobile_new` reads back as `created-on-mobile`;
-- `mobile_empty` and `mobile_clear` read back as JavaScript `null`, not `"null"`;
-- no `position` key exists in MetaEdit parsed property keys;
-- the raw scratch note does not contain a top-level `position:` line.
-
-The probe reports Obsidian's raw frontmatter cache keys as diagnostics, but does
-not fail solely because old mobile exposes an internal cache key named
-`position`. The failure is MetaEdit surfacing that key to users or writing it
-into the note.
-
-The scratch note is deleted after the probe collects the evidence returned in
-JSON.
-
-## Broader Smoke Criteria
-
-Mobile smoke is clean only if `core_smoke.js` returns `ok: true`, covering:
-
-- Edit Meta menu lists a YAML field and an inline field;
-- public API updates an inline `key:: value` field;
-- Auto Properties value prompt writes a selected value;
-- Progress Properties update YAML while leaving matching body text unchanged;
-- Kanban helper updates a linked card note after a lane move.
-
-The smoke probe keeps settings mutations in memory, restores the in-memory
-settings snapshot in `finally`, and deletes the scratch files it created after
-collecting evidence.
+Until that happens, this report deliberately does not conclude that #99 is fixed
+on real mobile.
 
 ## Pending iPhone Verification
 
 Do not deploy or run the write probes on an iPhone until Christian connects it
-and gives explicit per-session approval to touch the real `notes` vault.
+and gives explicit per-session approval to touch the target vault. The harness
+will snapshot and restore the target vault's real `metaedit` plugin folder
+around the test.

--- a/MOBILE_FINDINGS.md
+++ b/MOBILE_FINDINGS.md
@@ -1,6 +1,6 @@
 # MetaEdit Mobile Findings
 
-Status: device-independent setup complete; real-device verification pending.
+Status: Android emulator verification passed; iPhone verification pending.
 
 ## Scope
 
@@ -24,10 +24,13 @@ but they are not a mobile verdict until the probes below pass on a real device.
   `getFrontMatterInfo(content)`, with a modern Obsidian runtime floor.
 - Desktop/local isolated Obsidian E2E coverage exists for frontmatter reads and
   writes, but that does not prove the behavior inside Obsidian iOS.
+- Android emulator verification on 2026-06-28 passed the issue #99 probe and the
+  broader core smoke probe using Obsidian Android 1.12.7 and MetaEdit 1.8.4.
 
 ## Harness Added
 
 - `scripts/mobile/metaedit_ios.py`
+- `scripts/mobile/metaedit_android.py`
 - `scripts/mobile/README.md`
 - `scripts/mobile/probes/issue99_frontmatter.js`
 - `scripts/mobile/probes/core_smoke.js`
@@ -60,6 +63,73 @@ uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py logs --seconds 60
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py restore
 ```
+
+## Android Emulator Result
+
+Environment:
+
+- Emulator: `MetaEditMobileApi35`
+- Android: 15 / SDK 35
+- Device model: `sdk_gphone64_arm64`
+- ABI: `arm64-v8a`
+- WebView user agent: Chrome/124 Android WebView
+- Obsidian APK: official `Obsidian-1.12.7.apk`
+- Vault: `/sdcard/Documents/MetaEditMobile`
+- MetaEdit: local 1.8.4 build from this worktree
+
+Setup summary:
+
+```bash
+brew install android-platform-tools android-commandlinetools
+yes | ANDROID_HOME=/opt/homebrew/share/android-commandlinetools sdkmanager --licenses
+ANDROID_HOME=/opt/homebrew/share/android-commandlinetools sdkmanager \
+  "emulator" \
+  "platform-tools" \
+  "platforms;android-35" \
+  "system-images;android-35;google_apis;arm64-v8a"
+printf 'no\n' | ANDROID_HOME=/opt/homebrew/share/android-commandlinetools avdmanager create avd \
+  --force \
+  --name MetaEditMobileApi35 \
+  --package "system-images;android-35;google_apis;arm64-v8a" \
+  --device pixel_7
+```
+
+Commands run against the booted emulator:
+
+```bash
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py diagnose
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py deploy
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py eval --file scripts/mobile/probes/issue99_frontmatter.js
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py eval --file scripts/mobile/probes/core_smoke.js
+```
+
+Issue #99 probe result: `ok: true`.
+
+- `mobile_status` read back as `updated-on-mobile`.
+- `mobile_new` read back as `created-on-mobile`.
+- `mobile_empty` read back as `null`.
+- `mobile_clear` read back as `null`.
+- Parsed property keys were `mobile_status`, `mobile_empty`, `mobile_keep`,
+  `mobile_new`, `mobile_clear`, and `inline_mobile`.
+- Raw note content had no top-level `position:` line.
+- Scratch note cleanup deleted
+  `MetaEdit Mobile Debug/issue-99-frontmatter.md` without errors.
+
+Core smoke result: `ok: true`.
+
+- Edit Meta listed `status` and `inline_status`.
+- Inline field content became `inline_status:: published`.
+- Auto Properties wrote `ap_status: done`.
+- Progress Properties wrote `readProgress: "2"` and left the matching body text
+  `readProgress: 0` unchanged.
+- Kanban helper changed the linked note to `status: In Progress`.
+- Scratch file cleanup deleted all created smoke files without errors.
+
+Log check:
+
+- `adb logcat -d -t 1000` filtered for Obsidian/WebView/fatal/crash/exception
+  showed no MetaEdit or Obsidian fatal errors. The remaining lines were expected
+  IME, frame timing, media scanner, and MediaProvider cleanup noise.
 
 ## Issue #99 Verdict Criteria
 
@@ -95,8 +165,7 @@ The smoke probe keeps settings mutations in memory, restores the in-memory
 settings snapshot in `finally`, and deletes the scratch files it created after
 collecting evidence.
 
-## Pending
+## Pending iPhone Verification
 
-No iPhone is currently connected over USB, and Android tooling is not installed
-on this Mac. Do not deploy or run the write probes until Christian connects the
-iPhone and gives explicit per-session approval to touch the real `notes` vault.
+Do not deploy or run the write probes on an iPhone until Christian connects it
+and gives explicit per-session approval to touch the real `notes` vault.

--- a/MOBILE_FINDINGS.md
+++ b/MOBILE_FINDINGS.md
@@ -1,0 +1,102 @@
+# MetaEdit Mobile Findings
+
+Status: device-independent setup complete; real-device verification pending.
+
+## Scope
+
+This investigation starts from issue #99, where MetaEdit failed on Obsidian
+mobile because desktop exposed newer frontmatter range APIs while mobile still
+surfaced the older `frontmatter.position` shape. PR #119 replaced YAML writes
+with `app.fileManager.processFrontMatter`, and PR #136 moved frontmatter reads to
+Obsidian's `getFrontMatterInfo(content)`. Those changes are plausible root fixes,
+but they are not a mobile verdict until the probes below pass on a real device.
+
+## Current Evidence
+
+- Issue #99 remains open and describes Obsidian iOS TestFlight 1.4.7 / API 1.3.7
+  failing with `right side of assignment cannot be destructed`.
+- The issue comment by xt0rted identified two concrete old-mobile failure modes:
+  unset values could surface as the literal string `"null"`, and Obsidian's
+  legacy `frontmatter.position` data could leak into MetaEdit as a real property.
+- PR #119 was merged on 2026-06-27 and removed raw frontmatter substring writes in
+  favor of `processFrontMatter`.
+- PR #136 was merged on 2026-06-28 and changed frontmatter reads to
+  `getFrontMatterInfo(content)`, with a modern Obsidian runtime floor.
+- Desktop/local isolated Obsidian E2E coverage exists for frontmatter reads and
+  writes, but that does not prove the behavior inside Obsidian iOS.
+
+## Harness Added
+
+- `scripts/mobile/metaedit_ios.py`
+- `scripts/mobile/README.md`
+- `scripts/mobile/probes/issue99_frontmatter.js`
+- `scripts/mobile/probes/core_smoke.js`
+
+The harness deploy path requires `--confirm-real-vault`, creates a local backup
+of the existing phone plugin folder before writing, byte-verifies pushed
+artifacts, verifies the backup before writing, asserts that the AFC target vault
+matches the vault open in Obsidian, and supports restore.
+
+## Planned On-Device Commands
+
+Prerequisites:
+
+```bash
+pnpm run build
+```
+
+Read-only diagnosis first:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose
+```
+
+After Christian explicitly approves deployment to the real `notes` vault:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py deploy --confirm-real-vault
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --file scripts/mobile/probes/issue99_frontmatter.js
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --file scripts/mobile/probes/core_smoke.js
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py logs --seconds 60
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py restore
+```
+
+## Issue #99 Verdict Criteria
+
+Fixed on real mobile only if `issue99_frontmatter.js` returns `ok: true` on an
+actual iPhone after deploying the local MetaEdit build. The returned evidence
+must show:
+
+- `mobile_status` changes from `initial` to `updated-on-mobile`;
+- `mobile_new` reads back as `created-on-mobile`;
+- `mobile_empty` and `mobile_clear` read back as JavaScript `null`, not `"null"`;
+- no `position` key exists in MetaEdit parsed property keys;
+- the raw scratch note does not contain a top-level `position:` line.
+
+The probe reports Obsidian's raw frontmatter cache keys as diagnostics, but does
+not fail solely because old mobile exposes an internal cache key named
+`position`. The failure is MetaEdit surfacing that key to users or writing it
+into the note.
+
+The scratch note is deleted after the probe collects the evidence returned in
+JSON.
+
+## Broader Smoke Criteria
+
+Mobile smoke is clean only if `core_smoke.js` returns `ok: true`, covering:
+
+- Edit Meta menu lists a YAML field and an inline field;
+- public API updates an inline `key:: value` field;
+- Auto Properties value prompt writes a selected value;
+- Progress Properties update YAML while leaving matching body text unchanged;
+- Kanban helper updates a linked card note after a lane move.
+
+The smoke probe keeps settings mutations in memory, restores the in-memory
+settings snapshot in `finally`, and deletes the scratch files it created after
+collecting evidence.
+
+## Pending
+
+No iPhone is currently connected over USB, and Android tooling is not installed
+on this Mac. Do not deploy or run the write probes until Christian connects the
+iPhone and gives explicit per-session approval to touch the real `notes` vault.

--- a/scripts/mobile/README.md
+++ b/scripts/mobile/README.md
@@ -28,15 +28,24 @@ uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py
 
 ## Safety
 
-The phone vault is real. Christian's current phone uses an AFC-reachable local
-vault named `notes`, so deploy targets:
+The phone vault is real. Use a clearly named scratch vault when possible and
+pass it explicitly:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose --vault MetaEditMobileScratch
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py deploy --vault MetaEditMobileScratch --confirm-real-vault
+```
+
+Christian's primary phone vault has historically been an AFC-reachable local
+vault named `notes`. If `--vault` is omitted, deploy targets:
 
 ```text
 /Documents/notes/.obsidian/plugins/metaedit
 ```
 
-`deploy` refuses to run unless `--confirm-real-vault` is passed. Before writing,
-it snapshots the existing phone plugin folder into:
+Do not deploy to `notes` unless Christian explicitly approves that target for
+the current session. `deploy` refuses to run unless `--confirm-real-vault` is
+passed. Before writing, it snapshots the existing phone plugin folder into:
 
 ```text
 ~/.metaedit-mobile-backups/metaedit/<device>/<vault>/<timestamp>/
@@ -60,12 +69,14 @@ Diagnose install/runtime state:
 
 ```bash
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose --vault MetaEditMobileScratch
 ```
 
 Deploy the local build after explicit approval:
 
 ```bash
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py deploy --confirm-real-vault
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py deploy --vault MetaEditMobileScratch --confirm-real-vault
 ```
 
 Reload the already-installed plugin:
@@ -134,7 +145,7 @@ created after collecting evidence. If Web Inspector disconnects mid-run, rerun
 The Android harness uses `adb` plus WebView CDP forwarding. It expects Obsidian
 to be running and a scratch vault to be open.
 
-One emulator setup used for this investigation:
+Optional emulator setup:
 
 ```bash
 brew install android-platform-tools android-commandlinetools

--- a/scripts/mobile/README.md
+++ b/scripts/mobile/README.md
@@ -131,6 +131,40 @@ created after collecting evidence. If Web Inspector disconnects mid-run, rerun
 
 ## Android
 
-The safdeb Android path uses `adb` plus WebView CDP forwarding. This Mac does not
-currently have `adb` installed and has no AVD configured, so Android verification
-is intentionally secondary for this investigation.
+The Android harness uses `adb` plus WebView CDP forwarding. It expects Obsidian
+to be running and a scratch vault to be open.
+
+One emulator setup used for this investigation:
+
+```bash
+brew install android-platform-tools android-commandlinetools
+yes | ANDROID_HOME=/opt/homebrew/share/android-commandlinetools sdkmanager --licenses
+ANDROID_HOME=/opt/homebrew/share/android-commandlinetools sdkmanager \
+  "emulator" \
+  "platform-tools" \
+  "platforms;android-35" \
+  "system-images;android-35;google_apis;arm64-v8a"
+printf 'no\n' | ANDROID_HOME=/opt/homebrew/share/android-commandlinetools avdmanager create avd \
+  --force \
+  --name MetaEditMobileApi35 \
+  --package "system-images;android-35;google_apis;arm64-v8a" \
+  --device pixel_7
+ANDROID_HOME=/opt/homebrew/share/android-commandlinetools \
+  /opt/homebrew/share/android-commandlinetools/emulator/emulator \
+  -avd MetaEditMobileApi35 \
+  -no-snapshot \
+  -no-window \
+  -gpu swiftshader_indirect \
+  -no-audio \
+  -no-boot-anim
+```
+
+Install Obsidian's official Android APK, create/open a scratch vault at
+`/sdcard/Documents/MetaEditMobile`, then run:
+
+```bash
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py diagnose
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py deploy
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py eval --file scripts/mobile/probes/issue99_frontmatter.js
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py eval --file scripts/mobile/probes/core_smoke.js
+```

--- a/scripts/mobile/README.md
+++ b/scripts/mobile/README.md
@@ -58,10 +58,12 @@ uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py
 uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py restore
 ```
 
-Deploy also checks that the vault open in Obsidian's WebView has the same name as
-the AFC target vault before writing. The harness is not an iCloud-container
-deployer; if a vault is not visible under Obsidian's app Documents container, it
-will stop before deploy.
+Deploy checks that the vault open in Obsidian's WebView has the same name as the
+AFC target vault before writing. Restore also checks the backup's AFC plugin path
+against the connected device's current vault path, and verifies that the same
+target vault is open before restoring the saved enabled/disabled state. The
+harness is not an iCloud-container deployer; if a vault is not visible under
+Obsidian's app Documents container, it will stop before deploy or restore.
 
 ## Commands
 
@@ -148,7 +150,9 @@ disconnects mid-run, rerun `restore`/`reload` before continuing.
 The Android harness uses `adb` plus WebView CDP forwarding. It expects Obsidian
 to be running and a disposable scratch vault to be open. Android deploy does not
 snapshot or restore plugin files, so it refuses to deploy unless
-`--confirm-scratch-vault` is passed.
+`--confirm-scratch-vault` is passed. Before pushing files or enabling MetaEdit,
+it checks the currently open Obsidian Android vault against `--vault-path` and
+refuses to continue when they differ.
 
 Optional emulator setup:
 

--- a/scripts/mobile/README.md
+++ b/scripts/mobile/README.md
@@ -1,0 +1,136 @@
+# MetaEdit Mobile Debug Harness
+
+This directory contains a USB iPhone harness for testing the local MetaEdit build
+inside Obsidian iOS. It is adapted from `/Users/christian/Developer/safdeb` and
+uses:
+
+- `pymobiledevice3` House Arrest AFC to copy plugin files into Obsidian's app
+  documents container.
+- `pymobiledevice3` Web Inspector to evaluate JavaScript in Obsidian's WKWebView,
+  reload the plugin, and stream console errors.
+
+## Prerequisites
+
+- iPhone connected over USB, unlocked, trusted by this Mac.
+- Obsidian open on the phone.
+- iOS setting enabled: Settings > Apps > Safari > Advanced > Web Inspector.
+- Local build artifacts created first:
+
+```bash
+pnpm run build
+```
+
+Run commands through `uv` so the Python dependency is isolated:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose
+```
+
+## Safety
+
+The phone vault is real. Christian's current phone uses an AFC-reachable local
+vault named `notes`, so deploy targets:
+
+```text
+/Documents/notes/.obsidian/plugins/metaedit
+```
+
+`deploy` refuses to run unless `--confirm-real-vault` is passed. Before writing,
+it snapshots the existing phone plugin folder into:
+
+```text
+~/.metaedit-mobile-backups/metaedit/<device>/<vault>/<timestamp>/
+```
+
+List or restore backups with:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py backups
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py restore
+```
+
+Deploy also checks that the vault open in Obsidian's WebView has the same name as
+the AFC target vault before writing. The harness is not an iCloud-container
+deployer; if a vault is not visible under Obsidian's app Documents container, it
+will stop before deploy.
+
+## Commands
+
+Diagnose install/runtime state:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose
+```
+
+Deploy the local build after explicit approval:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py deploy --confirm-real-vault
+```
+
+Reload the already-installed plugin:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py reload
+```
+
+Evaluate JavaScript in Obsidian iOS:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval 'app.vault.getName()'
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --file scripts/mobile/probes/issue99_frontmatter.js
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --file scripts/mobile/probes/core_smoke.js
+```
+
+Stream console errors while reproducing manually:
+
+```bash
+uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py logs --seconds 120
+```
+
+## Issue #99 Probe
+
+`scripts/mobile/probes/issue99_frontmatter.js` creates this scratch note:
+
+```text
+MetaEdit Mobile Debug/issue-99-frontmatter.md
+```
+
+It verifies the frontmatter path that #99 reported, then removes the scratch note
+after collecting the returned evidence:
+
+- blank YAML values read as `null`, not the literal string `"null"`;
+- MetaEdit can create a YAML key through the public API;
+- MetaEdit can update an existing YAML key through the public API;
+- setting a YAML value to `null` reads back as `null`;
+- no visible `position` property appears in MetaEdit's parsed properties or raw
+  note text.
+
+Obsidian's raw frontmatter cache keys are returned only as diagnostics because
+older mobile APIs may keep an internal cache key named `position`.
+
+## Core Smoke Probe
+
+`scripts/mobile/probes/core_smoke.js` creates scratch files under:
+
+```text
+MetaEdit Mobile Debug/core-smoke/
+```
+
+It checks:
+
+- the Edit Meta command opens and lists YAML and inline fields;
+- an inline `key:: value` field updates through the public API;
+- the Auto Properties value prompt opens and writes a selected value;
+- Progress Properties update YAML without rewriting matching body text;
+- the Kanban helper updates a linked note when a card moves lanes.
+
+The smoke probe keeps settings changes in memory and removes the scratch files it
+created after collecting evidence. If Web Inspector disconnects mid-run, rerun
+`restore`/`reload` before continuing.
+
+## Android
+
+The safdeb Android path uses `adb` plus WebView CDP forwarding. This Mac does not
+currently have `adb` installed and has no AVD configured, so Android verification
+is intentionally secondary for this investigation.

--- a/scripts/mobile/README.md
+++ b/scripts/mobile/README.md
@@ -108,7 +108,7 @@ MetaEdit Mobile Debug/issue-99-frontmatter.md
 ```
 
 It verifies the frontmatter path that #99 reported, then removes the scratch note
-after collecting the returned evidence:
+and any empty scratch folder after collecting the returned evidence:
 
 - blank YAML values read as `null`, not the literal string `"null"`;
 - MetaEdit can create a YAML key through the public API;
@@ -122,10 +122,11 @@ older mobile APIs may keep an internal cache key named `position`.
 
 ## Core Smoke Probe
 
-`scripts/mobile/probes/core_smoke.js` creates scratch files under:
+`scripts/mobile/probes/core_smoke.js` creates scratch files under a unique
+per-run folder:
 
 ```text
-MetaEdit Mobile Debug/core-smoke/
+MetaEdit Mobile Debug/core-smoke-<timestamp>/
 ```
 
 It checks:
@@ -136,14 +137,18 @@ It checks:
 - Progress Properties update YAML without rewriting matching body text;
 - the Kanban helper updates a linked note when a card moves lanes.
 
-The smoke probe keeps settings changes in memory and removes the scratch files it
-created after collecting evidence. If Web Inspector disconnects mid-run, rerun
-`restore`/`reload` before continuing.
+The smoke probe keeps settings changes in memory and removes the scratch files
+and empty scratch folders it created after collecting evidence. It uses unique
+per-run paths and a unique Kanban board name so repeated runs do not collide with
+the automator's path-content cache or existing board names. If Web Inspector
+disconnects mid-run, rerun `restore`/`reload` before continuing.
 
 ## Android
 
 The Android harness uses `adb` plus WebView CDP forwarding. It expects Obsidian
-to be running and a scratch vault to be open.
+to be running and a disposable scratch vault to be open. Android deploy does not
+snapshot or restore plugin files, so it refuses to deploy unless
+`--confirm-scratch-vault` is passed.
 
 Optional emulator setup:
 
@@ -175,7 +180,7 @@ Install Obsidian's official Android APK, create/open a scratch vault at
 
 ```bash
 uv run --no-project --with websockets python scripts/mobile/metaedit_android.py diagnose
-uv run --no-project --with websockets python scripts/mobile/metaedit_android.py deploy
+uv run --no-project --with websockets python scripts/mobile/metaedit_android.py deploy --confirm-scratch-vault
 uv run --no-project --with websockets python scripts/mobile/metaedit_android.py eval --file scripts/mobile/probes/issue99_frontmatter.js
 uv run --no-project --with websockets python scripts/mobile/metaedit_android.py eval --file scripts/mobile/probes/core_smoke.js
 ```

--- a/scripts/mobile/metaedit_android.py
+++ b/scripts/mobile/metaedit_android.py
@@ -12,6 +12,7 @@ import argparse
 import asyncio
 import json
 import os
+import posixpath
 import subprocess
 import sys
 import urllib.request
@@ -50,6 +51,17 @@ def adb_out(args: list[str]) -> str:
 
 def js(value: str) -> str:
 	return json.dumps(value)
+
+
+def normalize_android_path(path: str) -> str:
+	normalized = posixpath.normpath(path.strip())
+	if not normalized.startswith("/"):
+		raise SystemExit(f"Android vault path must be absolute: {path!r}")
+	return normalized
+
+
+def expected_vault_name(vault_path: str) -> str:
+	return posixpath.basename(normalize_android_path(vault_path))
 
 
 def forward_cdp(port: int = CDP_PORT) -> int:
@@ -126,6 +138,7 @@ async def runtime_state() -> dict[str, Any]:
 		return {{
 			title: document.title,
 			vaultName: app?.vault?.getName?.() ?? null,
+			vaultBasePath: app?.vault?.adapter?.basePath ?? app?.vault?.adapter?.getBasePath?.() ?? null,
 			apiVersion: window.apiVersion ?? null,
 			manifestKnown: app?.plugins?.manifests?.[id] ?? null,
 			enabled: Array.from(app?.plugins?.enabledPlugins ?? []).includes(id),
@@ -136,6 +149,31 @@ async def runtime_state() -> dict[str, Any]:
 			body: document.body?.innerText?.slice(0, 500) ?? "",
 		}};
 	}})()""")
+
+
+def assert_open_vault_matches_vault_path(state: dict[str, Any], vault_path: str) -> None:
+	expected_name = expected_vault_name(vault_path)
+	open_name = state.get("vaultName")
+	if open_name != expected_name:
+		raise SystemExit(
+			"Refusing to deploy because the open Android vault differs from --vault-path.\n"
+			f"--vault-path: {normalize_android_path(vault_path)!r}\n"
+			f"Expected open vault name: {expected_name!r}\n"
+			f"Open Obsidian vault: {open_name!r}\n"
+			"Open the scratch vault in Obsidian Android, then rerun diagnose/deploy."
+		)
+
+	vault_base_path = state.get("vaultBasePath")
+	if vault_base_path:
+		expected_path = normalize_android_path(vault_path)
+		open_path = normalize_android_path(str(vault_base_path))
+		if open_path != expected_path:
+			raise SystemExit(
+				"Refusing to deploy because the open Android vault path differs from --vault-path.\n"
+				f"--vault-path: {expected_path!r}\n"
+				f"Open Obsidian vault path: {open_path!r}\n"
+				"Open the scratch vault in Obsidian Android, then rerun diagnose/deploy."
+			)
 
 
 async def enable_metaedit() -> dict[str, Any]:
@@ -162,7 +200,8 @@ async def enable_metaedit() -> dict[str, Any]:
 
 def deploy_artifacts(vault_path: str) -> None:
 	files = ensure_local_artifacts()
-	target = f"{vault_path.rstrip('/')}/.obsidian/plugins/{PLUGIN_ID}"
+	vault_path = normalize_android_path(vault_path)
+	target = f"{vault_path}/.obsidian/plugins/{PLUGIN_ID}"
 	adb_out(["shell", "mkdir", "-p", target])
 	for path in files.values():
 		run_adb(["push", str(path), f"{target}/"])
@@ -184,13 +223,15 @@ async def cmd_deploy(args: argparse.Namespace) -> None:
 			"Refusing to deploy without --confirm-scratch-vault. "
 			"Android deploy has no backup/restore path and is intended only for disposable scratch vaults."
 		)
-	deploy_artifacts(args.vault_path)
 	forward_cdp(args.port)
+	state_before = await runtime_state()
+	assert_open_vault_matches_vault_path(state_before, args.vault_path)
+	deploy_artifacts(args.vault_path)
 	result = await enable_metaedit()
 	state = await runtime_state()
 	local_manifest = json.loads((REPO / "manifest.json").read_text(encoding="utf-8"))
 	print(json.dumps({
-		"deployTarget": f"{args.vault_path.rstrip('/')}/.obsidian/plugins/{PLUGIN_ID}",
+		"deployTarget": f"{normalize_android_path(args.vault_path)}/.obsidian/plugins/{PLUGIN_ID}",
 		"enable": result,
 		"runtime": state,
 	}, indent=2, ensure_ascii=False))

--- a/scripts/mobile/metaedit_android.py
+++ b/scripts/mobile/metaedit_android.py
@@ -179,6 +179,11 @@ async def cmd_diagnose(args: argparse.Namespace) -> None:
 
 
 async def cmd_deploy(args: argparse.Namespace) -> None:
+	if not args.confirm_scratch_vault:
+		raise SystemExit(
+			"Refusing to deploy without --confirm-scratch-vault. "
+			"Android deploy has no backup/restore path and is intended only for disposable scratch vaults."
+		)
 	deploy_artifacts(args.vault_path)
 	forward_cdp(args.port)
 	result = await enable_metaedit()
@@ -244,6 +249,11 @@ async def main() -> None:
 	p_deploy = sub.add_parser("deploy")
 	p_deploy.add_argument("--vault-path", default=DEFAULT_VAULT_PATH)
 	p_deploy.add_argument("--port", type=int, default=CDP_PORT)
+	p_deploy.add_argument(
+		"--confirm-scratch-vault",
+		action="store_true",
+		help="Required: acknowledge Android deploy has no backup/restore path and targets a disposable scratch vault.",
+	)
 
 	p_reload = sub.add_parser("reload")
 	p_reload.add_argument("--port", type=int, default=CDP_PORT)

--- a/scripts/mobile/metaedit_android.py
+++ b/scripts/mobile/metaedit_android.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Deploy and inspect MetaEdit in Obsidian Android over CDP.
+
+This harness assumes an Android emulator or device is already running Obsidian.
+It mirrors the safdeb/android_cdp.py pattern: forward the app WebView's
+`webview_devtools_remote_<pid>` socket to localhost, then use Chrome DevTools
+Protocol Runtime.evaluate.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import websockets
+
+PLUGIN_ID = "metaedit"
+PACKAGE = "md.obsidian"
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_VAULT_PATH = "/sdcard/Documents/MetaEditMobile"
+CDP_PORT = 9333
+
+
+def adb_bin() -> str:
+	return os.environ.get(
+		"ADB",
+		"/opt/homebrew/share/android-commandlinetools/platform-tools/adb",
+	)
+
+
+def run_adb(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+	return subprocess.run(
+		[adb_bin(), *args],
+		check=check,
+		text=True,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE,
+	)
+
+
+def adb_out(args: list[str]) -> str:
+	return run_adb(args).stdout.strip()
+
+
+def js(value: str) -> str:
+	return json.dumps(value)
+
+
+def forward_cdp(port: int = CDP_PORT) -> int:
+	pid = adb_out(["shell", "pidof", PACKAGE]).split()[0]
+	run_adb(["forward", f"tcp:{port}", f"localabstract:webview_devtools_remote_{pid}"])
+	return int(pid)
+
+
+def discover_page_ws(port: int = CDP_PORT) -> tuple[str, str]:
+	data = json.load(urllib.request.urlopen(f"http://localhost:{port}/json", timeout=10))
+	pages = [page for page in data if page.get("type") == "page"]
+	if not pages:
+		raise SystemExit(f"No CDP page target found. Targets: {[page.get('type') for page in data]}")
+	page = pages[0]
+	return page["webSocketDebuggerUrl"], page.get("url", "")
+
+
+async def cdp_eval(expr: str, *, timeout: float = 120.0, await_promise: bool = True) -> Any:
+	ws_url, _url = discover_page_ws()
+	async with websockets.connect(ws_url, max_size=None, open_timeout=20) as ws:
+		await ws.send(json.dumps({
+			"id": 1,
+			"method": "Runtime.evaluate",
+			"params": {
+				"expression": expr,
+				"returnByValue": True,
+				"awaitPromise": await_promise,
+				"allowUnsafeEvalBlockedByCSP": True,
+				"userGesture": True,
+			},
+		}))
+		while True:
+			response = json.loads(await asyncio.wait_for(ws.recv(), timeout))
+			if response.get("id") != 1:
+				continue
+
+			result = response.get("result", {})
+			if "exceptionDetails" in result:
+				exception = result["exceptionDetails"]
+				raise RuntimeError(exception.get("exception", {}).get("description") or json.dumps(exception))
+			return result.get("result", {}).get("value")
+
+
+def read_eval_expression(args: argparse.Namespace) -> str:
+	if args.file:
+		return Path(args.file).read_text(encoding="utf-8")
+	if args.expr:
+		return args.expr
+	if not sys.stdin.isatty():
+		return sys.stdin.read()
+	raise SystemExit("Provide an expression, --file <path>, or JavaScript on stdin.")
+
+
+def ensure_local_artifacts() -> dict[str, Path]:
+	files = {
+		"main.js": REPO / "main.js",
+		"manifest.json": REPO / "manifest.json",
+		"styles.css": REPO / "styles.css",
+	}
+	missing = [str(path) for path in files.values() if not path.is_file()]
+	if missing:
+		raise SystemExit(
+			"Missing deploy artifact(s):\n  "
+			+ "\n  ".join(missing)
+			+ "\nRun `pnpm run build` before deploying to Android."
+		)
+	return files
+
+
+async def runtime_state() -> dict[str, Any]:
+	return await cdp_eval(f"""(() => {{
+		const id = {js(PLUGIN_ID)};
+		const plugin = app?.plugins?.plugins?.[id];
+		return {{
+			title: document.title,
+			vaultName: app?.vault?.getName?.() ?? null,
+			apiVersion: window.apiVersion ?? null,
+			manifestKnown: app?.plugins?.manifests?.[id] ?? null,
+			enabled: Array.from(app?.plugins?.enabledPlugins ?? []).includes(id),
+			instantiated: Boolean(plugin),
+			loadedVersion: plugin?.manifest?.version ?? null,
+			apiReady: Boolean(plugin?.api),
+			hasRunCommand: Boolean(app?.commands?.commands?.[`${{id}}:metaEditRun`]),
+			body: document.body?.innerText?.slice(0, 500) ?? "",
+		}};
+	}})()""")
+
+
+async def enable_metaedit() -> dict[str, Any]:
+	return await cdp_eval(f"""(async () => {{
+		const id = {js(PLUGIN_ID)};
+		try {{
+			await app.plugins.loadManifests();
+			if (app.plugins.plugins[id]) await app.plugins.disablePlugin(id);
+			await (app.plugins.enablePluginAndSave
+				? app.plugins.enablePluginAndSave(id)
+				: app.plugins.enablePlugin(id));
+			return {{
+				ok: true,
+				enabled: Array.from(app.plugins.enabledPlugins ?? []).includes(id),
+				instantiated: Boolean(app.plugins.plugins[id]),
+				version: app.plugins.plugins[id]?.manifest?.version ?? null,
+				apiReady: Boolean(app.plugins.plugins[id]?.api),
+			}};
+		}} catch (e) {{
+			return {{ok: false, error: String((e && e.stack) || e)}};
+		}}
+	}})()""")
+
+
+def deploy_artifacts(vault_path: str) -> None:
+	files = ensure_local_artifacts()
+	target = f"{vault_path.rstrip('/')}/.obsidian/plugins/{PLUGIN_ID}"
+	adb_out(["shell", "mkdir", "-p", target])
+	for path in files.values():
+		run_adb(["push", str(path), f"{target}/"])
+
+
+async def cmd_diagnose(args: argparse.Namespace) -> None:
+	pid = forward_cdp(args.port)
+	state = await runtime_state()
+	print(json.dumps({
+		"pid": pid,
+		"cdpPort": args.port,
+		"runtime": state,
+	}, indent=2, ensure_ascii=False))
+
+
+async def cmd_deploy(args: argparse.Namespace) -> None:
+	deploy_artifacts(args.vault_path)
+	forward_cdp(args.port)
+	result = await enable_metaedit()
+	state = await runtime_state()
+	local_manifest = json.loads((REPO / "manifest.json").read_text(encoding="utf-8"))
+	print(json.dumps({
+		"deployTarget": f"{args.vault_path.rstrip('/')}/.obsidian/plugins/{PLUGIN_ID}",
+		"enable": result,
+		"runtime": state,
+	}, indent=2, ensure_ascii=False))
+	if state.get("loadedVersion") != local_manifest.get("version"):
+		raise SystemExit(
+			"Deploy wrote files, but runtime version does not match local manifest. "
+			f"local={local_manifest.get('version')!r} runtime={state.get('loadedVersion')!r}"
+		)
+	if not state.get("apiReady"):
+		raise SystemExit("Deploy wrote files, but MetaEdit API did not become ready in Android runtime.")
+
+
+async def cmd_reload(args: argparse.Namespace) -> None:
+	forward_cdp(args.port)
+	print(json.dumps(await enable_metaedit(), indent=2, ensure_ascii=False))
+
+
+async def cmd_eval(args: argparse.Namespace) -> None:
+	forward_cdp(args.port)
+	expr = read_eval_expression(args)
+	print(json.dumps(await cdp_eval(expr, timeout=args.timeout, await_promise=not args.no_await), indent=2, ensure_ascii=False))
+
+
+async def cmd_logs(args: argparse.Namespace) -> None:
+	run_adb(["logcat", "-c"])
+	print(f"-- streaming Android logcat lines matching Obsidian/WebView for {args.seconds}s --")
+	process = subprocess.Popen(
+		[adb_bin(), "logcat", "-v", "time"],
+		text=True,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.STDOUT,
+	)
+	try:
+		end = asyncio.get_event_loop().time() + args.seconds
+		while asyncio.get_event_loop().time() < end:
+			line = await asyncio.to_thread(process.stdout.readline)
+			if not line:
+				break
+			if any(token in line.lower() for token in ("obsidian", "webview", "chromium", "fatal", "crash")):
+				print(line, end="")
+	finally:
+		process.terminate()
+		try:
+			process.wait(timeout=5)
+		except subprocess.TimeoutExpired:
+			process.kill()
+
+
+async def main() -> None:
+	parser = argparse.ArgumentParser()
+	sub = parser.add_subparsers(dest="cmd", required=True)
+
+	p_diag = sub.add_parser("diagnose")
+	p_diag.add_argument("--port", type=int, default=CDP_PORT)
+
+	p_deploy = sub.add_parser("deploy")
+	p_deploy.add_argument("--vault-path", default=DEFAULT_VAULT_PATH)
+	p_deploy.add_argument("--port", type=int, default=CDP_PORT)
+
+	p_reload = sub.add_parser("reload")
+	p_reload.add_argument("--port", type=int, default=CDP_PORT)
+
+	p_eval = sub.add_parser("eval")
+	p_eval.add_argument("expr", nargs="?")
+	p_eval.add_argument("--file")
+	p_eval.add_argument("--timeout", type=float, default=120.0)
+	p_eval.add_argument("--no-await", action="store_true")
+	p_eval.add_argument("--port", type=int, default=CDP_PORT)
+
+	p_logs = sub.add_parser("logs")
+	p_logs.add_argument("--seconds", type=int, default=60)
+
+	args = parser.parse_args()
+	if args.cmd == "diagnose":
+		await cmd_diagnose(args)
+	elif args.cmd == "deploy":
+		await cmd_deploy(args)
+	elif args.cmd == "reload":
+		await cmd_reload(args)
+	elif args.cmd == "eval":
+		await cmd_eval(args)
+	elif args.cmd == "logs":
+		await cmd_logs(args)
+
+
+if __name__ == "__main__":
+	asyncio.run(main())

--- a/scripts/mobile/metaedit_ios.py
+++ b/scripts/mobile/metaedit_ios.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import hashlib
 import json
 import logging
@@ -34,6 +35,9 @@ PLUGIN_ID = "metaedit"
 REPO = Path(__file__).resolve().parents[2]
 DEFAULT_VAULT = "notes"
 TOKEN = "__metaedit_ios_debug_result"
+SOURCE_TOKEN = "__metaedit_ios_debug_source"
+INSPECTOR_CALL_TIMEOUT = 10.0
+EVAL_CHUNK_SIZE = 768
 
 LOCAL_FILES = {
 	"main.js": REPO / "main.js",
@@ -119,18 +123,47 @@ async def open_session(inspector: WebinspectorService) -> tuple[Any, Any]:
 	return target, session
 
 
+async def runtime_evaluate(
+	session: Any,
+	expression: str,
+	*,
+	return_by_value: bool = True,
+	timeout: float = INSPECTOR_CALL_TIMEOUT,
+) -> Any:
+	try:
+		return await asyncio.wait_for(
+			session.runtime_evaluate(expression, return_by_value=return_by_value),
+			timeout=timeout,
+		)
+	except TimeoutError as exc:
+		raise TimeoutError(
+			f"Web Inspector Runtime.evaluate timed out after {timeout}s: {expression[:120]}"
+		) from exc
+
+
 async def ev(session: Any, expr: str, timeout: float = 30.0) -> Any:
+	encoded = base64.b64encode(expr.encode("utf-8")).decode("ascii")
+	await runtime_evaluate(session, f"window.{SOURCE_TOKEN}='';0")
+	for index in range(0, len(encoded), EVAL_CHUNK_SIZE):
+		await runtime_evaluate(
+			session,
+			f"window.{SOURCE_TOKEN}+={js(encoded[index:index + EVAL_CHUNK_SIZE])};0",
+		)
+
 	kickoff = (
-		f"(()=>{{window.{TOKEN}=undefined;"
-		f"(async()=>{{try{{window.{TOKEN}={{ok:JSON.stringify(await ({expr}))}}}}"
+		f"(()=>{{const __bytes=Uint8Array.from(atob(window.{SOURCE_TOKEN}),c=>c.charCodeAt(0));"
+		f"const __source=new TextDecoder('utf-8').decode(__bytes);"
+		f"window.{TOKEN}=undefined;"
+		f"(async()=>{{try{{const __runner=new Function('return (async()=>{{return await ('+__source+');}})()');"
+		f"window.{TOKEN}={{ok:JSON.stringify(await __runner())}}}}"
 		f"catch(e){{window.{TOKEN}={{err:String((e&&e.stack)||e)}}}}}})();return 0}})()"
 	)
-	await session.runtime_evaluate(kickoff, return_by_value=True)
+	await runtime_evaluate(session, kickoff)
 
 	waited = 0.0
 	poll = f"JSON.stringify(window.{TOKEN}===undefined?null:window.{TOKEN})"
 	while waited < timeout:
-		result = await session.runtime_evaluate(poll, return_by_value=True)
+		result = await runtime_evaluate(session, poll)
 		if result and result != "null":
 			obj = json.loads(result)
 			if "err" in obj:

--- a/scripts/mobile/metaedit_ios.py
+++ b/scripts/mobile/metaedit_ios.py
@@ -154,9 +154,10 @@ async def ev(session: Any, expr: str, timeout: float = 30.0) -> Any:
 		f"(()=>{{const __bytes=Uint8Array.from(atob(window.{SOURCE_TOKEN}),c=>c.charCodeAt(0));"
 		f"const __source=new TextDecoder('utf-8').decode(__bytes);"
 		f"window.{TOKEN}=undefined;"
+		f"const __formatError=e=>String(e&&e.message?e.message+'\\n'+(e.stack||''):(e&&e.stack)||e);"
 		f"(async()=>{{try{{const __runner=new Function('return (async()=>{{return await ('+__source+');}})()');"
 		f"window.{TOKEN}={{ok:JSON.stringify(await __runner())}}}}"
-		f"catch(e){{window.{TOKEN}={{err:String((e&&e.stack)||e)}}}}}})();return 0}})()"
+		f"catch(e){{window.{TOKEN}={{err:__formatError(e)}}}}}})();return 0}})()"
 	)
 	await runtime_evaluate(session, kickoff)
 
@@ -491,6 +492,12 @@ async def cmd_restore(lockdown: Any, args: argparse.Namespace) -> None:
 			if not local_plugin_dir.is_dir():
 				raise SystemExit(f"Backup plugin folder not found: {local_plugin_dir}")
 			await afc.push(str(local_plugin_dir), remote_parent)
+			local_manifest = collect_local_file_manifest(local_plugin_dir)
+			remote_manifest = await collect_remote_file_manifest(afc, remote_plugin_dir)
+			if remote_manifest != local_manifest:
+				raise SystemExit(
+					"Restore verification failed; remote plugin folder does not match the backup."
+				)
 			print(f"Restored {local_plugin_dir} -> {remote_plugin_dir}")
 		else:
 			print(f"Removed {remote_plugin_dir}; backup recorded that no plugin dir existed before deploy.")

--- a/scripts/mobile/metaedit_ios.py
+++ b/scripts/mobile/metaedit_ios.py
@@ -65,6 +65,17 @@ def safe_segment(value: str) -> str:
 	return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "unknown"
 
 
+def vault_name_from_plugin_dir(remote_plugin_dir: str) -> str | None:
+	parts = remote_plugin_dir.strip("/").split("/")
+	if len(parts) == 5 and parts[0] == "Documents" and parts[2:] == [".obsidian", "plugins", PLUGIN_ID]:
+		return parts[1]
+	return None
+
+
+def plugin_dir_for_vault(vault_path: str) -> str:
+	return f"{vault_path}/.obsidian/plugins/{PLUGIN_ID}"
+
+
 async def afc_open(lockdown: Any) -> HouseArrestService:
 	return await HouseArrestService.create(lockdown, OBSIDIAN_BUNDLE, documents_only=True)
 
@@ -353,14 +364,14 @@ async def enable_metaedit(session: Any) -> dict[str, Any]:
 	}})()""")
 
 
-def assert_open_vault_matches_afc_vault(state: dict[str, Any], vault_name: str) -> None:
+def assert_open_vault_matches_afc_vault(state: dict[str, Any], vault_name: str, operation: str) -> None:
 	open_vault = state.get("vaultName")
 	if open_vault != vault_name:
 		raise SystemExit(
-			"Refusing to deploy because the AFC target vault and the open Obsidian vault differ.\n"
+			f"Refusing to {operation} because the AFC target vault and the open Obsidian vault differ.\n"
 			f"AFC target vault: {vault_name!r}\n"
 			f"Open Obsidian vault: {open_vault!r}\n"
-			"Open the target vault on the phone, then rerun diagnose/deploy."
+			f"Open the target vault on the phone, then rerun {operation}."
 		)
 
 
@@ -380,7 +391,7 @@ async def cmd_diagnose(lockdown: Any, args: argparse.Namespace) -> None:
 	afc = await afc_open(lockdown)
 	try:
 		vault_path, vaults = await afc_find_vault(afc, args.vault)
-		plugin_dir = f"{vault_path}/.obsidian/plugins/{PLUGIN_ID}"
+		plugin_dir = plugin_dir_for_vault(vault_path)
 		print("\n# AFC vault state")
 		print(json.dumps({
 			"vaultPath": vault_path,
@@ -411,9 +422,9 @@ async def cmd_deploy(lockdown: Any, args: argparse.Namespace) -> None:
 			try:
 				vault_path, _vaults = await afc_find_vault(afc, args.vault)
 				vault_name = vault_path.rsplit("/", 1)[-1]
-				plugin_dir = f"{vault_path}/.obsidian/plugins/{PLUGIN_ID}"
+				plugin_dir = plugin_dir_for_vault(vault_path)
 				device_id = getattr(lockdown, "udid", None) or getattr(lockdown, "identifier", None) or "usb-device"
-				assert_open_vault_matches_afc_vault(state_before, vault_name)
+				assert_open_vault_matches_afc_vault(state_before, vault_name, "deploy")
 				backup_dir = await backup_existing_plugin(afc, plugin_dir, str(device_id), vault_name, state_before)
 
 				print(f"# backup\n{backup_dir}\n")
@@ -465,6 +476,12 @@ async def cmd_restore(lockdown: Any, args: argparse.Namespace) -> None:
 	remote_parent = remote_plugin_dir.rsplit("/", 1)[0]
 	local_plugin_dir = source / PLUGIN_ID
 	desired_enabled = (manifest.get("stateBeforeDeploy") or {}).get("enabled")
+	vault_name = manifest.get("vaultName") or vault_name_from_plugin_dir(remote_plugin_dir)
+	if not vault_name:
+		raise SystemExit(
+			"Backup manifest does not identify a restorable Obsidian vault. "
+			f"remotePluginDir={remote_plugin_dir!r}"
+		)
 	expected_device_id = manifest.get("deviceId")
 	current_device_id = getattr(lockdown, "udid", None) or getattr(lockdown, "identifier", None) or "usb-device"
 	if expected_device_id and expected_device_id != str(current_device_id) and not args.force:
@@ -476,13 +493,13 @@ async def cmd_restore(lockdown: Any, args: argparse.Namespace) -> None:
 
 	afc = await afc_open(lockdown)
 	try:
-		if manifest.get("vaultName"):
-			vault_path, _vaults = await afc_find_vault(afc, manifest["vaultName"])
-			if not remote_plugin_dir.startswith(f"{vault_path}/"):
-				raise SystemExit(
-					"Backup vault path does not match the connected device's current vault path. "
-					f"backup={remote_plugin_dir} current={vault_path}"
-				)
+		vault_path, _vaults = await afc_find_vault(afc, vault_name)
+		expected_plugin_dir = plugin_dir_for_vault(vault_path)
+		if remote_plugin_dir != expected_plugin_dir:
+			raise SystemExit(
+				"Backup plugin path does not match the connected device's current vault plugin path. "
+				f"backup={remote_plugin_dir} current={expected_plugin_dir}"
+			)
 		if await afc.exists(remote_plugin_dir):
 			undeleted = await afc.rm(remote_plugin_dir, force=True)
 			if undeleted:
@@ -512,6 +529,8 @@ async def cmd_restore(lockdown: Any, args: argparse.Namespace) -> None:
 	try:
 		async with inspector:
 			_, session = await open_session(inspector)
+			state = await read_plugin_state(session)
+			assert_open_vault_matches_afc_vault(state, vault_name, "restore enabled state")
 			result = await apply_enabled_state(session, desired_enabled)
 			print("# restored enabled state")
 			print(json.dumps(result, indent=2, ensure_ascii=False))

--- a/scripts/mobile/metaedit_ios.py
+++ b/scripts/mobile/metaedit_ios.py
@@ -1,0 +1,612 @@
+#!/usr/bin/env python3
+"""Deploy and inspect MetaEdit in Obsidian iOS over USB.
+
+This harness follows the proven safdeb/podnotes_ios.py pattern:
+
+	uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py diagnose
+	uv run --no-project --with pymobiledevice3 python scripts/mobile/metaedit_ios.py eval --file scripts/mobile/probes/issue99_frontmatter.js
+
+Deploy writes into the phone's real Obsidian vault. It intentionally requires an
+explicit flag, creates a local backup of the existing phone plugin folder first,
+and byte-verifies every pushed artifact.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import posixpath
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pymobiledevice3.lockdown import create_using_usbmux
+from pymobiledevice3.services.house_arrest import HouseArrestService
+from pymobiledevice3.services.webinspector import WebinspectorService
+
+OBSIDIAN_BUNDLE = "md.obsidian"
+PLUGIN_ID = "metaedit"
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_VAULT = "notes"
+TOKEN = "__metaedit_ios_debug_result"
+
+LOCAL_FILES = {
+	"main.js": REPO / "main.js",
+	"manifest.json": REPO / "manifest.json",
+	"styles.css": REPO / "styles.css",
+}
+
+
+def backup_root() -> Path:
+	return Path(os.environ.get(
+		"METAEDIT_IOS_BACKUP_DIR",
+		Path.home() / ".metaedit-mobile-backups" / PLUGIN_ID,
+	)).expanduser()
+
+
+def js(value: str) -> str:
+	return json.dumps(value)
+
+
+def sha256(data: bytes) -> str:
+	return hashlib.sha256(data).hexdigest()
+
+
+def safe_segment(value: str) -> str:
+	return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "unknown"
+
+
+async def afc_open(lockdown: Any) -> HouseArrestService:
+	return await HouseArrestService.create(lockdown, OBSIDIAN_BUNDLE, documents_only=True)
+
+
+async def afc_find_vault(afc: HouseArrestService, prefer: str | None) -> tuple[str, list[str]]:
+	candidates: list[str] = []
+	for name in await afc.listdir("/Documents"):
+		if name in (".", "..", ""):
+			continue
+		path = f"/Documents/{name}"
+		try:
+			if await afc.exists(f"{path}/.obsidian"):
+				candidates.append(name)
+		except Exception:
+			continue
+
+	if prefer and prefer != "auto":
+		if prefer in candidates:
+			return f"/Documents/{prefer}", candidates
+		raise SystemExit(
+			f"Vault {prefer!r} was not found under /Documents. "
+			f"Vaults with .obsidian: {candidates or '(none)'}"
+		)
+
+	if len(candidates) == 1:
+		return f"/Documents/{candidates[0]}", candidates
+	if DEFAULT_VAULT in candidates:
+		return f"/Documents/{DEFAULT_VAULT}", candidates
+	if candidates:
+		raise SystemExit(
+			"Multiple Obsidian vaults were found. Re-run with --vault <name>. "
+			f"Vaults: {candidates}"
+		)
+	raise SystemExit("No Obsidian vault with a .obsidian folder was found under /Documents.")
+
+
+async def open_session(inspector: WebinspectorService) -> tuple[Any, Any]:
+	pages = await inspector.get_open_application_pages(timeout=3)
+	target = next(
+		(
+			page for page in pages
+			if page.application.bundle == OBSIDIAN_BUNDLE
+			or "obsidian" in (page.application.name or "").lower()
+		),
+		None,
+	)
+	if target is None:
+		raise SystemExit(
+			"No Obsidian page found. Unlock the phone, open Obsidian, and enable "
+			"Settings > Apps > Safari > Advanced > Web Inspector.\n"
+			f"Inspectable pages seen: {[str(page) for page in pages]}"
+		)
+
+	session = await inspector.inspector_session(target.application, target.page)
+	await session.runtime_enable()
+	return target, session
+
+
+async def ev(session: Any, expr: str, timeout: float = 30.0) -> Any:
+	kickoff = (
+		f"(()=>{{window.{TOKEN}=undefined;"
+		f"(async()=>{{try{{window.{TOKEN}={{ok:JSON.stringify(await ({expr}))}}}}"
+		f"catch(e){{window.{TOKEN}={{err:String((e&&e.stack)||e)}}}}}})();return 0}})()"
+	)
+	await session.runtime_evaluate(kickoff, return_by_value=True)
+
+	waited = 0.0
+	poll = f"JSON.stringify(window.{TOKEN}===undefined?null:window.{TOKEN})"
+	while waited < timeout:
+		result = await session.runtime_evaluate(poll, return_by_value=True)
+		if result and result != "null":
+			obj = json.loads(result)
+			if "err" in obj:
+				raise RuntimeError(obj["err"])
+			value = obj.get("ok")
+			if value is None:
+				return None
+			try:
+				return json.loads(value)
+			except (TypeError, json.JSONDecodeError):
+				return value
+		await asyncio.sleep(0.1)
+		waited += 0.1
+	raise TimeoutError(f"eval timed out after {timeout}s: {expr[:120]}")
+
+
+async def read_plugin_state(session: Any) -> dict[str, Any]:
+	return await ev(session, f"""(() => {{
+		const id = {js(PLUGIN_ID)};
+		const plugin = app.plugins.plugins[id];
+		return {{
+			vaultName: app.vault.getName?.() ?? null,
+			configDir: app.vault.configDir,
+			manifestKnown: app.plugins.manifests[id] ?? null,
+			enabled: Array.from(app.plugins.enabledPlugins ?? []).includes(id),
+			instantiated: Boolean(plugin),
+			loadedVersion: plugin?.manifest?.version ?? null,
+			apiReady: Boolean(plugin?.api),
+			hasRunCommand: Boolean(app.commands?.commands?.[`${{id}}:metaEditRun`]),
+		}};
+	}})()""")
+
+
+def required_local_files() -> dict[str, Path]:
+	missing = [str(path) for path in LOCAL_FILES.values() if not path.is_file()]
+	if missing:
+		raise SystemExit(
+			"Missing deploy artifact(s):\n  "
+			+ "\n  ".join(missing)
+			+ "\nRun `pnpm run build` before deploying to mobile."
+		)
+	return dict(LOCAL_FILES)
+
+
+async def afc_put_verified(afc: HouseArrestService, remote_path: str, data: bytes) -> dict[str, Any]:
+	await afc.set_file_contents(remote_path, data)
+	remote = await afc.get_file_contents(remote_path)
+	remote_bytes = bytes(remote)
+	local_hash = sha256(data)
+	remote_hash = sha256(remote_bytes)
+	return {
+		"bytes": len(remote_bytes),
+		"ok": len(remote_bytes) == len(data) and remote_hash == local_hash,
+		"sha256": remote_hash,
+		"wantBytes": len(data),
+		"wantSha256": local_hash,
+	}
+
+
+async def collect_remote_file_manifest(afc: HouseArrestService, remote_dir: str) -> dict[str, dict[str, Any]]:
+	files: dict[str, dict[str, Any]] = {}
+	async for dirpath, _dirnames, filenames in afc.walk(remote_dir):
+		for filename in filenames:
+			remote_path = posixpath.join(dirpath, filename)
+			relpath = posixpath.relpath(remote_path, remote_dir)
+			data = bytes(await afc.get_file_contents(remote_path))
+			files[relpath] = {
+				"bytes": len(data),
+				"sha256": sha256(data),
+			}
+	return files
+
+
+def collect_local_file_manifest(local_dir: Path) -> dict[str, dict[str, Any]]:
+	files: dict[str, dict[str, Any]] = {}
+	for path in sorted(local_dir.rglob("*")):
+		if not path.is_file():
+			continue
+		data = path.read_bytes()
+		files[path.relative_to(local_dir).as_posix()] = {
+			"bytes": len(data),
+			"sha256": sha256(data),
+		}
+	return files
+
+
+async def backup_existing_plugin(
+	afc: HouseArrestService,
+	remote_plugin_dir: str,
+	device_id: str,
+	vault_name: str,
+	state: dict[str, Any] | None,
+) -> Path:
+	stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+	target = backup_root() / safe_segment(device_id) / safe_segment(vault_name) / stamp
+	target.mkdir(parents=True, exist_ok=False)
+
+	exists = await afc.exists(remote_plugin_dir)
+	file_manifest: dict[str, dict[str, Any]] = {}
+	if exists:
+		file_manifest = await collect_remote_file_manifest(afc, remote_plugin_dir)
+		await afc.pull(remote_plugin_dir, str(target), progress_bar=False)
+		local_plugin_dir = target / posixpath.basename(remote_plugin_dir)
+		local_manifest = collect_local_file_manifest(local_plugin_dir)
+		if local_manifest != file_manifest:
+			raise SystemExit(
+				"Pre-deploy backup verification failed; refusing to write to the phone. "
+				f"Backup: {target}"
+			)
+
+	manifest = {
+		"createdAt": stamp,
+		"deviceId": device_id,
+		"pluginId": PLUGIN_ID,
+		"repo": str(REPO),
+		"remotePluginDir": remote_plugin_dir,
+		"remotePluginDirExisted": exists,
+		"vaultName": vault_name,
+		"fileManifest": file_manifest,
+		"stateBeforeDeploy": state,
+		"note": "Created by scripts/mobile/metaedit_ios.py before writing to an Obsidian iOS vault.",
+	}
+	(target / "backup-manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+	return target
+
+
+def latest_backup() -> Path:
+	root = backup_root()
+	if not root.exists():
+		raise SystemExit(f"No backup directory exists yet: {root}")
+	manifests = sorted(root.glob("*/*/*/backup-manifest.json"), key=lambda path: path.stat().st_mtime)
+	if not manifests:
+		raise SystemExit(f"No backups found below {root}")
+	return manifests[-1].parent
+
+
+async def apply_enabled_state(session: Any, desired_enabled: bool | None) -> dict[str, Any]:
+	if desired_enabled is None:
+		return {"ok": True, "skipped": True, "reason": "No previous enabled state recorded."}
+	return await ev(session, f"""(async () => {{
+		const id = {js(PLUGIN_ID)};
+		try {{
+			await app.plugins.loadManifests();
+			if ({json.dumps(desired_enabled)}) {{
+				await (app.plugins.enablePluginAndSave
+					? app.plugins.enablePluginAndSave(id)
+					: app.plugins.enablePlugin(id));
+			}} else {{
+				if (app.plugins.plugins[id]) {{
+					await (app.plugins.disablePluginAndSave
+						? app.plugins.disablePluginAndSave(id)
+						: app.plugins.disablePlugin(id));
+				}}
+			}}
+			return {{
+				ok: true,
+				enabled: Array.from(app.plugins.enabledPlugins ?? []).includes(id),
+				instantiated: Boolean(app.plugins.plugins[id]),
+				version: app.plugins.plugins[id]?.manifest?.version ?? null,
+			}};
+		}} catch (e) {{
+			return {{ok: false, error: String((e && e.stack) || e)}};
+		}}
+	}})()""")
+
+
+async def enable_metaedit(session: Any) -> dict[str, Any]:
+	return await ev(session, f"""(async () => {{
+		const id = {js(PLUGIN_ID)};
+		try {{
+			await app.plugins.loadManifests();
+			if (app.plugins.plugins[id]) await app.plugins.disablePlugin(id);
+			await (app.plugins.enablePluginAndSave
+				? app.plugins.enablePluginAndSave(id)
+				: app.plugins.enablePlugin(id));
+			return {{
+				ok: true,
+				enabled: Array.from(app.plugins.enabledPlugins ?? []).includes(id),
+				instantiated: Boolean(app.plugins.plugins[id]),
+				version: app.plugins.plugins[id]?.manifest?.version ?? null,
+				apiReady: Boolean(app.plugins.plugins[id]?.api),
+			}};
+		}} catch (e) {{
+			return {{ok: false, error: String((e && e.stack) || e)}};
+		}}
+	}})()""")
+
+
+def assert_open_vault_matches_afc_vault(state: dict[str, Any], vault_name: str) -> None:
+	open_vault = state.get("vaultName")
+	if open_vault != vault_name:
+		raise SystemExit(
+			"Refusing to deploy because the AFC target vault and the open Obsidian vault differ.\n"
+			f"AFC target vault: {vault_name!r}\n"
+			f"Open Obsidian vault: {open_vault!r}\n"
+			"Open the target vault on the phone, then rerun diagnose/deploy."
+		)
+
+
+async def cmd_diagnose(lockdown: Any, args: argparse.Namespace) -> None:
+	inspector = WebinspectorService(lockdown=lockdown)
+	await inspector.connect()
+	try:
+		async with inspector:
+			target, session = await open_session(inspector)
+			state = await read_plugin_state(session)
+			print(f"# Web Inspector target\n{target}\n")
+			print("# Runtime plugin state")
+			print(json.dumps(state, indent=2, ensure_ascii=False))
+	finally:
+		await inspector.close()
+
+	afc = await afc_open(lockdown)
+	try:
+		vault_path, vaults = await afc_find_vault(afc, args.vault)
+		plugin_dir = f"{vault_path}/.obsidian/plugins/{PLUGIN_ID}"
+		print("\n# AFC vault state")
+		print(json.dumps({
+			"vaultPath": vault_path,
+			"vaults": vaults,
+			"pluginDir": plugin_dir,
+			"pluginDirExists": await afc.exists(plugin_dir),
+			"pluginFiles": await afc.listdir(plugin_dir) if await afc.exists(plugin_dir) else [],
+		}, indent=2, ensure_ascii=False))
+	finally:
+		await afc.close()
+
+
+async def cmd_deploy(lockdown: Any, args: argparse.Namespace) -> None:
+	if not args.confirm_real_vault:
+		raise SystemExit(
+			"Refusing to deploy without --confirm-real-vault. This writes to the phone's real Obsidian vault."
+		)
+	files = required_local_files()
+
+	inspector = WebinspectorService(lockdown=lockdown)
+	await inspector.connect()
+	try:
+		async with inspector:
+			_, session = await open_session(inspector)
+			state_before = await read_plugin_state(session)
+
+			afc = await afc_open(lockdown)
+			try:
+				vault_path, _vaults = await afc_find_vault(afc, args.vault)
+				vault_name = vault_path.rsplit("/", 1)[-1]
+				plugin_dir = f"{vault_path}/.obsidian/plugins/{PLUGIN_ID}"
+				device_id = getattr(lockdown, "udid", None) or getattr(lockdown, "identifier", None) or "usb-device"
+				assert_open_vault_matches_afc_vault(state_before, vault_name)
+				backup_dir = await backup_existing_plugin(afc, plugin_dir, str(device_id), vault_name, state_before)
+
+				print(f"# backup\n{backup_dir}\n")
+				print(f"# deploy target\n{plugin_dir}\n")
+
+				try:
+					await afc.makedirs(plugin_dir)
+				except Exception:
+					pass
+
+				results: dict[str, Any] = {}
+				for name, path in files.items():
+					data = path.read_bytes()
+					results[name] = await afc_put_verified(afc, f"{plugin_dir}/{name}", data)
+				results[".hotreload"] = await afc_put_verified(afc, f"{plugin_dir}/.hotreload", b"")
+
+				print("# pushed files")
+				print(json.dumps(results, indent=2, ensure_ascii=False))
+				if not all(result.get("ok") for result in results.values()):
+					raise SystemExit("At least one pushed file failed byte verification.")
+			finally:
+				await afc.close()
+
+			enable_result = await enable_metaedit(session)
+			state_after = await read_plugin_state(session)
+			local_manifest = json.loads((REPO / "manifest.json").read_text(encoding="utf-8"))
+			print("\n# enable/reload result")
+			print(json.dumps(enable_result, indent=2, ensure_ascii=False))
+			print("\n# runtime state after deploy")
+			print(json.dumps(state_after, indent=2, ensure_ascii=False))
+			if state_after.get("loadedVersion") != local_manifest.get("version"):
+				raise SystemExit(
+					"Deploy wrote files, but runtime version does not match local manifest. "
+					f"local={local_manifest.get('version')!r} runtime={state_after.get('loadedVersion')!r}"
+				)
+			if not state_after.get("apiReady"):
+				raise SystemExit("Deploy wrote files, but MetaEdit API did not become ready in the iOS runtime.")
+	finally:
+		await inspector.close()
+
+
+async def cmd_restore(lockdown: Any, args: argparse.Namespace) -> None:
+	source = Path(args.backup).expanduser() if args.backup else latest_backup()
+	manifest_path = source / "backup-manifest.json"
+	if not manifest_path.is_file():
+		raise SystemExit(f"Backup manifest not found: {manifest_path}")
+	manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+	remote_plugin_dir = manifest["remotePluginDir"]
+	remote_parent = remote_plugin_dir.rsplit("/", 1)[0]
+	local_plugin_dir = source / PLUGIN_ID
+	desired_enabled = (manifest.get("stateBeforeDeploy") or {}).get("enabled")
+	expected_device_id = manifest.get("deviceId")
+	current_device_id = getattr(lockdown, "udid", None) or getattr(lockdown, "identifier", None) or "usb-device"
+	if expected_device_id and expected_device_id != str(current_device_id) and not args.force:
+		raise SystemExit(
+			"Refusing to restore a backup from a different device without --force.\n"
+			f"Backup device: {expected_device_id}\n"
+			f"Connected device: {current_device_id}"
+		)
+
+	afc = await afc_open(lockdown)
+	try:
+		if manifest.get("vaultName"):
+			vault_path, _vaults = await afc_find_vault(afc, manifest["vaultName"])
+			if not remote_plugin_dir.startswith(f"{vault_path}/"):
+				raise SystemExit(
+					"Backup vault path does not match the connected device's current vault path. "
+					f"backup={remote_plugin_dir} current={vault_path}"
+				)
+		if await afc.exists(remote_plugin_dir):
+			undeleted = await afc.rm(remote_plugin_dir, force=True)
+			if undeleted:
+				raise SystemExit(f"Could not remove current remote plugin dir: {undeleted}")
+
+		if manifest.get("remotePluginDirExisted"):
+			if not local_plugin_dir.is_dir():
+				raise SystemExit(f"Backup plugin folder not found: {local_plugin_dir}")
+			await afc.push(str(local_plugin_dir), remote_parent)
+			print(f"Restored {local_plugin_dir} -> {remote_plugin_dir}")
+		else:
+			print(f"Removed {remote_plugin_dir}; backup recorded that no plugin dir existed before deploy.")
+	finally:
+		await afc.close()
+
+	if args.no_reload:
+		return
+
+	inspector = WebinspectorService(lockdown=lockdown)
+	await inspector.connect()
+	try:
+		async with inspector:
+			_, session = await open_session(inspector)
+			result = await apply_enabled_state(session, desired_enabled)
+			print("# restored enabled state")
+			print(json.dumps(result, indent=2, ensure_ascii=False))
+	finally:
+		await inspector.close()
+
+
+async def cmd_reload(lockdown: Any) -> None:
+	inspector = WebinspectorService(lockdown=lockdown)
+	await inspector.connect()
+	try:
+		async with inspector:
+			_, session = await open_session(inspector)
+			print(json.dumps(await enable_metaedit(session), indent=2, ensure_ascii=False))
+	finally:
+		await inspector.close()
+
+
+def read_eval_expression(args: argparse.Namespace) -> str:
+	if args.file:
+		return Path(args.file).read_text(encoding="utf-8")
+	if args.expr:
+		return args.expr
+	if not sys.stdin.isatty():
+		return sys.stdin.read()
+	raise SystemExit("Provide an expression, --file <path>, or JavaScript on stdin.")
+
+
+async def cmd_eval(lockdown: Any, args: argparse.Namespace) -> None:
+	expr = read_eval_expression(args)
+	inspector = WebinspectorService(lockdown=lockdown)
+	await inspector.connect()
+	try:
+		async with inspector:
+			_, session = await open_session(inspector)
+			print(json.dumps(await ev(session, expr, timeout=args.timeout), indent=2, ensure_ascii=False))
+	finally:
+		await inspector.close()
+
+
+async def cmd_logs(lockdown: Any, args: argparse.Namespace) -> None:
+	inspector = WebinspectorService(lockdown=lockdown)
+	await inspector.connect()
+	try:
+		async with inspector:
+			_, session = await open_session(inspector)
+			await ev(session, """((w) => {
+				if (w.__metaeditMobileDebugHooked) return "already hooked";
+				w.__metaeditMobileDebugHooked = true;
+				w.addEventListener("error", (event) => console.error(
+					"[window.onerror]",
+					event.message,
+					(event.filename || "") + ":" + (event.lineno || ""),
+					event.error && event.error.stack || ""
+				));
+				w.addEventListener("unhandledrejection", (event) => console.error(
+					"[unhandledrejection]",
+					event.reason && (event.reason.stack || event.reason) || event.reason
+				));
+				return "hooked";
+			})(window)""")
+			await session.console_enable()
+			logging.getLogger("webinspector.console").setLevel(logging.DEBUG)
+			print(f"-- streaming Obsidian console/errors for {args.seconds}s --")
+			await asyncio.sleep(args.seconds)
+	finally:
+		await inspector.close()
+
+
+def cmd_backups() -> None:
+	root = backup_root()
+	print(f"# backup root\n{root}\n")
+	if not root.exists():
+		return
+	for manifest in sorted(root.glob("*/*/*/backup-manifest.json"), key=lambda path: path.stat().st_mtime):
+		data = json.loads(manifest.read_text(encoding="utf-8"))
+		print(json.dumps({
+			"path": str(manifest.parent),
+			"createdAt": data.get("createdAt"),
+			"remotePluginDir": data.get("remotePluginDir"),
+			"remotePluginDirExisted": data.get("remotePluginDirExisted"),
+			"stateBeforeDeploy": data.get("stateBeforeDeploy"),
+		}, indent=2, ensure_ascii=False))
+
+
+async def async_main() -> None:
+	logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+
+	parser = argparse.ArgumentParser()
+	sub = parser.add_subparsers(dest="cmd", required=True)
+
+	p_diag = sub.add_parser("diagnose", help="Report installed files and runtime plugin state.")
+	p_diag.add_argument("--vault", default=DEFAULT_VAULT, help="AFC vault name, default: notes. Use 'auto' to auto-select.")
+
+	p_deploy = sub.add_parser("deploy", help="Push local build artifacts to the iPhone and enable MetaEdit.")
+	p_deploy.add_argument("--vault", default=DEFAULT_VAULT, help="AFC vault name, default: notes. Use 'auto' to auto-select.")
+	p_deploy.add_argument("--confirm-real-vault", action="store_true", help="Required: acknowledge this writes to the real phone vault.")
+
+	p_restore = sub.add_parser("restore", help="Restore the latest or selected pre-deploy phone plugin backup.")
+	p_restore.add_argument("--backup", help="Backup directory. Defaults to the newest backup below METAEDIT_IOS_BACKUP_DIR.")
+	p_restore.add_argument("--force", action="store_true", help="Allow restore when the backup device id differs from the connected device.")
+	p_restore.add_argument("--no-reload", action="store_true", help="Copy files only; do not adjust runtime enabled state.")
+
+	sub.add_parser("reload", help="Disable and enable MetaEdit in the open Obsidian iOS WebView.")
+
+	p_eval = sub.add_parser("eval", help="Evaluate JavaScript in the Obsidian iOS WebView.")
+	p_eval.add_argument("expr", nargs="?", help="JavaScript expression. Wrap statements in an async IIFE.")
+	p_eval.add_argument("--file", help="Read the JavaScript expression from a file.")
+	p_eval.add_argument("--timeout", type=float, default=120.0, help="Evaluation timeout in seconds.")
+
+	p_logs = sub.add_parser("logs", help="Stream console output and uncaught errors from the Obsidian WebView.")
+	p_logs.add_argument("--seconds", type=int, default=60)
+
+	sub.add_parser("backups", help="List local backups created by deploy.")
+
+	args = parser.parse_args()
+	if args.cmd == "backups":
+		cmd_backups()
+		return
+
+	lockdown = await create_using_usbmux()
+
+	if args.cmd == "diagnose":
+		await cmd_diagnose(lockdown, args)
+	elif args.cmd == "deploy":
+		await cmd_deploy(lockdown, args)
+	elif args.cmd == "restore":
+		await cmd_restore(lockdown, args)
+	elif args.cmd == "reload":
+		await cmd_reload(lockdown)
+	elif args.cmd == "eval":
+		await cmd_eval(lockdown, args)
+	elif args.cmd == "logs":
+		await cmd_logs(lockdown, args)
+
+
+if __name__ == "__main__":
+	asyncio.run(async_main())

--- a/scripts/mobile/probes/core_smoke.js
+++ b/scripts/mobile/probes/core_smoke.js
@@ -1,7 +1,9 @@
 (async () => {
 	const PLUGIN_ID = "metaedit";
 	const SCRATCH_DIR = "MetaEdit Mobile Debug";
-	const ROOT = `${SCRATCH_DIR}/core-smoke`;
+	const RUN_ID = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+	const ROOT = `${SCRATCH_DIR}/core-smoke-${RUN_ID}`;
+	const BOARD_NAME = `Roadmap-${RUN_ID}`;
 	const CLEANUP = true;
 	const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 	const failures = [];
@@ -21,6 +23,15 @@
 	const deleteIfExists = async (path) => {
 		const existing = app.vault.getAbstractFileByPath(path);
 		if (existing) await app.vault.delete(existing);
+	};
+	const deleteEmptyFolder = async (path) => {
+		const existing = app.vault.getAbstractFileByPath(path);
+		if (!existing) return;
+		const listed = await app.vault.adapter.list(path).catch(() => null);
+		if (listed && listed.files.length === 0 && listed.folders.length === 0) {
+			await app.vault.delete(existing);
+			cleanup.deleted.push(path);
+		}
 	};
 	const createFreshFile = async (path, content) => {
 		const folder = path.split("/").slice(0, -1).join("/");
@@ -66,6 +77,12 @@
 				cleanup.errors.push(`${path}: ${String(error?.stack || error)}`);
 			}
 		}
+		try {
+			await deleteEmptyFolder(ROOT);
+			await deleteEmptyFolder(SCRATCH_DIR);
+		} catch (error) {
+			cleanup.errors.push(`folders: ${String(error?.stack || error)}`);
+		}
 		return cleanup;
 	};
 	const textOfSuggestion = (element) => {
@@ -77,6 +94,11 @@
 	if (!plugin?.api) throw new Error("MetaEdit plugin API is not available.");
 	const settingsSnapshot = JSON.parse(JSON.stringify(plugin.settings));
 	const results = {};
+	const resetAutomators = () => {
+		plugin.settings.KanbanHelper.enabled = false;
+		plugin.settings.ProgressProperties.enabled = false;
+		plugin.toggleAutomators();
+	};
 
 	try {
 		await ensureFolder(ROOT);
@@ -146,6 +168,7 @@
 			"Body line should stay literal: readProgress: 0",
 			"",
 		].join("\n"));
+		resetAutomators();
 		plugin.settings.ProgressProperties.enabled = true;
 		plugin.settings.ProgressProperties.properties = [{ name: "readProgress", type: "Total Tasks" }];
 		const progressProps = await plugin.controller.getPropertiesInFile(progressFile);
@@ -157,7 +180,7 @@
 		if (!progressContent.includes("Body line should stay literal: readProgress: 0")) failures.push("Progress Properties rewrote matching body text.");
 
 		const cardFile = await createFreshFile(`${ROOT}/Project A.md`, "---\nstatus: Backlog\n---\n\nbody\n");
-		const boardPath = `${ROOT}/Roadmap.md`;
+		const boardPath = `${ROOT}/${BOARD_NAME}.md`;
 		const backlogBoard = [
 			"---",
 			"kanban-plugin: board",
@@ -183,9 +206,10 @@
 			"",
 		].join("\n");
 		const boardFile = await createFreshFile(boardPath, backlogBoard);
+		resetAutomators();
 		plugin.settings.KanbanHelper = {
 			enabled: true,
-			boards: [{ boardName: "Roadmap", property: "status" }],
+			boards: [{ boardName: BOARD_NAME, property: "status" }],
 		};
 		plugin.toggleAutomators();
 		await sleep(1800);
@@ -198,6 +222,7 @@
 		if (!kanbanContent.includes("status: In Progress")) failures.push("Kanban helper did not update linked card lane.");
 	} finally {
 		await closeTransientUi();
+		resetAutomators();
 		plugin.settings = settingsSnapshot;
 		plugin.toggleAutomators();
 		await cleanupScratch();

--- a/scripts/mobile/probes/core_smoke.js
+++ b/scripts/mobile/probes/core_smoke.js
@@ -1,0 +1,216 @@
+(async () => {
+	const PLUGIN_ID = "metaedit";
+	const SCRATCH_DIR = "MetaEdit Mobile Debug";
+	const ROOT = `${SCRATCH_DIR}/core-smoke`;
+	const CLEANUP = true;
+	const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+	const failures = [];
+	const createdPaths = [];
+	const cleanup = { attempted: false, deleted: [], errors: [] };
+
+	const ensureFolder = async (path) => {
+		const parts = path.split("/");
+		let current = "";
+		for (const part of parts) {
+			current = current ? `${current}/${part}` : part;
+			if (!app.vault.getAbstractFileByPath(current)) {
+				await app.vault.createFolder(current);
+			}
+		}
+	};
+	const deleteIfExists = async (path) => {
+		const existing = app.vault.getAbstractFileByPath(path);
+		if (existing) await app.vault.delete(existing);
+	};
+	const createFreshFile = async (path, content) => {
+		const folder = path.split("/").slice(0, -1).join("/");
+		if (folder) await ensureFolder(folder);
+		await deleteIfExists(path);
+		const file = await app.vault.create(path, content);
+		createdPaths.push(path);
+		await sleep(500);
+		return file;
+	};
+	const waitFor = async (selectorOrPredicate, label, timeout = 10000) => {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			const value = typeof selectorOrPredicate === "string"
+				? document.querySelector(selectorOrPredicate)
+				: await selectorOrPredicate();
+			if (value) return value;
+			await sleep(100);
+		}
+		throw new Error(`Timed out waiting for ${label}`);
+	};
+	const closeTransientUi = async () => {
+		for (const button of Array.from(document.querySelectorAll(".modal-close-button"))) {
+			button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		}
+		document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+		for (const element of Array.from(document.querySelectorAll(".suggestion-container, .suggestion-item"))) {
+			element.remove();
+		}
+		await sleep(100);
+	};
+	const cleanupScratch = async () => {
+		if (!CLEANUP) return cleanup;
+		cleanup.attempted = true;
+		for (const path of [...createdPaths].reverse()) {
+			try {
+				const existing = app.vault.getAbstractFileByPath(path);
+				if (existing) {
+					await app.vault.delete(existing);
+					cleanup.deleted.push(path);
+				}
+			} catch (error) {
+				cleanup.errors.push(`${path}: ${String(error?.stack || error)}`);
+			}
+		}
+		return cleanup;
+	};
+	const textOfSuggestion = (element) => {
+		const textEl = element.querySelector(".suggestion-item-text") || element;
+		return (textEl.textContent || "").replace(/[\u274c\ud83d\udd03]/g, "").trim();
+	};
+
+	const plugin = app.plugins.plugins[PLUGIN_ID];
+	if (!plugin?.api) throw new Error("MetaEdit plugin API is not available.");
+	const settingsSnapshot = JSON.parse(JSON.stringify(plugin.settings));
+	const results = {};
+
+	try {
+		await ensureFolder(ROOT);
+
+		const editFile = await createFreshFile(`${ROOT}/edit-meta-and-inline.md`, [
+			"---",
+			"status: todo",
+			"---",
+			"# Edit Meta smoke",
+			"inline_status:: draft",
+			"",
+		].join("\n"));
+		await app.workspace.getLeaf(false).openFile(editFile);
+		await sleep(300);
+		await app.commands.executeCommandById(`${PLUGIN_ID}:metaEditRun`);
+		await waitFor(".suggestion-item", "Edit Meta suggestion items");
+		await sleep(150);
+		const menuKeys = Array.from(document.querySelectorAll(".suggestion-item")).map(textOfSuggestion);
+		results.editMetaMenuKeys = menuKeys;
+		if (!menuKeys.includes("status")) failures.push("Edit Meta menu did not include YAML status.");
+		if (!menuKeys.includes("inline_status")) failures.push("Edit Meta menu did not include inline_status.");
+		await closeTransientUi();
+
+		await plugin.api.update("inline_status", "published", editFile);
+		await sleep(300);
+		const inlineContent = await app.vault.read(editFile);
+		results.inlineContent = inlineContent;
+		if (!inlineContent.includes("inline_status:: published")) failures.push("Inline key:: field did not update.");
+
+		const autoFile = await createFreshFile(`${ROOT}/auto-property.md`, [
+			"---",
+			"ap_status: todo",
+			"---",
+			"# Auto Property smoke",
+			"",
+		].join("\n"));
+		plugin.settings.AutoProperties.enabled = true;
+		plugin.settings.AutoProperties.properties = [{
+			name: "ap_status",
+			choices: ["todo", "done"],
+			description: "Mobile smoke choice",
+			type: "Single",
+		}];
+		const autoProps = await plugin.controller.getPropertiesInFile(autoFile);
+		const autoProperty = autoProps.find((property) => property.key === "ap_status");
+		if (!autoProperty) throw new Error("ap_status property was not parsed.");
+		const autoEditPromise = plugin.controller.editMetaElement(autoProperty, autoProps, autoFile);
+		const modal = await waitFor(".metaedit-ap-prompt", "Auto Property prompt");
+		const doneRow = await waitFor(
+			() => Array.from(modal.querySelectorAll(".metaedit-ap-prompt-row")).find((row) => row.textContent.trim() === "done"),
+			"Auto Property done row"
+		);
+		doneRow.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		await Promise.race([autoEditPromise, sleep(5000)]);
+		await sleep(500);
+		const autoContent = await app.vault.read(autoFile);
+		results.autoPropertyContent = autoContent;
+		if (!autoContent.includes("ap_status: done")) failures.push("Auto Properties value prompt did not write selected value.");
+
+		const progressFile = await createFreshFile(`${ROOT}/progress.md`, [
+			"---",
+			"readProgress: 0",
+			"---",
+			"# Tasks",
+			"- [ ] one",
+			"- [x] two",
+			"Body line should stay literal: readProgress: 0",
+			"",
+		].join("\n"));
+		plugin.settings.ProgressProperties.enabled = true;
+		plugin.settings.ProgressProperties.properties = [{ name: "readProgress", type: "Total Tasks" }];
+		const progressProps = await plugin.controller.getPropertiesInFile(progressFile);
+		await plugin.controller.handleProgressProps(progressProps, progressFile);
+		await sleep(500);
+		const progressContent = await app.vault.read(progressFile);
+		results.progressContent = progressContent;
+		if (!/readProgress:\s*"?2"?/.test(progressContent)) failures.push("Progress Properties did not write total task count.");
+		if (!progressContent.includes("Body line should stay literal: readProgress: 0")) failures.push("Progress Properties rewrote matching body text.");
+
+		const cardFile = await createFreshFile(`${ROOT}/Project A.md`, "---\nstatus: Backlog\n---\n\nbody\n");
+		const boardPath = `${ROOT}/Roadmap.md`;
+		const backlogBoard = [
+			"---",
+			"kanban-plugin: board",
+			"---",
+			"",
+			"## Backlog",
+			"",
+			"- [ ] [[Project A]]",
+			"",
+			"## In Progress",
+			"",
+		].join("\n");
+		const movedBoard = [
+			"---",
+			"kanban-plugin: board",
+			"---",
+			"",
+			"## Backlog",
+			"",
+			"## In Progress",
+			"",
+			"- [ ] [[Project A]]",
+			"",
+		].join("\n");
+		const boardFile = await createFreshFile(boardPath, backlogBoard);
+		plugin.settings.KanbanHelper = {
+			enabled: true,
+			boards: [{ boardName: "Roadmap", property: "status" }],
+		};
+		plugin.toggleAutomators();
+		await sleep(1800);
+		await app.vault.modify(boardFile, movedBoard);
+		const kanbanContent = await waitFor(async () => {
+			const content = await app.vault.read(cardFile);
+			return content.includes("status: In Progress") ? content : null;
+		}, "Kanban helper to update linked card", 25000);
+		results.kanbanCardContent = kanbanContent;
+		if (!kanbanContent.includes("status: In Progress")) failures.push("Kanban helper did not update linked card lane.");
+	} finally {
+		await closeTransientUi();
+		plugin.settings = settingsSnapshot;
+		plugin.toggleAutomators();
+		await cleanupScratch();
+	}
+
+	return {
+		ok: failures.length === 0,
+		failures,
+		scratchRoot: ROOT,
+		vault: app.vault.getName?.() ?? null,
+		obsidianApiVersion: window.apiVersion ?? null,
+		metaeditVersion: plugin.manifest?.version ?? null,
+		results,
+		cleanup,
+	};
+})()

--- a/scripts/mobile/probes/issue99_frontmatter.js
+++ b/scripts/mobile/probes/issue99_frontmatter.js
@@ -16,6 +16,15 @@
 		const existing = app.vault.getAbstractFileByPath(path);
 		if (existing) await app.vault.delete(existing);
 	};
+	const deleteEmptyFolder = async (path) => {
+		const existing = app.vault.getAbstractFileByPath(path);
+		if (!existing) return;
+		const listed = await app.vault.adapter.list(path).catch(() => null);
+		if (listed && listed.files.length === 0 && listed.folders.length === 0) {
+			await app.vault.delete(existing);
+			cleanup.deleted.push(path);
+		}
+	};
 	const waitFor = async (predicate, label, timeout = 10000) => {
 		const start = Date.now();
 		while (Date.now() - start < timeout) {
@@ -34,6 +43,7 @@
 				await app.vault.delete(existing);
 				cleanup.deleted.push(NOTE_PATH);
 			}
+			await deleteEmptyFolder(SCRATCH_DIR);
 		} catch (error) {
 			cleanup.errors.push(String(error?.stack || error));
 		}

--- a/scripts/mobile/probes/issue99_frontmatter.js
+++ b/scripts/mobile/probes/issue99_frontmatter.js
@@ -1,0 +1,112 @@
+(async () => {
+	const PLUGIN_ID = "metaedit";
+	const SCRATCH_DIR = "MetaEdit Mobile Debug";
+	const NOTE_PATH = `${SCRATCH_DIR}/issue-99-frontmatter.md`;
+	const CLEANUP = true;
+	const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+	const failures = [];
+	const cleanup = { attempted: false, deleted: [], errors: [] };
+
+	const ensureFolder = async (path) => {
+		if (!app.vault.getAbstractFileByPath(path)) {
+			await app.vault.createFolder(path);
+		}
+	};
+	const deleteIfExists = async (path) => {
+		const existing = app.vault.getAbstractFileByPath(path);
+		if (existing) await app.vault.delete(existing);
+	};
+	const waitFor = async (predicate, label, timeout = 10000) => {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			const value = await predicate();
+			if (value) return value;
+			await sleep(120);
+		}
+		throw new Error(`Timed out waiting for ${label}`);
+	};
+	const cleanupScratch = async () => {
+		if (!CLEANUP) return cleanup;
+		cleanup.attempted = true;
+		try {
+			const existing = app.vault.getAbstractFileByPath(NOTE_PATH);
+			if (existing) {
+				await app.vault.delete(existing);
+				cleanup.deleted.push(NOTE_PATH);
+			}
+		} catch (error) {
+			cleanup.errors.push(String(error?.stack || error));
+		}
+		return cleanup;
+	};
+
+	const plugin = app.plugins.plugins[PLUGIN_ID];
+	if (!plugin?.api) throw new Error("MetaEdit plugin API is not available.");
+
+	try {
+		await ensureFolder(SCRATCH_DIR);
+		await deleteIfExists(NOTE_PATH);
+		const file = await app.vault.create(NOTE_PATH, [
+			"---",
+			"mobile_status: initial",
+			"mobile_empty:",
+			"mobile_keep: stay",
+			"---",
+			"# MetaEdit mobile issue #99 scratch",
+			"",
+			"inline_mobile:: inline initial",
+			"",
+		].join("\n"));
+		await waitFor(
+			() => app.metadataCache.getFileCache(file)?.frontmatter,
+			"initial frontmatter cache"
+		);
+
+		const initialEmpty = await plugin.api.getPropertyValue("mobile_empty", file);
+		await plugin.api.addOrUpdateProperty("mobile_new", "created-on-mobile", file);
+		await plugin.api.update("mobile_status", "updated-on-mobile", file);
+		await plugin.api.addOrUpdateProperty("mobile_clear", "set-before-clear", file);
+		await plugin.api.update("mobile_clear", null, file);
+		await sleep(600);
+
+		const properties = await plugin.api.getPropertiesInFile(file);
+		const rawContent = await app.vault.read(file);
+		const cache = app.metadataCache.getFileCache(file);
+		const values = {
+			initialEmpty,
+			status: await plugin.api.getPropertyValue("mobile_status", file),
+			created: await plugin.api.getPropertyValue("mobile_new", file),
+			cleared: await plugin.api.getPropertyValue("mobile_clear", file),
+			keep: await plugin.api.getPropertyValue("mobile_keep", file),
+		};
+		const keys = properties.map((property) => property.key);
+		const frontmatterKeys = Object.keys(cache?.frontmatter ?? {});
+
+		if (values.initialEmpty === "null") failures.push("Blank YAML value read back as literal string \"null\".");
+		if (values.initialEmpty !== null) failures.push(`Blank YAML value should read as null, got ${JSON.stringify(values.initialEmpty)}.`);
+		if (values.cleared === "null") failures.push("Cleared YAML value read back as literal string \"null\".");
+		if (values.status !== "updated-on-mobile") failures.push(`mobile_status read-back mismatch: ${values.status}`);
+		if (values.created !== "created-on-mobile") failures.push(`mobile_new read-back mismatch: ${values.created}`);
+		if (values.cleared !== null) failures.push(`mobile_clear should read as null after clearing, got ${JSON.stringify(values.cleared)}.`);
+		if (keys.includes("position")) failures.push("MetaEdit parsed Obsidian's legacy frontmatter.position as a real property.");
+		if (/^position\s*:/m.test(rawContent)) failures.push("Raw note content contains a spurious top-level position property.");
+
+		await cleanupScratch();
+		return {
+			ok: failures.length === 0,
+			failures,
+			notePath: NOTE_PATH,
+			vault: app.vault.getName?.() ?? null,
+			obsidianApiVersion: window.apiVersion ?? null,
+			metaeditVersion: plugin.manifest?.version ?? null,
+			values,
+			frontmatterKeys,
+			propertyKeys: keys,
+			rawContent,
+			cleanup,
+		};
+	} catch (error) {
+		await cleanupScratch();
+		throw error;
+	}
+})()


### PR DESCRIPTION
Add a repo-local mobile debug harness for MetaEdit and record the issue #99 mobile investigation.

This adds:
- `scripts/mobile/metaedit_ios.py` for USB iPhone diagnosis/deploy/eval/logs through `pymobiledevice3` House Arrest + Web Inspector, with pre-deploy backup verification, byte-verified deploy, and restore support for the real `notes` vault.
- `scripts/mobile/metaedit_android.py` for Android emulator/device diagnosis/deploy/eval through `adb` + WebView CDP, gated as scratch-vault-only because it has no backup/restore path.
- reusable JS probes for the issue #99 frontmatter path and a broader mobile smoke pass.
- `scripts/mobile/README.md` plus `MOBILE_FINDINGS.md` with the approved iPhone run evidence.

Approved iPhone verification:
- Obsidian iOS `1.13.1` build `339`, iPhone WebView user agent reporting iOS 18.7, vault `notes`.
- Snapshot created before writing: `~/.metaedit-mobile-backups/metaedit/<device>/notes/20260628T160849Z`.
- Deployed local MetaEdit `1.8.4` build with byte-verified `main.js`, `manifest.json`, `styles.css`, and `.hotreload`.
- `issue99_frontmatter.js` returned `ok: true`: blank and cleared YAML values read back as JavaScript `null`, not the literal string `"null"`; YAML create/update worked through MetaEdit; no `position` key appeared in parsed properties or raw note content.
- `core_smoke.js` returned `ok: true` for Edit Meta, inline `key::` fields, Auto Properties, Progress Properties, and the Kanban helper.
- Fresh post-probe console stream was clean after `console.clear()`.
- Restored the original phone plugin folder from the snapshot and final diagnosis showed MetaEdit back to disabled/uninstantiated, with the original plugin files and no `.hotreload`.

Verdict:
- On the approved real iPhone run, issue #99's two reported failure modes are fixed/not reproducible in the post-#119/#136 build.
- This exercises the current read/write paths introduced by #119/#136 and found no real iOS product bug requiring a root-cause code fix.
- It does not prove a same-runtime before/after against the original Obsidian iOS 1.4.7 / API 1.3.7 environment.
- Android was not run in this session.

Validation performed:
- `pnpm run build`
- `pnpm run lint`
- `pnpm run test`
- `python3 -m py_compile scripts/mobile/metaedit_ios.py scripts/mobile/metaedit_android.py`
- `node --check scripts/mobile/probes/issue99_frontmatter.js`
- `node --check scripts/mobile/probes/core_smoke.js`
- iPhone: `metaedit_ios.py diagnose --vault notes`, `deploy --vault notes --confirm-real-vault`, `eval --file issue99_frontmatter.js`, `eval --timeout 180 --file core_smoke.js`, clean `logs --seconds 10`, `restore --backup ...`, final `diagnose --vault notes`

Refs #99.
