### PR TITLE
fix(tags): correct and clarify tag editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ This is an asynchronous function, so you should `await` it.
 
 When updating inline Dataview fields, non-string values are stringified. YAML frontmatter properties can preserve richer YAML values such as numbers, booleans, arrays, and objects.
 
+`update` is replace-by-design: when a note has several inline `name:: value` lines with the same name, it rewrites all of them to the new value. To add a new instance instead and leave the existing ones untouched, use [`appendDataviewField`](#appenddataviewfieldpropertyname-string-propertyvalue-unknown-file-tfile--string-options-location-afterlastmatch--end).
+
 ### `createYamlProperty(propertyName: string, propertyValue: unknown, file: TFile | string)`
 Creates a YAML frontmatter property in the given file.
 
@@ -89,6 +91,25 @@ This is an asynchronous function, so you should `await` it.
 Updates an existing property with the given name, or creates a YAML frontmatter property when the property does not exist.
 
 This is an asynchronous function, so you should `await` it.
+
+### `appendDataviewField(propertyName: string, propertyValue: unknown, file: TFile | string, options?: { location?: "afterLastMatch" | "end" })`
+Adds a new inline `name:: value` Dataview field instance to the body of the note, leaving any existing fields with the same name unchanged. This is the add-an-instance counterpart to `update`, which replaces every existing instance.
+
+The field is never inserted into YAML frontmatter or a fenced code block. Non-string values are stringified (arrays are joined with `, `).
+
+`options.location` controls placement:
+- `"afterLastMatch"` (default): right after the last existing `name::` line; if there is none, at the end of the note body.
+- `"end"`: always at the end of the note body.
+
+If the file is a string, it should be the file path. Otherwise, a `TFile` is fine.
+
+This is an asynchronous function, so you should `await` it.
+
+For example, a Dataview/Templater wishlist that appends a new pick without disturbing earlier ones:
+```js
+const {appendDataviewField} = this.app.plugins.plugins["metaedit"].api;
+await appendDataviewField("watch", "[[Dune: Part Two]]", tp.file.path);
+```
 
 ### `getPropertyValue(propertyName: string, file: TFile | string)`
 Gets the value of the given property in the given file.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - Delete properties easily
 - Auto update properties in files linked to from Kanban boards on lane change
 - Edit metadata through a filemenu
-- Edit last value in tags - works with [Obsidian Tracker](https://github.com/pyrochlore/obsidian-tracker), too.
+- Edit tags wherever they live - rename a body `#tag` in place or edit a frontmatter `tags:` list (see [Editing tags](#editing-tags-guide))
 - API to use in other plugins and Templater templates.
 
 ## Installation
@@ -31,6 +31,21 @@ This plugin is in the community plugin browser in Obsidian. Search for MetaEdit 
 https://user-images.githubusercontent.com/29108628/119513092-3223e000-bd74-11eb-9060-3e0cae4dbef3.mp4
 
 ## Guides
+### Editing tags guide
+Run MetaEdit on a note and it lists that note's tags from **both** homes:
+
+- **Body `#tags`** show up as `#tag` rows. Selecting one lets you:
+  - **Rename tag** - replace the whole tag for that one occurrence (e.g. `#draft` -> `#published`). The rest of the line, and any other occurrence of the same tag, are left untouched.
+  - **Edit last segment** (nested tags only) - change just the leaf, e.g. `#area/old` -> `#area/new`.
+  - **Tracker value** - when the [Obsidian Tracker](https://github.com/pyrochlore/obsidian-tracker) plugin is installed, write its `#tag:value` data syntax. This choice is made per edit and never leaks into later edits.
+- **Frontmatter `tags:`** show up as the `tags` property. Editing it strips a leading `#` you type, accepts a list / single value / comma- or space-separated string, stores the canonical `#`-free YAML list, and removes the key entirely when you clear the last tag.
+
+What MetaEdit deliberately leaves to Obsidian (verified against Obsidian 1.12.7):
+
+- **Vault-wide rename** (rename a tag across every note) - use Obsidian's **Tag pane**: right-click a tag and choose *Rename*.
+- **The rich frontmatter tag widget** (pills, type-ahead) - Obsidian's native **Properties** editor.
+- **Deleting a body tag** - edit the note directly; MetaEdit no longer offers a delete/transform action on body `#tags` (it could not target them safely).
+
 ### Kanban Helper Guide
 https://user-images.githubusercontent.com/29108628/121333246-ebf48200-c918-11eb-889b-23b9a80299b2.mp4
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ When updating inline Dataview fields, non-string values are stringified. YAML fr
 
 `update` is replace-by-design: when a note has several inline `name:: value` lines with the same name, it rewrites all of them to the new value. To add a new instance instead and leave the existing ones untouched, use [`appendDataviewField`](#appenddataviewfieldpropertyname-string-propertyvalue-unknown-file-tfile--string-options-location-afterlastmatch--end).
 
+When the named property is a body `#tag`, `update` renames that one occurrence in place (`update("#topic", "science", file)` writes `#science`, not `#topic/science`). The value is normalized to a valid tag (a leading `#` is optional) and an invalid name - one with spaces, commas, or punctuation Obsidian would not index as a single tag - is rejected rather than written.
+
 ### `createYamlProperty(propertyName: string, propertyValue: unknown, file: TFile | string)`
 Creates a YAML frontmatter property in the given file.
 

--- a/TAG_EDITING_DESIGN.md
+++ b/TAG_EDITING_DESIGN.md
@@ -1,6 +1,8 @@
 # Unified Tag Editing - Design Spike
 
-Status: Draft for review (design spike, no implementation). Adversarially reviewed.
+Status: Approved and IMPLEMENTED as Option B (Repair + clarify), Decision D = rename.
+The implementation lives in the same branch/PR (Fixes #49); this document is the
+design record it was built from. Originally a design spike, adversarially reviewed.
 Prompted by: issue #49 ("How to use this new feature 'Edit last value in tags'?")
 Base: `origin/master`
 Runtime verified against: Obsidian 1.12.7 (isolated E2E vault), current build.

--- a/TAG_EDITING_DESIGN.md
+++ b/TAG_EDITING_DESIGN.md
@@ -1,0 +1,595 @@
+# Unified Tag Editing - Design Spike
+
+Status: Draft for review (design spike, no implementation). Adversarially reviewed.
+Prompted by: issue #49 ("How to use this new feature 'Edit last value in tags'?")
+Base: `origin/master`
+Runtime verified against: Obsidian 1.12.7 (isolated E2E vault), current build.
+Author: design spike, 2026-06-28
+
+---
+
+## 1. TL;DR and recommendation
+
+MetaEdit's tag editing today operates on **body `#tags` only**, through a path
+(`editTag` -> `updatePropertyLine`) that is undocumented, originally built around
+the Tracker plugin, and carries **five confirmed defects** - including silent
+data loss, a session-wide state leak, and an edit path that cannot tell two
+identical tags apart. Issue #49 was two users who could not figure out what the
+feature does; that is a symptom of the feature being both confusing and partly
+broken, not evidence of demand for *more* tag features.
+
+Modern Obsidian (verified 1.12.7) already does the two things users most want:
+the native **Properties** UI edits frontmatter `tags:` with a typed tag widget
+(pills, autocomplete, add/remove), and the native **Tag pane** renames a tag
+vault-wide across body *and* frontmatter. MetaEdit re-implementing either would
+duplicate a better-integrated native feature.
+
+So the honest recommendation is a choice between three scoped options, not a
+binary "build the unification or not" (Section 11). The recommended path:
+
+1. **Decide the tag-operation semantics first** (rename vs append-leaf; one
+   occurrence vs all) - because the correctness fix depends on it (Section 9).
+2. **Fix the correctness defects** (Section 4) and **canonicalize frontmatter
+   tag input** (Section 6.3). This is the high-value real work and directly
+   addresses #49 by making the feature behave sanely.
+3. **Treat any cross-location unification as a model-layer concern, on demand**
+   (Section 6, Section 11) - never a UI-only grouping, and only if users ask for
+   single-note, all-homes tag operations.
+
+A credible **smaller** option also exists and is now first-class: **remove or
+default-hide body-tag editing** and lean entirely on native Obsidian
+(Section 11, Option A). The decisions Christian needs to make are in Section 12.
+
+---
+
+## 2. Issue #49 in context
+
+> "I see on the release notes that you added 'Edit last value in tags' but I
+> cannot see how to do it. An example would be nice."
+
+Two users could not discover or understand the feature. The eventual answer
+(forum + the close comment) was: it checks for the Tracker plugin, then lets you
+choose Tracker or MetaEdit before replacing the final tag segment
+(`src/metaController.ts:124-153`). That is an accurate description of the code -
+and it confirms the feature is opaque. The discoverability problem is real, and
+underneath it the feature is also defective (Section 4).
+
+The framing for this spike: "there's clearly behavior expected re. tags being
+able to be both in the note body and YAML frontmatter." That is true - but the
+gap is mostly **correctness and clarity**, not a missing unification layer.
+
+---
+
+## 3. How tag editing works today (precise map)
+
+### 3.1 Two disconnected data sources
+
+`getPropertiesInFile` concatenates three independently-parsed sources
+(`src/metaController.ts:39-45`):
+
+```ts
+const yaml = await this.parser.parseFrontmatter(file);
+const inlineFields = await this.parser.parseInlineFields(file);
+const tags = await this.parser.getTagsForFile(file);
+return [...tags, ...yaml, ...inlineFields];
+```
+
+- `getTagsForFile` reads **`cache.tags`** and emits `MetaType.Tag` entries -
+  **discarding `TagCache.position`**, keeping only `{key, content, type}`
+  (`src/parser.ts:49-58`). This dropped position is the root of BUG-3.
+- `parseFrontmatter` reads frontmatter and emits `MetaType.YAML` entries
+  (`src/parser.ts:60-65`), so a frontmatter `tags:` list becomes
+  `{key: "tags", content: [...], type: MetaType.YAML}`.
+
+**`cache.tags` contains body tags only.** Verified live for a note with
+`tags: [alpha, nested/beta]` in frontmatter and `#gamma #delta` (mid-line) plus
+`#epsilon` (line start) in the body:
+
+```jsonc
+// app.metadataCache.getFileCache(file)
+"cacheTags":   [ {"tag":"#gamma","line":7}, {"tag":"#delta","line":7}, {"tag":"#epsilon","line":8} ],
+"frontmatter": { "tags": ["alpha","nested/beta"], "status":"open" }
+```
+
+So the two homes never meet in MetaEdit's model:
+
+| Tag location          | Parsed by          | Property.type     | Edited by                         |
+|-----------------------|--------------------|-------------------|-----------------------------------|
+| Body `#tag`           | `getTagsForFile`   | `MetaType.Tag`    | `editTag` -> `updatePropertyLine` |
+| Frontmatter `tags:`   | `parseFrontmatter` | `MetaType.YAML`   | generic YAML / multi-value editor |
+
+A frontmatter `tags:` key is just another YAML property to MetaEdit - no `#`
+handling, no nested-segment logic, no dedupe with body tags. This sameness is
+also relied upon deliberately: `hideFileTags` removes body `MetaType.Tag` entries
+but **keeps** the frontmatter `tags:` key editable (`src/Modals/menuFilter.ts:26`,
+`:30-39`).
+
+### 3.2 The body-tag edit flow
+
+`editMetaElement` routes `MetaType.Tag` to `editTag`
+(`src/metaController.ts:96-100`). `editTag` (`src/metaController.ts:124-153`):
+
+1. Splits the tag on `/`; `allButLast` = everything before the last segment.
+2. If the Tracker plugin is installed, asks "Use Tracker" vs "Use MetaEdit"
+   (`:131-132`).
+3. On "Use Tracker": prompts for a value and **sets `this.useTrackerPlugin =
+   true`** (`:136-138`).
+4. On "Use MetaEdit": if an Auto Property is configured for `allButLast`, runs
+   it; otherwise free-text prompt (`:139-147`).
+5. Writes via `updatePropertyFromUi` -> `updatePropertyInFile` ->
+   `updatePropertyLine`.
+
+`updatePropertyLine` for `MetaType.Tag` (`src/metaController.ts:434-447`):
+
+```ts
+case MetaType.Tag:
+    if (this.useTrackerPlugin) {
+        newLine = `${property.key}:${newValue}`;            // Tracker: #tag:value
+    } else {
+        const splitTag = property.key.split("/");
+        if (splitTag.length === 1)
+            newLine = `${splitTag[0]}/${newValue}`;          // #foo  -> #foo/value (append leaf)
+        else if (splitTag.length > 1) {
+            const allButLast = splitTag.slice(0, -1).join("/");
+            newLine = `${allButLast}/${newValue}`;           // #a/b  -> #a/value (replace leaf)
+        } else newLine = property.key;
+    }
+```
+
+The matched line is **replaced wholesale** with `newLine`
+(`src/metaController.ts:390-396`):
+
+```ts
+const newFileContent = fileContent.split("\n").map(line => {
+    if (this.lineMatch(property, line)) return this.updatePropertyLine(property, newValue, line);
+    return line;
+}).join("\n");
+```
+
+The same `updatePropertyLine` is also reached from `updateMultipleInFile`
+(`src/metaController.ts:477-481`); any fix to the Tracker flag must account for
+every caller (Section 4, BUG-1).
+
+### 3.3 Line matching (`lineMatch`, `src/metaController.ts:406-421`)
+
+```ts
+const tagRegex = new RegExp(`^\s*${this.escapeSpecialCharacters(property.key)}`);
+if (property.key.contains('#')) return tagRegex.test(line);
+```
+
+The template literal `` `^\s*...` `` does **not** mean "start, optional
+whitespace." In a JS string/template literal `\s` is an unknown escape and
+collapses to the literal character `s`, so the compiled source is `^s*\#tag`
+(verified). Effects:
+
+| Line                      | `^s*\#gamma` (actual) | `^\s*\#gamma` (intended) |
+|---------------------------|-----------------------|--------------------------|
+| `#gamma at start`         | matches               | matches                  |
+| `  #gamma` (indented)     | **no match**          | matches                  |
+| `- #gamma` (list item)    | **no match**          | no match (line-start only)|
+| `text #gamma` (mid-line)  | **no match**          | no match (line-start only)|
+| `s#gamma`, `ss#gamma`     | **matches (false +)** | no match                 |
+
+So tags are only rewritten at an unindented line start, and the broken `s*` even
+introduces a false-positive on lines that begin with literal `s` characters
+before the tag. (The same broken `\s` appears at `deleteProperty`,
+`src/metaController.ts:203`; the correctly-escaped `\\s` is used at `:419` for
+non-tag properties.)
+
+### 3.4 What MetaEdit does with frontmatter tags today
+
+Nothing tag-specific. A `tags:` list is a `MetaType.YAML` property; because its
+content is an array, `shouldUseMultiValueEditor` returns true
+(`src/multiValue.ts:27-44`) and it opens the element-aware list editor
+(`src/metaController.ts:245-313`). That editor is decent for lists in general,
+but it has no notion of the `#` convention or nested tag segments. So a user who
+types `#alpha` into the YAML list editor gets a literal `#alpha` stored in
+frontmatter (wrong convention) - see Section 6.3. Frontmatter writes go through
+`processFrontMatter` (`src/metaController.ts:368-400`, the #119 path), preserving
+the rest of the YAML block. This YAML-tags-as-list editing is already exercised
+by tests (`tests/e2e/multi-value.test.ts`), i.e. it is live, core behavior - not
+a future concern.
+
+### 3.5 Tests
+
+`getTagsForFile` is *indirectly* covered: `tests/e2e/metaedit-runtime.test.ts`
+asserts a body `#mytag` surfaces from `getPropertiesInFile` (`:212`). What is
+**uncovered** is the part that matters here: `editTag`, the `MetaType.Tag`
+write path, the Tracker branch, and tag deletion. Adjacent unit coverage exists
+for `filterMenuItems` (`src/Modals/menuFilter.test.ts`), tag value suggestions
+(`src/Modals/GenericPrompt/valueSuggest.test.ts`), `isMultiValueYamlProperty`
+(`src/multiValue.test.ts:21`), and that frontmatter `tags:` parses as YAML
+(`src/parser.test.ts:69`).
+
+---
+
+## 4. Defects found (confirmed, with live evidence)
+
+All reproduced in an isolated Obsidian 1.12.7 vault against the current build.
+
+### BUG-1 - `useTrackerPlugin` leaks across the whole session (correctness, high)
+
+`this.useTrackerPlugin` is an instance field (`src/metaController.ts:29`), set to
+`true` when a user picks "Use Tracker" (`:138`) and **never reset**. The
+controller is a session singleton (`src/main.ts:33`). So after anyone picks "Use
+Tracker" once, every later tag edit that session writes Tracker `#tag:value`
+syntax - even when the user explicitly picks "Use MetaEdit" - until reload.
+
+Live proof - forcing the leaked state and writing through the real controller:
+
+```jsonc
+// controller.useTrackerPlugin = true (the post-"Use Tracker" state)
+{ "leakedBefore": false, "afterWrite": "#epsilon:5" }   // got Tracker syntax, MetaEdit was not chosen
+```
+
+**Fix:** derive the choice per-edit and thread it through the write call; never
+store it on the instance. Audit *all* callers of `updatePropertyLine` -
+`editTag -> updatePropertyFromUi` (`:150-151`, `:501-503`) and
+`updateMultipleInFile` (`:477-481`), plus the public API update paths in
+`src/MetaEditApi.ts`. Non-UI callers must default to MetaEdit syntax. Do **not**
+add a new setting for this (Section 6.5).
+
+### BUG-2 - Editing a body tag destroys the rest of its line (data loss, high)
+
+`updatePropertyLine` returns a freshly-built tag string and the caller replaces
+the **entire** matched line with it (`src/metaController.ts:390-396`,
+`:434-447`). Any prose sharing the line is lost.
+
+Live proof:
+
+```text
+BEFORE:  #epsilon at line start with trailing prose.
+AFTER:   #epsilon/newleaf
+```
+
+" at line start with trailing prose." was deleted - silent, unrecoverable data
+loss on an ordinary note.
+
+**Fix:** rewrite only the tag token's span in place. The pattern exists for
+inline fields in `replaceInlineFieldValue` (`src/parser.ts:393-404`), which
+splices `[start, valueEnd)` rather than rebuilding the line - but note that
+helper is **line-local** while `TagCache.position` is **document-global**
+(offsets into the whole file). A sound implementation must therefore (Section 9):
+carry tag position on the `Property`, splice by document offset (or locate the
+token within the resolved line), validate the offset against current content
+before writing, and decide the duplicate-occurrence policy (BUG-3).
+
+### BUG-3 - The edit path has no tag-occurrence identity (correctness, high)
+
+This is the linchpin defect and is deeper than "mid-line tags are a no-op."
+Because `getTagsForFile` discards position (`src/parser.ts:49-58`) and the writer
+matches by key regex across all lines (`src/metaController.ts:390-396`,
+`:406-421`), MetaEdit cannot tell two occurrences of the same tag apart. Three
+distinct failures follow:
+
+1. **Mid-line / indented tag, no line-start twin -> silent no-op.** The selected
+   tag is never rewritten. Live proof (editing mid-line `#zeta`):
+   ```text
+   BEFORE:  Mid-line tag #zeta should be editable too.
+   AFTER:   Mid-line tag #zeta should be editable too.   (unchanged)
+   ```
+2. **Same tag appears twice -> the wrong one is edited.** If `#zeta` is mid-line
+   on one line and at line-start on another, selecting the mid-line occurrence
+   still rewrites the line-start one (the only `lineMatch`). With two line-start
+   occurrences, **both** are rewritten.
+3. **False-positive match.** The `^s*` escape bug (Section 3.3) can rewrite an
+   unrelated line that happens to start with literal `s` before the tag.
+
+**Fix:** give tag Properties stable occurrence identity (position from
+`cache.tags`) and edit that specific span; correct `\s` -> `\\s` at `:409` and
+`:203` regardless. If carrying position is out of scope for the first slice, the
+honest fallback is to **filter non-rewritable / ambiguous tags out of the picker
+and disable structure edits on tags** so nothing is silently mis-edited
+(Section 11, Option A/B).
+
+### BUG-5 - Deleting or transforming a body tag is broken (correctness, medium)
+
+The suggester shows ❌ Delete and 🔃 Transform buttons on every non-nested
+property, including body tags (`src/Modals/metaEditSuggester.ts:50-53`,
+`:139-141`). But `deleteProperty` matches `` `^\s*${property.key}:` `` -
+requiring a trailing colon (`src/metaController.ts:201-205`), which a `#tag`
+line does not have. Live proof: deleting `#epsilon` left the file **unchanged**
+(`deleted_no_op: true`). And 🔃 Transform on a tag calls `deleteProperty` (no-op)
+then `addYamlProp("#tag", "#tag", ...)` (`src/Modals/metaEditSuggester.ts:122-130`),
+creating a literal frontmatter key named `#tag`.
+
+**Fix (minimal):** disable the structure buttons for `MetaType.Tag`
+(`canStructureEdit` already exists as the gate at `:139-141`), or implement a
+real position-based tag delete. Disabling is the smallest correct step.
+
+### DESIGN-1 - "Edit last value" appends a child to a flat tag (UX, not a bug)
+
+For a flat tag, `updatePropertyLine` writes `` `${splitTag[0]}/${newValue}` ``
+(`src/metaController.ts:438-440`): `#epsilon` edited to `newleaf` becomes
+`#epsilon/newleaf` - it appends a child segment rather than renaming. Live proof:
+`#epsilon` -> `#epsilon/newleaf`.
+
+This is **intended behavior**, not a defect: the feature is literally "Edit last
+value in tags," and `valueSuggest` documents and depends on it - it suggests only
+leaf segments precisely because the writer replaces the last segment
+(`src/Modals/GenericPrompt/valueSuggest.ts:24-33`). It is, however, the single
+most confusing thing about the feature and a likely root of the #49 confusion: a
+user expecting to **rename** `#epsilon` instead gets a nested child. This is a
+product decision to settle (Decision D), and - critically - it must be settled
+**before** the correctness slice, because the writer, prompt copy, tests, and
+`valueSuggest` all encode the current semantics.
+
+---
+
+## 5. The design question, assessed critically
+
+**What native Obsidian already does well (verified 1.12.7):**
+
+- Frontmatter `tags:` - the native Properties editor renders a dedicated tag
+  widget (pills, vault-aware autocomplete, click-to-remove). This is the
+  convention users know and is better than a modal picker.
+- Vault-wide rename - the Tag pane's right-click "Rename tag" rewrites every
+  occurrence across body and frontmatter. The canonical "edit a tag everywhere"
+  flow.
+- Body `#tag` entry - inline `#` autocomplete while typing.
+
+**What is genuinely unserved:** a *single-note* operation that treats "this
+note's tags" as one set regardless of home (e.g. "add `#x` to this note",
+"remove `#x` wherever it is in this note"). Native tools are either per-field
+(Properties) or vault-wide (Tag pane); neither is "this one note, all its tags."
+MetaEdit's "Run" command is already a file-scoped all-metadata entry point
+(`src/main.ts:88`) and its API advertises returning tags + YAML + inline fields
+together (`README.md:85`), so this single-note niche is a natural fit - *if* it
+is built at the model layer (Section 6.1), not bolted onto the picker.
+
+**Implication.** The strongest case is correctness of what exists plus, at most,
+a small model-level single-note convenience. A large merged tag-management UI
+would duplicate native features, re-introduce the "which one am I editing?"
+confusion #49 reported, and create maintenance that chases Obsidian's evolving
+native tag UX. The native-handoff claim is load-bearing, so PR-level work should
+**document** exactly what MetaEdit handles vs. what it defers to native, against
+a stated Obsidian version.
+
+---
+
+## 6. Unification: design notes (deferred; for decision only)
+
+Kept deliberately short. This is **not** implementation-ready scope; it exists so
+the build/don't-build decision (Section 11/12) is informed. Build only on demand.
+
+### 6.1 If unified, it belongs at the model layer - not the picker
+
+The tempting shape is a grouped picker that lists body and frontmatter tags
+together. That is the wrong boundary: grouping, `#` normalization, cross-home
+dedupe, and write rules would live only in `MetaEditSuggester` and be missing
+from the API metadata events (`src/MetaEditApi.ts`), the settings/menu filters
+(`src/Modals/menuFilter.ts:26`), value suggestions, and any future bulk/automation
+surface. A coherent unification introduces a parser/controller-level concept
+(e.g. a `TagOccurrence`/tag-service that knows location + position) while keeping
+the public `Property[]` API backward-compatible. Without that, "one tag set, two
+homes" is unenforceable.
+
+### 6.2 Operations (sketch)
+
+- **Add**: prompt with vault-tag autocomplete (already exists for `MetaType.Tag`),
+  then write to frontmatter (recommended default) or body. A body insert needs
+  editor/cursor context the current `TFile`-only boundary does not carry
+  (`src/main.ts:49,88`, `src/Modals/LinkMenu.ts`), so it requires a separate
+  editor-aware command or an explicit "append to note" file operation - do not
+  leak editor state into the controller.
+- **Rename/remove**: frontmatter via `processFrontMatter` (preserve list form,
+  `#`-less convention); body via position-based span splice (BUG-2/BUG-3 fixes).
+- **Nested** (`a/b/c`): offer "rename whole tag" and "rename last segment";
+  for a flat tag only "rename" is meaningful (Decision D).
+- **Cross-location write ordering**: a single-note "rename everywhere" must
+  serialize the two writers - a `processFrontMatter` rewrite shifts every body
+  document offset, so recompute body positions after the frontmatter write (or
+  do one validated full-content transform that preserves the `processFrontMatter`
+  invariant). Naive parallel writes corrupt offsets.
+
+### 6.3 Frontmatter `tags` input canonicalization (small; fold into PR scope)
+
+Independent of any picker, frontmatter `tags`/`tag` deserve tag-aware input *now*
+(Section 3.4): strip a leading `#` on input so a user typing `#alpha` stores
+`alpha`. Obsidian also accepts `tags:` as a scalar or comma/space string, and
+`tags: null | 5 | {nested}` are valid YAML mappings that pass the non-mapping
+guard (`src/parser.ts:114-118`) and are emitted as properties (`:123-131`) - so a
+tag-aware editor must handle those shapes explicitly rather than assume a list.
+(Note: the malformed-YAML *parse-exception* guard is separately at
+`src/parser.ts:216-229`, not `114-118`.)
+
+### 6.4 The `#` prefix convention
+
+Frontmatter stores without `#` (canonical); body stores with `#`; display
+normalized without `#`, location shown by group; moving a tag across homes adds
+or strips `#`.
+
+### 6.5 Tracker integration (and BUG-1)
+
+Tracker's `#tag:value` is body-only and is reached **only** through `editTag`
+(`src/metaController.ts:96`, `:124`); frontmatter tags parse as YAML
+(`src/parser.ts:60`). So the only real work is the BUG-1 leak fix: a per-edit
+local choice plus clearer prompt copy. A dedicated "enable Tracker syntax"
+setting + migration would be manufactured optionality for a single call site -
+do not add it. Decision B is only "keep (fixed) vs deprecate."
+
+### 6.6 Data invariants
+
+1. **Round-trip:** editing one tag changes only that occurrence - never another
+   tag, never surrounding prose, never unrelated YAML (today violated by BUG-2,
+   BUG-3).
+2. **No silent no-ops / mis-edits:** any tag shown is editable and maps to the
+   selected occurrence, or it is not shown (today violated by BUG-3, BUG-5).
+3. **Frontmatter via `processFrontMatter` only; body via validated span splice
+   only; cross-home writes serialized (Section 6.2).**
+
+---
+
+## 7. Edge cases
+
+- Tag appears multiple times in the body - decide one-occurrence vs all (Decision
+  D / BUG-3); whichever, it must be deterministic and shown to the user.
+- Tag inside code - `cache.tags` already excludes code spans (good).
+- `tags` vs `tag` frontmatter key; scalar/CSV/list shapes (Section 6.3).
+- Frontmatter `tags:` that is null/number/object - never throw (parser guards
+  non-mapping at `src/parser.ts:114-118`, parse errors at `:216-229`).
+- Case-only / trailing-slash differences - normalize for compare, preserve for
+  write.
+- Auto Property configured against `allButLast` for a nested tag
+  (`src/metaController.ts:140-144`) must keep working.
+
+---
+
+## 8. Out of scope
+
+- Vault-wide tag rename / merge (native Tag pane owns this; verified 1.12.7).
+- Reinventing tag autocomplete or the native Properties tag widget.
+- Tracker's own data/rendering behavior.
+- A large tag-management UI (Section 6.1 explains why grouping at the UI layer is
+  the wrong boundary).
+
+---
+
+## 9. Sequencing constraint (read before slicing)
+
+Two dependencies force ordering:
+
+1. **Semantics before correctness.** The body-tag writer encodes "append/replace
+   last segment" (`src/metaController.ts:438-446`) and `valueSuggest` depends on
+   it (`:24-33`). Decision D (rename vs leaf vs both) must be settled first, or
+   the correctness slice will land tests that the semantics change later undoes.
+2. **Occurrence identity before span writes.** BUG-2's span-splice fix is only
+   correct once BUG-3's occurrence identity is resolved (position carried,
+   duplicate policy chosen). Otherwise the writer still cannot target the right
+   token. The cheaper alternative is to *not* build span writes and instead
+   filter ambiguous tags out and disable tag structure edits.
+
+---
+
+## 10. Migration and back-compat
+
+- Correctness fixes change observed behavior: edits no longer destroy line prose
+  (BUG-2); deletion/transform on tags stops mis-firing (BUG-5); if Decision D
+  flips to rename, flat tags rename instead of nesting. These are corrections -
+  call them out in release notes.
+- API: `getPropertiesInFile` output shape stays. Adding optional `position`/
+  `location` to tag `Property` objects is additive; keep `IMetaEditApi` stable.
+- Settings: no new setting is required for the correctness work or the Tracker
+  fix (Section 6.5). Any future "default add location" rides the existing
+  `mergeSettings` migration. No stored-data migration is required for the fixes.
+
+---
+
+## 11. Options, slicing, effort, and risk
+
+Three honest options, smallest first. They are alternatives, not a fixed staircase.
+
+### Option A - Subtract: remove or default-hide body-tag editing (smallest)
+
+Lean entirely on native Obsidian + frontmatter editing. `hideFileTags` already
+removes body `MetaType.Tag` entries while keeping frontmatter `tags:` editable
+(`src/Modals/menuFilter.ts:14`, `:30-39`; `src/Settings/metaEditSettingsTab.ts`).
+Minimal version: disable tag structure edits (BUG-5), fix the Tracker leak
+(BUG-1, since the path still exists), default `hideFileTags` on or deprecate the
+"Edit last value in tags" command, and document the native handoff.
+- Effort: **Low.** Risk: **Low.** Value: removes the buggy surface entirely.
+- Cost: abandons a (niche) capability native does not exactly replicate
+  (single-note last-segment / Tracker editing).
+
+### Option B - Repair + clarify (recommended)
+
+Keep body-tag editing, make it correct and honest.
+- Settle Decision D (Section 9) -> BUG-1 (per-edit Tracker flag, all callers) ->
+  BUG-3 (occurrence identity / position) -> BUG-2 (validated span splice) ->
+  BUG-5 (disable or implement tag delete) -> `\s` fix -> frontmatter `tags`
+  `#`-canonicalization (Section 6.3) -> regression tests for each -> docs + an
+  in-modal hint + documented native handoff.
+- Effort: **Medium.** Risk: **Low-Med** (touches the write path; mitigated by
+  tests and the existing span-splice pattern). Value: **High** - fixes data loss
+  and the leak, resolves #49 by correctness + clarity.
+- If carrying tag position proves heavy, fall back to the Option-A picker filter
+  for ambiguous tags within this same slice.
+
+### Option C - Model-level single-note tag operations (on demand)
+
+The coherent middle: a controller/parser tag-service exposing list/rename/remove
+across both homes for the current note (Section 6.1, 6.2), reusing Option B's
+correct writers. No big UI, no native duplication.
+- Effort: **Medium-High.** Risk: **Medium** (new model boundary, cross-home
+  write ordering). Value: **Medium, demand-gated.**
+
+### Not recommended - Option D: a full grouped tag-management UI (Section 6.1).
+
+Recommended order: settle Decision D -> Option B. Consider Option A if the
+maintainer would rather shrink surface than maintain it. Hold Option C for
+explicit demand.
+
+---
+
+## 12. Recommendation and decisions for Christian
+
+**Recommendation:** Settle the semantics (Decision D), then ship **Option B**.
+It fixes real data loss, a state leak, and broken delete/transform, and resolves
+the #49 confusion by making tag editing correct and documented. If you would
+rather not own a feature that overlaps native Obsidian, **Option A** is a
+legitimate, smaller call. Hold the cross-location unification (Option C) unless
+users specifically ask for single-note, all-homes tag operations - native
+already covers frontmatter editing and vault-wide rename better than we can.
+
+**Decisions needed (D first - it gates the work):**
+
+- **D. "Edit last value" semantics** (DESIGN-1): keep append-leaf, switch the
+  primary action to rename-tag, or offer both? This also dictates whether an edit
+  hits one occurrence or all. *Recommend: primary = rename whole tag; offer
+  "edit last segment" only for nested tags; edit a single, identified
+  occurrence.* Settle before any code.
+- **A. Scope:** Option A (subtract), Option B (repair), or commit to Option C?
+  *Recommend: Option B.*
+- **B. Tracker's future:** keep `#tag:value` (leak fixed, body-only) or
+  deprecate it? *Recommend: keep, fixed; no new setting.*
+- **C. Occurrence-identity investment** (gates BUG-2/BUG-3 fix quality): carry
+  tag `position` on `Property` and edit the exact span, or take the smaller route
+  (filter ambiguous tags out + disable tag structure edits)? *Recommend: carry
+  position; it is the root fix and unblocks Option C later.*
+- **E. Empty frontmatter `tags:`** after removing the last tag: leave `tags: []`
+  or remove the key? *Recommend: remove the key.*
+
+---
+
+## Appendix A - evidence index
+
+- Disconnected sources / dropped position: `src/metaController.ts:39-45`,
+  `src/parser.ts:49-58`, `:60-65`; live cache probe (Section 3.1).
+- Body-tag flow: `src/metaController.ts:96-100`, `:124-153`, `:434-447`,
+  `:390-396`, `:477-481`.
+- `lineMatch` line-start-only + `\s`->`s` escape (incl. `s#gamma` false +):
+  `src/metaController.ts:406-421`; node repro (Section 3.3).
+- BUG-1 Tracker leak: `src/metaController.ts:29`, `:138`, `:435-436`,
+  `src/main.ts:33`; live proof `#epsilon:5`.
+- BUG-2 data loss: live proof `#epsilon at line start...` -> `#epsilon/newleaf`.
+- BUG-3 occurrence identity: `src/parser.ts:49-58`, `src/metaController.ts:390-396`,
+  `:406-421`; live no-op proof (`#zeta` unchanged).
+- BUG-5 broken delete/transform: `src/metaController.ts:195-211` (`:203` regex),
+  `src/Modals/metaEditSuggester.ts:50-53`, `:122-130`, `:139-141`; live proof
+  `deleted_no_op: true`.
+- DESIGN-1 leaf semantics by design: `src/metaController.ts:438-446`,
+  `src/Modals/GenericPrompt/valueSuggest.ts:24-33`; live proof
+  `#epsilon` -> `#epsilon/newleaf`.
+- Frontmatter tag handling: `src/multiValue.ts:27-44`,
+  `src/metaController.ts:245-313`, `:368-400`; `tests/e2e/multi-value.test.ts`.
+- Parser guards: non-mapping `src/parser.ts:114-118`, `:123-131`; parse-exception
+  `src/parser.ts:216-229`.
+- Test coverage: `tests/e2e/metaedit-runtime.test.ts:212` (body tag surfaces);
+  edit/write/Tracker/delete paths uncovered.
+- Native Obsidian 1.12.7 verified in the isolated E2E vault.
+
+## Appendix B - adversarial review
+
+Reviewed by three opposing-model (Codex) reviewers - Skeptic, Architect,
+Minimalist. Accepted findings folded into this revision: occurrence-identity is
+the linchpin (BUG-3 reframed; PR ordering in Section 9); the wrong
+malformed-YAML citation corrected (Section 6.3); BUG-4 reclassified as intended
+behavior (DESIGN-1); a fifth defect added (BUG-5, broken tag delete/transform,
+verified live); the unified model demoted to a deferred sketch and re-homed at
+the model layer (Section 6.1); a "subtract the feature" path added as a
+first-class option (Section 11, Option A); the Tracker setting dropped as
+manufactured optionality (Section 6.5); the span-splice fix tightened for
+document-global offsets (Section 4 BUG-2, Section 9); the test-coverage claim
+narrowed (Section 3.5); and the native-handoff claim verified against Obsidian
+1.12.7 and flagged for documentation.
+</content>

--- a/src/Modals/GenericPrompt/GenericPromptContent.svelte
+++ b/src/Modals/GenericPrompt/GenericPromptContent.svelte
@@ -55,7 +55,7 @@
             suggestions = hasExplicitSuggestions
                 ? initialSuggestValues
                 : context
-                    ? getValueSuggestions(context.app, context.key, context.type)
+                    ? getValueSuggestions(context.app, context.key, context.type, context.tagMode)
                     : [];
         }
 

--- a/src/Modals/GenericPrompt/promptValueContext.ts
+++ b/src/Modals/GenericPrompt/promptValueContext.ts
@@ -1,10 +1,14 @@
 import type {App} from "obsidian";
 import type {MetaType} from "../../Types/metaType";
+import type {TagEditMode} from "../../tagEditing";
 
 export interface PromptValueContext {
     app: App;
     key: string;
     type: MetaType;
+    // For a body-tag edit: which suggestions to source - full tag names for a
+    // rename, leaf segments for a last-segment edit.
+    tagMode?: TagEditMode;
 }
 
 let pending: PromptValueContext | null = null;

--- a/src/Modals/GenericPrompt/valueSuggest.test.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.test.ts
@@ -93,18 +93,39 @@ describe("getValueSuggestions - frontmatter values", () => {
 });
 
 describe("getValueSuggestions - tags", () => {
-    it("suggests leaf segments (not full paths) ranked by count", () => {
-        const app = makeApp({
-            tags: {
-                "#topic/science": 2,
-                "#topic/history": 1,
-                "#topic": 5,
-                "#status/active": 3,
-            },
-        });
+    const sample = {
+        tags: {
+            "#topic/science": 2,
+            "#topic/history": 1,
+            "#topic": 5,
+            "#status/active": 3,
+        },
+    };
 
-        // leaves: science(2), history(1), topic(5), active(3) -> by count desc
+    it("rename (default) suggests full tag paths (no #) ranked by count", () => {
+        const app = makeApp(sample);
+
+        // full names by count desc: topic(5), status/active(3), topic/science(2), topic/history(1)
         expect(getValueSuggestions(app, "#topic/science", MetaType.Tag)).toEqual([
+            "topic",
+            "status/active",
+            "topic/science",
+            "topic/history",
+        ]);
+        // Explicit rename mode behaves the same as the default.
+        expect(getValueSuggestions(app, "#topic/science", MetaType.Tag, "rename")).toEqual([
+            "topic",
+            "status/active",
+            "topic/science",
+            "topic/history",
+        ]);
+    });
+
+    it("leaf mode suggests leaf segments ranked by count", () => {
+        const app = makeApp(sample);
+
+        // leaves: topic(5), active(3), science(2), history(1) -> by count desc
+        expect(getValueSuggestions(app, "#topic/science", MetaType.Tag, "leaf")).toEqual([
             "topic",
             "active",
             "science",
@@ -112,7 +133,7 @@ describe("getValueSuggestions - tags", () => {
         ]);
     });
 
-    it("merges identical leaf segments under different parents", () => {
+    it("leaf mode merges identical leaf segments under different parents", () => {
         const app = makeApp({
             tags: {
                 "#a/draft": 1,
@@ -121,7 +142,7 @@ describe("getValueSuggestions - tags", () => {
             },
         });
 
-        expect(getValueSuggestions(app, "#a/draft", MetaType.Tag)).toEqual(["draft"]);
+        expect(getValueSuggestions(app, "#a/draft", MetaType.Tag, "leaf")).toEqual(["draft"]);
     });
 });
 

--- a/src/Modals/GenericPrompt/valueSuggest.ts
+++ b/src/Modals/GenericPrompt/valueSuggest.ts
@@ -1,5 +1,6 @@
 import type {App} from "obsidian";
 import {MetaType} from "../../Types/metaType";
+import type {TagEditMode} from "../../tagEditing";
 
 export type DateInputType = "date" | "datetime";
 
@@ -22,24 +23,25 @@ const MAX_RENDERED_SUGGESTIONS = 100;
  * Distinct values already used for a property across the vault, ranked so the
  * most frequently used values surface first.
  *
- * Tags resolve to their leaf segment (the part after the last `/`) because
- * MetaEdit rewrites a tag by replacing only that last segment - suggesting a
- * full `topic/science` path while editing `#topic/science` would write
- * `#topic/topic/science`. Leaf segments are the only values that round-trip
- * safely through the tag writer.
+ * Tags depend on the edit mode (see TagEditMode): a `rename` replaces the whole
+ * tag, so full tag names (without `#`) are suggested; a `leaf` edit replaces only
+ * the last `/`-segment, so leaf segments are suggested. Both round-trip safely
+ * through the span-based tag writer.
  *
  * Inline Dataview (`key:: value`) fields are not in the metadata cache, so
  * sourcing their values would mean a full-text scan that duplicates the parser;
  * that is a deliberate follow-up, so Dataview keys return nothing for now.
  */
-export function getValueSuggestions(app: App, key: string, type: MetaType): string[] {
+export function getValueSuggestions(app: App, key: string, type: MetaType, tagMode?: TagEditMode): string[] {
     if (!key) return [];
 
     // These read untyped runtime APIs (getTags, metadataCache); never let a
     // sourcing failure break the prompt - degrade to no suggestions.
     try {
         if (type === MetaType.Tag) {
-            return rankByCount(collectTagLeafCounts(app));
+            return tagMode === "leaf"
+                ? rankByCount(collectTagLeafCounts(app))
+                : rankByCount(collectTagFullCounts(app));
         }
 
         if (type === MetaType.YAML) {
@@ -128,17 +130,32 @@ export function filterSuggestions(items: string[], inputStr: string): string[] {
 
 function collectTagLeafCounts(app: App): Map<string, number> {
     const counts = new Map<string, number>();
-    // getTags() is present at runtime but missing from the pinned obsidian typings.
-    const metadataCache = app.metadataCache as unknown as {getTags?: () => Record<string, number>};
-    const tags: Record<string, number> = metadataCache.getTags?.() ?? {};
 
-    for (const [tag, count] of Object.entries(tags)) {
+    for (const [tag, count] of Object.entries(readVaultTags(app))) {
         const leaf = tag.replace(/^#/, "").split("/").pop()?.trim();
         if (!leaf) continue;
         counts.set(leaf, (counts.get(leaf) ?? 0) + (count ?? 1));
     }
 
     return counts;
+}
+
+function collectTagFullCounts(app: App): Map<string, number> {
+    const counts = new Map<string, number>();
+
+    for (const [tag, count] of Object.entries(readVaultTags(app))) {
+        const full = tag.replace(/^#/, "").trim();
+        if (!full) continue;
+        counts.set(full, (counts.get(full) ?? 0) + (count ?? 1));
+    }
+
+    return counts;
+}
+
+function readVaultTags(app: App): Record<string, number> {
+    // getTags() is present at runtime but missing from the pinned obsidian typings.
+    const metadataCache = app.metadataCache as unknown as {getTags?: () => Record<string, number>};
+    return metadataCache.getTags?.() ?? {};
 }
 
 function collectFrontmatterValueCounts(app: App, key: string): Map<string, number> {

--- a/src/Modals/GenericSuggester/GenericSuggester.ts
+++ b/src/Modals/GenericSuggester/GenericSuggester.ts
@@ -3,6 +3,7 @@ import {type App, FuzzySuggestModal} from "obsidian";
 export default class GenericSuggester extends FuzzySuggestModal<string>{
     private resolvePromise: (value: string) => void;
     private promise: Promise<string>;
+    private didChoose = false;
 
     public static Suggest(app: App, displayItems: string[], items: string[]) {
         const newSuggester = new GenericSuggester(app, displayItems, items);
@@ -28,7 +29,21 @@ export default class GenericSuggester extends FuzzySuggestModal<string>{
     }
 
     onChooseItem(item: string, _evt: MouseEvent | KeyboardEvent): void {
+        this.didChoose = true;
         this.resolvePromise(item);
     }
-    
+
+    onClose(): void {
+        super.onClose();
+        // Escape / click-away without choosing resolves to "" so callers can treat
+        // it as a cancel instead of leaving the promise (and the caller's finally
+        // cleanup) pending forever. Deferred to a microtask because Obsidian may
+        // fire onClose BEFORE onChooseItem when an item is selected; deferring lets
+        // a real selection settle the promise first, so this only fires on a true
+        // cancel.
+        queueMicrotask(() => {
+            if (!this.didChoose) this.resolvePromise("");
+        });
+    }
+
 }

--- a/src/Modals/menuFilter.test.ts
+++ b/src/Modals/menuFilter.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest";
-import {filterMenuItems} from "./menuFilter";
+import {canStructureEditProperty, filterMenuItems} from "./menuFilter";
 import {MetaType} from "../Types/metaType";
 import type {Property} from "../parser";
 
@@ -101,5 +101,22 @@ describe("filterMenuItems", () => {
         // The suggester always prepends its action options, so a fully-filtered
         // data list still yields a non-empty menu.
         expect(result).toEqual([]);
+    });
+});
+
+describe("canStructureEditProperty", () => {
+    it("never offers structure edits (delete/transform) on a body tag (BUG-5)", () => {
+        expect(canStructureEditProperty(tag("#project"))).toBe(false);
+        expect(canStructureEditProperty(tag("#area/work"))).toBe(false);
+    });
+
+    it("offers structure edits on plain YAML and Dataview properties", () => {
+        expect(canStructureEditProperty(yaml("status"))).toBe(true);
+        expect(canStructureEditProperty(dataview("rating"))).toBe(true);
+    });
+
+    it("withholds structure edits on nested/virtual YAML rows", () => {
+        expect(canStructureEditProperty({key: "a.b", content: "v", type: MetaType.YAML, isNested: true})).toBe(false);
+        expect(canStructureEditProperty({key: "a.b", content: "v", type: MetaType.YAML, isVirtual: true})).toBe(false);
     });
 });

--- a/src/Modals/menuFilter.ts
+++ b/src/Modals/menuFilter.ts
@@ -37,3 +37,16 @@ export function filterMenuItems(data: Property[], opts: MenuFilterOptions): Prop
         return true;
     });
 }
+
+/**
+ * Whether the picker should offer the structure actions (delete / transform) on
+ * a property.
+ *
+ * Body tags are excluded: they have no `key:` line, so the key-based delete and
+ * transform actions silently no-op or mangle a tag. Nested/virtual YAML rows are
+ * excluded because they cannot be safely deleted as a unit yet.
+ */
+export function canStructureEditProperty(property: Pick<Property, "type" | "isNested" | "isVirtual">): boolean {
+    if (property.type === MetaType.Tag) return false;
+    return !property.isNested && !property.isVirtual;
+}

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -57,10 +57,17 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
 
     getItemText(item: Property): string {
         // Disambiguate repeated body tags so the user can tell which occurrence
-        // they are about to edit (each row rewrites its own exact span).
-        if (item.type === MetaType.Tag && item.position?.line !== undefined &&
-            this.data.filter(d => d.type === MetaType.Tag && d.key === item.key).length > 1) {
-            return `${item.key} (line ${item.position.line + 1})`;
+        // they are about to edit (each row rewrites its own exact span). Show the
+        // line and an occurrence ordinal, so even two #dup on the same line differ.
+        if (item.type === MetaType.Tag && item.position) {
+            const sameKey = this.data
+                .filter(d => d.type === MetaType.Tag && d.key === item.key && d.position)
+                .sort((a, b) => a.position!.start - b.position!.start);
+            if (sameKey.length > 1) {
+                const ordinal = sameKey.findIndex(d => d.position!.start === item.position!.start) + 1;
+                const line = item.position.line !== undefined ? `line ${item.position.line + 1}, ` : "";
+                return `${item.key} (${line}${ordinal}/${sameKey.length})`;
+            }
         }
         return item.key;
     }

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -37,7 +37,8 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
 
         this.setInstructions([
             {command: "❌", purpose: "Delete property"},
-            {command: "🔃", purpose: "Transform to YAML/Dataview"}
+            {command: "🔃", purpose: "Transform to YAML/Dataview"},
+            {command: "#tag", purpose: "Select to rename here · vault-wide rename: Obsidian Tag pane"},
         ])
     }
 

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -137,6 +137,11 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     }
 
     private static canStructureEdit(property: Property): boolean {
+        // Body tags have no `key:` line, so the property delete/transform actions
+        // (which match `key:`) silently no-op or mangle them. Until there is a
+        // real position-based tag delete, do not offer structure edits on tags -
+        // rename/remove a tag in the editor or via Obsidian's native tag tools.
+        if (property.type === MetaType.Tag) return false;
         return !property.isNested && !property.isVirtual;
     }
 

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -56,6 +56,12 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     }
 
     getItemText(item: Property): string {
+        // Disambiguate repeated body tags so the user can tell which occurrence
+        // they are about to edit (each row rewrites its own exact span).
+        if (item.type === MetaType.Tag && item.position?.line !== undefined &&
+            this.data.filter(d => d.type === MetaType.Tag && d.key === item.key).length > 1) {
+            return `${item.key} (line ${item.position.line + 1})`;
+        }
         return item.key;
     }
 

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -7,7 +7,7 @@ import {MetaType} from "../Types/metaType";
 import type {AutoProperty} from "../Types/autoProperty";
 import {getKnownPropertyNames} from "./GenericPrompt/valueSuggest";
 import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
-import {filterMenuItems} from "./menuFilter";
+import {canStructureEditProperty, filterMenuItems} from "./menuFilter";
 import {isYamlParentContainerValue} from "../yamlPath";
 
 export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
@@ -137,12 +137,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     }
 
     private static canStructureEdit(property: Property): boolean {
-        // Body tags have no `key:` line, so the property delete/transform actions
-        // (which match `key:`) silently no-op or mangle them. Until there is a
-        // real position-based tag delete, do not offer structure edits on tags -
-        // rename/remove a tag in the editor or via Obsidian's native tag tools.
-        if (property.type === MetaType.Tag) return false;
-        return !property.isNested && !property.isVirtual;
+        return canStructureEditProperty(property);
     }
 
     private static isYamlParentContainer(property: Property): boolean {

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -14,7 +14,7 @@ import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
 import {getYamlPath, isYamlParentContainerValue, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
-import {computeTagRewrite, isNestedTag, isTagsKey, isValidTagToken, normalizeTagToken, splitFrontmatterTags, spliceTag, stripHash, tagLeaf, canonicalizeFrontmatterTag, type TagEditMode} from "./tagEditing";
+import {computeTagRewrite, isNestedTag, isTagsKey, isValidTagToken, normalizeTagToken, splitFrontmatterTags, spliceTag, stripHash, tagLeaf, tagParent, canonicalizeFrontmatterTag, type TagEditMode} from "./tagEditing";
 import {setPendingValueContext} from "./Modals/GenericPrompt/promptValueContext";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
@@ -169,9 +169,10 @@ export default class MetaController {
 
         let input: string | null;
         // Preserve the Auto Property hook for the leaf of a nested tag (the only
-        // case it ever matched): an Auto Property named after the parent path
-        // supplies the new leaf value.
-        const parentPath = stripHash(tag).split("/").slice(0, -1).join("/");
+        // case it ever matched): an Auto Property named after the parent path -
+        // WITH the leading `#`, matching the historical key (`#area` for `#area/x`)
+        // - supplies the new leaf value.
+        const parentPath = tagParent(tag);
         if (mode === "leaf" && this.getActiveAutoProperty(parentPath)) {
             const autoProp = await this.handleAutoProperties(parentPath);
             if (autoProp === null) return; // cancelled

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -14,6 +14,8 @@ import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
 import {getYamlPath, isYamlParentContainerValue, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
+import {computeTagRewrite, isNestedTag, spliceTag, stripHash, tagLeaf, type TagEditMode} from "./tagEditing";
+import {setPendingValueContext} from "./Modals/GenericPrompt/promptValueContext";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
 const ADD_FIRST_SELECTION = "metaedit:multi-value:add-first";
@@ -26,7 +28,6 @@ export default class MetaController {
     private readonly app: App;
     private plugin: MetaEdit;
     private readonly hasTrackerPlugin: boolean = false;
-    private useTrackerPlugin: boolean = false;
 
     constructor(app: App, plugin: MetaEdit) {
         this.app = app;
@@ -121,35 +122,58 @@ export default class MetaController {
             await this.standardMode(property, file);
     }
 
+    /**
+     * Edit a single body `#tag` occurrence.
+     *
+     * Decision D: the primary action RENAMES the whole tag (a flat tag is renamed,
+     * not turned into a child); "Edit last segment" is offered only for nested
+     * tags; Tracker's `#tag:value` data syntax is offered only when the Tracker
+     * plugin is present. The chosen action is derived here per edit and baked into
+     * the replacement token, so nothing about Tracker survives on the controller
+     * (BUG-1). The exact occurrence is rewritten by position (BUG-2/BUG-3).
+     */
     private async editTag(property: Property, file: TFile) {
-        const splitTag: string[] = property.key.split("/");
-        const allButLast: string = splitTag.slice(0, splitTag.length - 1).join("/");
-        const trackerPluginMethod = "Use Tracker", metaEditMethod = "Use MetaEdit", choices = [trackerPluginMethod, metaEditMethod];
-        let newValue: string | string[];
-        let method: string = metaEditMethod;
+        const tag = property.key;
+        const nested = isNestedTag(tag);
 
-        if (this.hasTrackerPlugin)
-            method = await GenericSuggester.Suggest(this.app, choices, choices);
+        const RENAME = "Rename tag", LEAF = "Edit last segment", TRACKER = "Tracker value (#tag:value)";
+        const actions: string[] = [RENAME];
+        if (nested) actions.push(LEAF);
+        if (this.hasTrackerPlugin) actions.push(TRACKER);
 
-        if (!method) return;
-
-        if (method === trackerPluginMethod) {
-            newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`)
-            this.useTrackerPlugin = true;
-        } else if (method === metaEditMethod) {
-            if (this.getActiveAutoProperty(allButLast)) {
-                const autoProp = await this.handleAutoProperties(allButLast);
-                if (autoProp === null) return; // user cancelled the auto property prompt
-                // A tag is a single token; collapse a multi result into one string.
-                newValue = Array.isArray(autoProp) ? autoProp.join(", ") : autoProp;
-            } else {
-                newValue = await GenericPrompt.Prompt(this.app, `Enter a new value for ${property.key}`);
-            }
+        let action = RENAME;
+        if (actions.length > 1) {
+            action = await GenericSuggester.Suggest(this.app, actions, actions);
+            if (!action) return; // cancelled
         }
 
-        if (newValue) {
-            await this.updatePropertyFromUi(property, newValue, file);
+        const mode: TagEditMode = action === TRACKER ? "tracker" : action === LEAF ? "leaf" : "rename";
+
+        let input: string | null;
+        // Preserve the Auto Property hook for the leaf of a nested tag (the only
+        // case it ever matched): an Auto Property named after the parent path
+        // supplies the new leaf value.
+        const parentPath = stripHash(tag).split("/").slice(0, -1).join("/");
+        if (mode === "leaf" && this.getActiveAutoProperty(parentPath)) {
+            const autoProp = await this.handleAutoProperties(parentPath);
+            if (autoProp === null) return; // cancelled
+            input = Array.isArray(autoProp) ? autoProp.join(", ") : autoProp;
+        } else if (mode === "tracker") {
+            input = await GenericPrompt.Prompt(this.app, `Enter a Tracker value for ${tag}`);
+        } else {
+            // Source mode-appropriate suggestions through the prompt bridge: full
+            // tag names for a rename, leaf segments for a last-segment edit.
+            setPendingValueContext({app: this.app, key: tag, type: MetaType.Tag, tagMode: mode});
+            const header = mode === "leaf" ? `Change the last segment of ${tag} to` : `Rename ${tag} to`;
+            const seed = mode === "leaf" ? tagLeaf(tag) : stripHash(tag);
+            input = await GenericPrompt.Prompt(this.app, header, seed, seed);
         }
+
+        if (input === null) return; // cancelled
+        const newToken = computeTagRewrite(tag, input, mode);
+        if (!newToken || newToken === tag) return; // nothing to change
+
+        await this.updatePropertyFromUi(property, newToken, file);
     }
 
     public async handleProgressProps(meta: Property[], file: TFile): Promise<void> {
@@ -200,7 +224,9 @@ export default class MetaController {
 
         const fileContent = await this.app.vault.read(file);
         const splitContent = fileContent.split("\n");
-        const regexp = new RegExp(`^\s*${property.key}:`);
+        // Escape the key (so a key like `c++` is not read as regex) and use a real
+        // `\s` so an indented property line still matches its own line, not another.
+        const regexp = new RegExp(`^\\s*${this.escapeSpecialCharacters(property.key)}\\s*:`);
 
         const idx = splitContent.findIndex(s => s.match(regexp));
         const newFileContent = splitContent.filter((v, i) => {
@@ -385,6 +411,11 @@ export default class MetaController {
                 return;
             }
 
+            if (property.type === MetaType.Tag) {
+                await this.writeTagOccurrence(property, newValue, file);
+                return;
+            }
+
             const fileContent = await this.app.vault.read(file);
 
             const newFileContent = fileContent.split("\n").map(line => {
@@ -399,6 +430,26 @@ export default class MetaController {
         });
     }
 
+    /**
+     * Rewrite one body-tag occurrence in place, by its parsed span. The span is
+     * re-validated against current file content first, so an edit that raced a
+     * change to the note refuses to write (with a Notice) rather than corrupt
+     * unrelated text. `newValue` is the full replacement token computed by the UI.
+     */
+    private async writeTagOccurrence(property: Partial<Property>, newValue: unknown, file: TFile): Promise<void> {
+        const newToken = String(newValue);
+        const content = await this.app.vault.read(file);
+        const updated = spliceTag(content, property.position, property.key ?? "", newToken);
+
+        if (updated === null) {
+            throw new Error(
+                `could not locate the tag '${property.key}' to edit - the note may have changed since it was opened. Reopen and try again.`,
+            );
+        }
+
+        await this.app.vault.modify(file, updated);
+    }
+
     private escapeSpecialCharacters(text: string): string{
         return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
     }
@@ -406,7 +457,7 @@ export default class MetaController {
     private lineMatch(property: Partial<Property>, line: string): boolean {
         if (!property.key) return false;
 
-        const tagRegex = new RegExp(`^\s*${this.escapeSpecialCharacters(property.key)}`);
+        const tagRegex = new RegExp(`^\\s*${this.escapeSpecialCharacters(property.key)}`);
 
         if (property.key.contains('#')) {
             return tagRegex.test(line);
@@ -431,22 +482,10 @@ export default class MetaController {
             case MetaType.YAML:
                 newLine = `${property.key}: ${newValue}`;
                 break;
-            case MetaType.Tag:
-                if (this.useTrackerPlugin) {
-                    newLine = `${property.key}:${newValue}`;
-                } else {
-                    const splitTag: string[] = property.key.split("/");
-                    if (splitTag.length === 1)
-                        newLine = `${splitTag[0]}/${newValue}`;
-                    else if (splitTag.length > 1) {
-                        const allButLast: string = splitTag.slice(0, splitTag.length - 1).join("/");
-                        newLine = `${allButLast}/${newValue}`;
-                    } else
-                        newLine = property.key;
-                }
-                break;
+            // Body tags are rewritten by span in writeTagOccurrence, never here.
             default:
-                newLine = property.key;
+                // Never collapse a matched line to just the key - leave it untouched.
+                newLine = line;
                 break;
         }
 
@@ -457,7 +496,8 @@ export default class MetaController {
         await this.enqueueFileWrite(file, async () => {
             const yamlProperties = properties.filter(prop => prop.type === MetaType.YAML && !prop.path);
             const yamlPathProperties = properties.filter(prop => prop.type === MetaType.YAML && prop.path);
-            const textProperties = properties.filter(prop => prop.type !== MetaType.YAML);
+            const tagProperties = properties.filter(prop => prop.type === MetaType.Tag);
+            const textProperties = properties.filter(prop => prop.type !== MetaType.YAML && prop.type !== MetaType.Tag);
 
             if (yamlProperties.length > 0 || yamlPathProperties.length > 0) {
                 await this.processFrontMatter(file, (frontmatter) => {
@@ -470,23 +510,31 @@ export default class MetaController {
                 });
             }
 
-            if (textProperties.length === 0) return;
+            if (tagProperties.length === 0 && textProperties.length === 0) return;
 
-            let fileContent = (await this.app.vault.read(file)).split("\n");
+            let content = await this.app.vault.read(file);
 
-            for (const prop of textProperties) {
-                fileContent = fileContent.map(line => {
-
-                    if (this.lineMatch(prop, line)) {
-                        return this.updatePropertyLine(prop, prop.content, line)
-                    }
-
-                    return line;
-                });
+            // Splice tag occurrences highest-offset-first so earlier spans stay
+            // valid as later ones change length. A stale span is skipped, not
+            // forced, so a batch never corrupts unrelated prose.
+            for (const prop of [...tagProperties].sort((a, b) => (b.position?.start ?? 0) - (a.position?.start ?? 0))) {
+                const updated = spliceTag(content, prop.position, prop.key, String(prop.content));
+                if (updated === null) {
+                    log.logMessage(`MetaEdit skipped tag '${prop.key}': its position no longer matches the note.`);
+                    continue;
+                }
+                content = updated;
             }
-            const newFileContent = fileContent.join("\n");
 
-            await this.app.vault.modify(file, newFileContent);
+            if (textProperties.length > 0) {
+                let lines = content.split("\n");
+                for (const prop of textProperties) {
+                    lines = lines.map(line => this.lineMatch(prop, line) ? this.updatePropertyLine(prop, prop.content, line) : line);
+                }
+                content = lines.join("\n");
+            }
+
+            await this.app.vault.modify(file, content);
         });
     }
 

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -14,7 +14,7 @@ import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
 import {getYamlPath, isYamlParentContainerValue, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
-import {computeTagRewrite, isNestedTag, spliceTag, stripHash, tagLeaf, type TagEditMode} from "./tagEditing";
+import {computeTagRewrite, isNestedTag, isTagsKey, splitFrontmatterTags, spliceTag, stripHash, tagLeaf, canonicalizeFrontmatterTag, type TagEditMode} from "./tagEditing";
 import {setPendingValueContext} from "./Modals/GenericPrompt/promptValueContext";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
@@ -47,6 +47,12 @@ export default class MetaController {
 
     public async addYamlProp(propName: string, propValue: unknown, file: TFile): Promise<void> {
         const settings = this.plugin.settings;
+
+        // A new `tags`/`tag` property is stored as a canonical, `#`-free list.
+        if (isTagsKey(propName)) {
+            propValue = splitFrontmatterTags(propValue);
+        }
+
         const activeAutoProperty = this.getActiveAutoProperty(propName);
         const autoPropertyKeepsScalar = !!activeAutoProperty &&
             !isMultiAutoProperty(activeAutoProperty, settings.EditMode, propName);
@@ -274,10 +280,16 @@ export default class MetaController {
         // and spelling (commas and `[[wikilinks]]` included). An inline field (or
         // a YAML value stored as a comma string) has no real array, so it is
         // split on commas and re-joined.
-        const editsArray = isMultiValueYamlProperty(property);
-        const writeBase: unknown[] = editsArray
-            ? (property.content as unknown[])
-            : this.splitMultiValue(property);
+        // Frontmatter `tags` is always edited as a canonical list: any stored
+        // shape (list, scalar, comma/space string) is read with the `#` stripped,
+        // and it is written back as a YAML list (Obsidian's canonical form).
+        const tagsKey = property.type === MetaType.YAML && isTagsKey(property.key);
+        const editsArray = tagsKey || isMultiValueYamlProperty(property);
+        const writeBase: unknown[] = tagsKey
+            ? splitFrontmatterTags(property.content)
+            : editsArray
+                ? (property.content as unknown[])
+                : this.splitMultiValue(property);
         // The selectable view is always strings, kept 1:1 with `writeBase` so a
         // selection maps back to the correct element.
         const displayValues: string[] = editsArray
@@ -322,6 +334,10 @@ export default class MetaController {
         }
 
         if (!tempValue) return false;
+
+        // A tag entered with a leading `#` (`#area/x`) is stored without it.
+        if (tagsKey) tempValue = canonicalizeFrontmatterTag(tempValue);
+        if (tagsKey && tempValue === "") return false;
 
         const edit: MultiValueEdit =
             selectedOption === ADD_FIRST_SELECTION ? {kind: "addFirst", value: tempValue} :
@@ -404,8 +420,15 @@ export default class MetaController {
                             expectedValue: property.content,
                             validateExpectedValue: true,
                         });
+                    } else if (isTagsKey(property.key)) {
+                        // Canonicalise `tags`: strip `#`, drop blanks, store a list.
+                        // When the last tag is gone, remove the key (Decision E)
+                        // rather than leave a dangling `tags:` / `tags: []`.
+                        const tags = splitFrontmatterTags(newValue);
+                        if (tags.length === 0) delete frontmatter[property.key!];
+                        else frontmatter[property.key!] = tags;
                     } else {
-                        frontmatter[property.key] = newValue;
+                        frontmatter[property.key!] = newValue;
                     }
                 });
                 return;

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -14,7 +14,7 @@ import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
 import {getYamlPath, isYamlParentContainerValue, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
-import {computeTagRewrite, isNestedTag, isTagsKey, splitFrontmatterTags, spliceTag, stripHash, tagLeaf, canonicalizeFrontmatterTag, type TagEditMode} from "./tagEditing";
+import {computeTagRewrite, isNestedTag, isTagsKey, isValidTagToken, normalizeTagToken, splitFrontmatterTags, spliceTag, stripHash, tagLeaf, canonicalizeFrontmatterTag, type TagEditMode} from "./tagEditing";
 import {setPendingValueContext} from "./Modals/GenericPrompt/promptValueContext";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
@@ -165,6 +165,9 @@ export default class MetaController {
             if (autoProp === null) return; // cancelled
             input = Array.isArray(autoProp) ? autoProp.join(", ") : autoProp;
         } else if (mode === "tracker") {
+            // A Tracker value is free-form data, not a tag name - clear the tag
+            // suggestion context the picker seeded so it does not autocomplete.
+            setPendingValueContext(null);
             input = await GenericPrompt.Prompt(this.app, `Enter a Tracker value for ${tag}`);
         } else {
             // Source mode-appropriate suggestions through the prompt bridge: full
@@ -178,6 +181,11 @@ export default class MetaController {
         if (input === null) return; // cancelled
         const newToken = computeTagRewrite(tag, input, mode);
         if (!newToken || newToken === tag) return; // nothing to change
+
+        if (!isValidTagToken(normalizeTagToken(newToken))) {
+            new Notice(`'${input.trim()}' is not a valid tag name. Tags cannot contain spaces or commas.`);
+            return;
+        }
 
         await this.updatePropertyFromUi(property, newToken, file);
     }
@@ -460,7 +468,15 @@ export default class MetaController {
      * unrelated text. `newValue` is the full replacement token computed by the UI.
      */
     private async writeTagOccurrence(property: Partial<Property>, newValue: unknown, file: TFile): Promise<void> {
-        const newToken = String(newValue);
+        // The UI passes a full token (`#new`, `#a/leaf`, `#tag:value`); a bare
+        // value from the API (`"done"`) is normalised to `#done`. Reject anything
+        // that is not a single valid tag rather than splice invalid text into the
+        // note (e.g. `#meeting notes`, which Obsidian would parse as `#meeting`).
+        const newToken = normalizeTagToken(String(newValue));
+        if (!isValidTagToken(newToken)) {
+            throw new Error(`'${String(newValue)}' is not a valid tag name.`);
+        }
+
         const content = await this.app.vault.read(file);
         const updated = spliceTag(content, property.position, property.key ?? "", newToken);
 
@@ -522,6 +538,30 @@ export default class MetaController {
             const tagProperties = properties.filter(prop => prop.type === MetaType.Tag);
             const textProperties = properties.filter(prop => prop.type !== MetaType.YAML && prop.type !== MetaType.Tag);
 
+            // Splice body tags FIRST, while their parsed offsets still match the
+            // file. A later processFrontMatter write only touches the frontmatter,
+            // so it preserves these body edits; doing it the other way round would
+            // shift every body offset and stale the tag spans. Highest-offset-first
+            // keeps earlier spans valid as later ones change length; a stale span
+            // is skipped, never forced, so a batch never corrupts prose.
+            if (tagProperties.length > 0) {
+                let content = await this.app.vault.read(file);
+                for (const prop of [...tagProperties].sort((a, b) => (b.position?.start ?? 0) - (a.position?.start ?? 0))) {
+                    const token = normalizeTagToken(String(prop.content));
+                    if (!isValidTagToken(token)) {
+                        log.logMessage(`MetaEdit skipped tag '${prop.key}': '${String(prop.content)}' is not a valid tag.`);
+                        continue;
+                    }
+                    const updated = spliceTag(content, prop.position, prop.key, token);
+                    if (updated === null) {
+                        log.logMessage(`MetaEdit skipped tag '${prop.key}': its position no longer matches the note.`);
+                        continue;
+                    }
+                    content = updated;
+                }
+                await this.app.vault.modify(file, content);
+            }
+
             if (yamlProperties.length > 0 || yamlPathProperties.length > 0) {
                 await this.processFrontMatter(file, (frontmatter) => {
                     for (const prop of yamlProperties) {
@@ -533,31 +573,13 @@ export default class MetaController {
                 });
             }
 
-            if (tagProperties.length === 0 && textProperties.length === 0) return;
-
-            let content = await this.app.vault.read(file);
-
-            // Splice tag occurrences highest-offset-first so earlier spans stay
-            // valid as later ones change length. A stale span is skipped, not
-            // forced, so a batch never corrupts unrelated prose.
-            for (const prop of [...tagProperties].sort((a, b) => (b.position?.start ?? 0) - (a.position?.start ?? 0))) {
-                const updated = spliceTag(content, prop.position, prop.key, String(prop.content));
-                if (updated === null) {
-                    log.logMessage(`MetaEdit skipped tag '${prop.key}': its position no longer matches the note.`);
-                    continue;
-                }
-                content = updated;
-            }
-
             if (textProperties.length > 0) {
-                let lines = content.split("\n");
+                let lines = (await this.app.vault.read(file)).split("\n");
                 for (const prop of textProperties) {
                     lines = lines.map(line => this.lineMatch(prop, line) ? this.updatePropertyLine(prop, prop.content, line) : line);
                 }
-                content = lines.join("\n");
+                await this.app.vault.modify(file, lines.join("\n"));
             }
-
-            await this.app.vault.modify(file, content);
         });
     }
 

--- a/src/multiValue.test.ts
+++ b/src/multiValue.test.ts
@@ -34,6 +34,14 @@ describe("shouldUseMultiValueEditor", () => {
         expect(shouldUseMultiValueEditor({key: "status", type: MetaType.YAML, content: "open"}, allSingle)).toBe(false);
     });
 
+    it("always routes frontmatter tags/tag to the list editor, even as a scalar/CSV", () => {
+        expect(shouldUseMultiValueEditor({key: "tags", type: MetaType.YAML, content: "alpha"}, allSingle)).toBe(true);
+        expect(shouldUseMultiValueEditor({key: "tag", type: MetaType.YAML, content: "a, b"}, allSingle)).toBe(true);
+        expect(shouldUseMultiValueEditor({key: "Tags", type: MetaType.YAML, content: "alpha"}, allSingle)).toBe(true);
+        // A body tag is not a YAML property, so this rule does not touch it.
+        expect(shouldUseMultiValueEditor({key: "#tags", type: MetaType.Tag, content: "#tags"}, allSingle)).toBe(false);
+    });
+
     it("honours AllMulti and SomeMulti for non-array values", () => {
         expect(shouldUseMultiValueEditor({key: "status", type: MetaType.Dataview, content: "a"}, allMulti)).toBe(true);
 

--- a/src/multiValue.ts
+++ b/src/multiValue.ts
@@ -1,5 +1,6 @@
 import {MetaType} from "./Types/metaType";
 import {EditMode} from "./Types/editMode";
+import {isTagsKey} from "./tagEditing";
 
 /**
  * Pure, Obsidian-free helpers for editing multi-value (list) properties. Kept
@@ -36,6 +37,9 @@ export function isMultiValueYamlProperty(property: PropertyLike): boolean {
  */
 export function shouldUseMultiValueEditor(property: PropertyLike, editMode: EditModeSettings): boolean {
     if (isMultiValueYamlProperty(property)) return true;
+    // Frontmatter `tags`/`tag` is inherently multi-value in Obsidian even when
+    // stored as a scalar or comma/space string, so always edit it as a list.
+    if (property.type === MetaType.YAML && isTagsKey(property.key)) return true;
     if (editMode.mode === EditMode.AllMulti) return true;
     if (editMode.mode === EditMode.SomeMulti && !!property.key && editMode.properties.includes(property.key)) {
         return true;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,6 +2,7 @@ import type {App, CachedMetadata, FrontMatterInfo, TFile} from "obsidian";
 import {getFrontMatterInfo, parseYaml} from "obsidian";
 import {MetaType} from "./Types/metaType";
 import {formatYamlPath, isPlainYamlObject, isYamlScalarLeaf, type YamlPath} from "./yamlPath";
+import type {TagPosition} from "./tagEditing";
 
 export type Property = {
 	key: string,
@@ -11,6 +12,9 @@ export type Property = {
 	rootKey?: string,
 	isNested?: boolean,
 	isVirtual?: boolean,
+	// For MetaType.Tag only: the exact span of this body-tag occurrence, so an
+	// edit rewrites that one token in place instead of guessing by key.
+	position?: TagPosition,
 };
 // `start`/`end` are the field's span in the line; `sepEnd` is the offset just
 // after `::`; `valueEnd` is where the value content ends (the closing bracket
@@ -52,9 +56,15 @@ export default class MetaEditParser {
         const tags = cache.tags;
         if (!tags) return [];
 
-        const mTags: Property[] = [];
-        tags.forEach(tag => mTags.push({key: tag.tag, content: tag.tag, type: MetaType.Tag}));
-        return mTags;
+        // Carry each occurrence's document-offset span so the write path can
+        // rewrite that exact token (incl. mid-line and duplicate tags) without
+        // touching the rest of the line.
+        return tags.map(tag => ({
+            key: tag.tag,
+            content: tag.tag,
+            type: MetaType.Tag,
+            position: {start: tag.position.start.offset, end: tag.position.end.offset},
+        }));
     }
 
     public async parseFrontmatter(file: TFile): Promise<Property[]> {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -63,7 +63,7 @@ export default class MetaEditParser {
             key: tag.tag,
             content: tag.tag,
             type: MetaType.Tag,
-            position: {start: tag.position.start.offset, end: tag.position.end.offset},
+            position: {start: tag.position.start.offset, end: tag.position.end.offset, line: tag.position.start.line},
         }));
     }
 

--- a/src/tagEditing.test.ts
+++ b/src/tagEditing.test.ts
@@ -114,6 +114,14 @@ describe("spliceTag", () => {
         expect(spliceTag(tracker, {start: 0, end: 7}, "#weight", "#mass"))
             .toBe("#mass:80 logged.");
     });
+
+    it("bounds the Tracker suffix so it never eats adjacent tags or markup", () => {
+        // The :value must stop at punctuation, not run to the next whitespace.
+        expect(spliceTag("#weight:80,#other", {start: 0, end: 7}, "#weight", "#weight:85"))
+            .toBe("#weight:85,#other");
+        expect(spliceTag("(#weight:80)", {start: 1, end: 8}, "#weight", "#weight:85"))
+            .toBe("(#weight:85)");
+    });
 });
 
 describe("tag token validation/normalization", () => {
@@ -135,12 +143,22 @@ describe("tag token validation/normalization", () => {
     it("accepts valid tag tokens and rejects ones Obsidian would split", () => {
         expect(isValidTagToken("#done")).toBe(true);
         expect(isValidTagToken("#a/b/c")).toBe(true);
+        expect(isValidTagToken("#in-progress")).toBe(true);
+        expect(isValidTagToken("#year_2024")).toBe(true);
+        expect(isValidTagToken("#café")).toBe(true); // unicode letters
         expect(isValidTagToken("#weight:85")).toBe(true); // Tracker
         expect(isValidTagToken("#meeting notes")).toBe(false); // space
         expect(isValidTagToken("#a,b")).toBe(false); // comma
         expect(isValidTagToken("#a#b")).toBe(false); // extra #
         expect(isValidTagToken("#")).toBe(false); // empty body
         expect(isValidTagToken("plain")).toBe(false); // no #
+    });
+
+    it("rejects tokens Obsidian does not index as a single tag", () => {
+        expect(isValidTagToken("#v1.2")).toBe(false); // dot ends the tag
+        expect(isValidTagToken("#done!")).toBe(false); // punctuation
+        expect(isValidTagToken("#2024")).toBe(false); // purely numeric -> text
+        expect(isValidTagToken("#12/34")).toBe(false); // numeric segments only
     });
 });
 
@@ -171,5 +189,15 @@ describe("frontmatter tag helpers", () => {
         expect(splitFrontmatterTags(null)).toEqual([]);
         expect(splitFrontmatterTags(undefined)).toEqual([]);
         expect(splitFrontmatterTags(["", "  ", "ok"])).toEqual(["ok"]);
+    });
+
+    it("splits each list element and skips non-primitive garbage", () => {
+        // A stray multi-word list item becomes two tags, not one invalid tag.
+        expect(splitFrontmatterTags(["alpha beta", "gamma"])).toEqual(["alpha", "beta", "gamma"]);
+        // Objects / nested arrays are skipped instead of stringified to garbage.
+        expect(splitFrontmatterTags([{x: 1}, "ok"])).toEqual(["ok"]);
+        expect(splitFrontmatterTags({x: 1})).toEqual([]);
+        // Numbers/booleans stringify to a single token.
+        expect(splitFrontmatterTags([1, true, "ok"])).toEqual(["1", "true", "ok"]);
     });
 });

--- a/src/tagEditing.test.ts
+++ b/src/tagEditing.test.ts
@@ -4,6 +4,9 @@ import {
     computeTagRewrite,
     isNestedTag,
     isTagsKey,
+    isTrackerToken,
+    isValidTagToken,
+    normalizeTagToken,
     splitFrontmatterTags,
     spliceTag,
     stripHash,
@@ -96,6 +99,48 @@ describe("spliceTag", () => {
         expect(spliceTag(content, {start: -1, end: 3}, "#epsilon", "#x")).toBeNull();
         expect(spliceTag(content, {start: 5, end: content.length + 10}, "#epsilon", "#x")).toBeNull();
         expect(spliceTag(content, {start: 5, end: 5}, "#epsilon", "#x")).toBeNull();
+    });
+
+    it("replaces an existing Tracker :value suffix instead of stacking it", () => {
+        const tracker = "#weight:80 logged today.";
+        // Obsidian's tag span covers only "#weight"; a Tracker re-edit must consume ":80".
+        expect(spliceTag(tracker, {start: 0, end: 7}, "#weight", "#weight:85"))
+            .toBe("#weight:85 logged today.");
+    });
+
+    it("does not consume a following :value when the new token is a plain tag", () => {
+        const tracker = "#weight:80 logged.";
+        // A plain rename keeps the existing Tracker value (renames the series).
+        expect(spliceTag(tracker, {start: 0, end: 7}, "#weight", "#mass"))
+            .toBe("#mass:80 logged.");
+    });
+});
+
+describe("tag token validation/normalization", () => {
+    it("detects Tracker tokens", () => {
+        expect(isTrackerToken("#weight:85")).toBe(true);
+        expect(isTrackerToken("#a/b:1")).toBe(true);
+        expect(isTrackerToken("#plain")).toBe(false);
+        expect(isTrackerToken("#has space:1")).toBe(false);
+    });
+
+    it("normalizes a bare value to a single-# token", () => {
+        expect(normalizeTagToken("done")).toBe("#done");
+        expect(normalizeTagToken("#done")).toBe("#done");
+        expect(normalizeTagToken("##done")).toBe("#done");
+        expect(normalizeTagToken("  done  ")).toBe("#done");
+        expect(normalizeTagToken("")).toBe("");
+    });
+
+    it("accepts valid tag tokens and rejects ones Obsidian would split", () => {
+        expect(isValidTagToken("#done")).toBe(true);
+        expect(isValidTagToken("#a/b/c")).toBe(true);
+        expect(isValidTagToken("#weight:85")).toBe(true); // Tracker
+        expect(isValidTagToken("#meeting notes")).toBe(false); // space
+        expect(isValidTagToken("#a,b")).toBe(false); // comma
+        expect(isValidTagToken("#a#b")).toBe(false); // extra #
+        expect(isValidTagToken("#")).toBe(false); // empty body
+        expect(isValidTagToken("plain")).toBe(false); // no #
     });
 });
 

--- a/src/tagEditing.test.ts
+++ b/src/tagEditing.test.ts
@@ -1,0 +1,130 @@
+import {describe, expect, it} from "vitest";
+import {
+    canonicalizeFrontmatterTag,
+    computeTagRewrite,
+    isNestedTag,
+    isTagsKey,
+    splitFrontmatterTags,
+    spliceTag,
+    stripHash,
+    tagLeaf,
+    tagParent,
+} from "./tagEditing";
+
+describe("tag token helpers", () => {
+    it("strips one or more leading hashes", () => {
+        expect(stripHash("#a")).toBe("a");
+        expect(stripHash("##a")).toBe("a");
+        expect(stripHash("a")).toBe("a");
+        expect(stripHash("#a/b")).toBe("a/b");
+    });
+
+    it("detects nested tags", () => {
+        expect(isNestedTag("#a")).toBe(false);
+        expect(isNestedTag("#a/b")).toBe(true);
+        expect(isNestedTag("a/b/c")).toBe(true);
+    });
+
+    it("extracts leaf and parent", () => {
+        expect(tagLeaf("#a/b/c")).toBe("c");
+        expect(tagLeaf("#flat")).toBe("flat");
+        expect(tagParent("#a/b/c")).toBe("#a/b");
+        expect(tagParent("#a/b")).toBe("#a");
+    });
+});
+
+describe("computeTagRewrite", () => {
+    it("rename: the typed value becomes the whole tag (flat tag is NOT nested)", () => {
+        expect(computeTagRewrite("#epsilon", "renamed", "rename")).toBe("#renamed");
+        // The pre-fix bug turned #epsilon into #epsilon/renamed; rename must not.
+        expect(computeTagRewrite("#epsilon", "renamed", "rename")).not.toBe("#epsilon/renamed");
+    });
+
+    it("rename: strips a leading # the user may type, and honours nested input", () => {
+        expect(computeTagRewrite("#old", "#new", "rename")).toBe("#new");
+        expect(computeTagRewrite("#old", "area/new", "rename")).toBe("#area/new");
+    });
+
+    it("leaf: replaces only the last segment of a nested tag", () => {
+        expect(computeTagRewrite("#a/b", "c", "leaf")).toBe("#a/c");
+        expect(computeTagRewrite("#a/b/c", "x", "leaf")).toBe("#a/b/x");
+        expect(computeTagRewrite("#a/b", "#c", "leaf")).toBe("#a/c");
+    });
+
+    it("tracker: writes #tag:value", () => {
+        expect(computeTagRewrite("#epsilon", "5", "tracker")).toBe("#epsilon:5");
+        expect(computeTagRewrite("#weight", "70.5", "tracker")).toBe("#weight:70.5");
+    });
+
+    it("returns empty string for a blank edit so callers can cancel", () => {
+        expect(computeTagRewrite("#a", "   ", "rename")).toBe("");
+        expect(computeTagRewrite("#a/b", "  ", "leaf")).toBe("");
+        expect(computeTagRewrite("#a", "", "tracker")).toBe("");
+    });
+});
+
+describe("spliceTag", () => {
+    const content = "#epsilon at line start with trailing prose.\nMid-line tag #zeta here.\n";
+    const epsilon = {start: 0, end: "#epsilon".length};
+
+    it("rewrites only the tag span, preserving surrounding prose (BUG-2)", () => {
+        expect(spliceTag(content, epsilon, "#epsilon", "#renamed"))
+            .toBe("#renamed at line start with trailing prose.\nMid-line tag #zeta here.\n");
+    });
+
+    it("rewrites a mid-line occurrence in place (BUG-3)", () => {
+        const start = content.indexOf("#zeta");
+        const pos = {start, end: start + "#zeta".length};
+        expect(spliceTag(content, pos, "#zeta", "#omega"))
+            .toBe("#epsilon at line start with trailing prose.\nMid-line tag #omega here.\n");
+    });
+
+    it("targets the exact occurrence when a tag repeats", () => {
+        const dup = "#dup here and #dup there";
+        const second = dup.lastIndexOf("#dup");
+        expect(spliceTag(dup, {start: second, end: second + 4}, "#dup", "#two"))
+            .toBe("#dup here and #two there");
+    });
+
+    it("refuses to write (returns null) when the span no longer holds the tag", () => {
+        expect(spliceTag(content, epsilon, "#WRONG", "#x")).toBeNull();
+        expect(spliceTag(content, {start: 0, end: 5}, "#epsilon", "#x")).toBeNull();
+    });
+
+    it("refuses to write for missing or out-of-range positions", () => {
+        expect(spliceTag(content, undefined, "#epsilon", "#x")).toBeNull();
+        expect(spliceTag(content, {start: -1, end: 3}, "#epsilon", "#x")).toBeNull();
+        expect(spliceTag(content, {start: 5, end: content.length + 10}, "#epsilon", "#x")).toBeNull();
+        expect(spliceTag(content, {start: 5, end: 5}, "#epsilon", "#x")).toBeNull();
+    });
+});
+
+describe("frontmatter tag helpers", () => {
+    it("recognises the tags / tag keys case-insensitively", () => {
+        expect(isTagsKey("tags")).toBe(true);
+        expect(isTagsKey("tag")).toBe(true);
+        expect(isTagsKey("Tags")).toBe(true);
+        expect(isTagsKey("status")).toBe(false);
+        expect(isTagsKey(undefined)).toBe(false);
+    });
+
+    it("canonicalises a single tag to no-# trimmed form", () => {
+        expect(canonicalizeFrontmatterTag("  #alpha ")).toBe("alpha");
+        expect(canonicalizeFrontmatterTag("nested/beta")).toBe("nested/beta");
+    });
+
+    it("splits a YAML list, scalar, or comma/space string into canonical tags", () => {
+        expect(splitFrontmatterTags(["#alpha", "nested/beta"])).toEqual(["alpha", "nested/beta"]);
+        expect(splitFrontmatterTags("alpha")).toEqual(["alpha"]);
+        expect(splitFrontmatterTags("alpha, beta")).toEqual(["alpha", "beta"]);
+        expect(splitFrontmatterTags("alpha beta")).toEqual(["alpha", "beta"]);
+        expect(splitFrontmatterTags("#alpha,  #beta nested/gamma")).toEqual(["alpha", "beta", "nested/gamma"]);
+    });
+
+    it("drops blanks and null/undefined", () => {
+        expect(splitFrontmatterTags("")).toEqual([]);
+        expect(splitFrontmatterTags(null)).toEqual([]);
+        expect(splitFrontmatterTags(undefined)).toEqual([]);
+        expect(splitFrontmatterTags(["", "  ", "ok"])).toEqual(["ok"]);
+    });
+});

--- a/src/tagEditing.ts
+++ b/src/tagEditing.ts
@@ -13,6 +13,9 @@
 export interface TagPosition {
     start: number;
     end: number;
+    // 0-based source line of the occurrence, used only to disambiguate duplicate
+    // tags in the picker.
+    line?: number;
 }
 
 /**
@@ -74,6 +77,32 @@ export function computeTagRewrite(oldTag: string, input: string, mode: TagEditMo
     return `#${normalized}`;
 }
 
+/** A Tracker token is `#tag:value` - a tag, then a `:value` suffix, no spaces. */
+export function isTrackerToken(token: string): boolean {
+    return /^#[^\s]+:[^\s]+$/.test(token);
+}
+
+/**
+ * Coerce arbitrary input into a tag token: trim, collapse leading hashes to one
+ * `#`. The result still has to pass {@link isValidTagToken}; this only guarantees
+ * a single leading `#` so a bare value from the API (`"done"`) becomes `#done`.
+ */
+export function normalizeTagToken(value: string): string {
+    const trimmed = value.trim();
+    if (trimmed === "") return "";
+    return `#${trimmed.replace(/^#+/, "")}`;
+}
+
+/**
+ * Whether `token` is a single, writable tag: one leading `#`, a non-empty body,
+ * and no whitespace, comma, or further `#` (any of which Obsidian would parse as
+ * a tag boundary, leaving stray text in the note). A Tracker `:value` suffix is
+ * allowed.
+ */
+export function isValidTagToken(token: string): boolean {
+    return /^#[^\s,#]+$/.test(token);
+}
+
 /**
  * Replace the tag occupying `position` with `newToken`, but only when the span
  * still holds the expected tag text. Returns the rewritten content, or `null`
@@ -82,7 +111,10 @@ export function computeTagRewrite(oldTag: string, input: string, mode: TagEditMo
  *
  * This is the body-tag counterpart to the inline-field splice in
  * `parser.replaceInlineFieldValue`: it rewrites one exact occurrence and leaves
- * everything else - other tags, surrounding text - byte-for-byte intact.
+ * everything else - other tags, surrounding text - byte-for-byte intact. When
+ * writing a Tracker token over a tag that already carries a `:value` suffix, the
+ * old suffix is replaced too, so re-editing a value never stacks
+ * (`#weight:80` -> `#weight:85`, not `#weight:85:80`).
  */
 export function spliceTag(
     content: string,
@@ -97,7 +129,13 @@ export function spliceTag(
     if (start < 0 || end > content.length || start >= end) return null;
     if (content.slice(start, end) !== expectedTag) return null;
 
-    return content.slice(0, start) + newToken + content.slice(end);
+    let cutEnd = end;
+    if (isTrackerToken(newToken)) {
+        const existingSuffix = content.slice(end).match(/^:[^\s]+/);
+        if (existingSuffix) cutEnd = end + existingSuffix[0].length;
+    }
+
+    return content.slice(0, start) + newToken + content.slice(cutEnd);
 }
 
 const TAG_FRONTMATTER_KEYS: ReadonlySet<string> = new Set(["tags", "tag"]);

--- a/src/tagEditing.ts
+++ b/src/tagEditing.ts
@@ -77,9 +77,13 @@ export function computeTagRewrite(oldTag: string, input: string, mode: TagEditMo
     return `#${normalized}`;
 }
 
-/** A Tracker token is `#tag:value` - a tag, then a `:value` suffix, no spaces. */
+// A Tracker value is a simple, space-free token (typically numeric). Bounded so
+// a suffix splice never reaches into adjacent punctuation/markup (`,` `)` `#`).
+const TRACKER_VALUE = "[A-Za-z0-9._+-]+";
+
+/** A Tracker token is `#tag:value` - a tag, then a bounded `:value` suffix. */
 export function isTrackerToken(token: string): boolean {
-    return /^#[^\s]+:[^\s]+$/.test(token);
+    return new RegExp(`^#[^\\s:]+:${TRACKER_VALUE}$`).test(token);
 }
 
 /**
@@ -94,13 +98,22 @@ export function normalizeTagToken(value: string): string {
 }
 
 /**
- * Whether `token` is a single, writable tag: one leading `#`, a non-empty body,
- * and no whitespace, comma, or further `#` (any of which Obsidian would parse as
- * a tag boundary, leaving stray text in the note). A Tracker `:value` suffix is
- * allowed.
+ * Whether `token` is a single, writable tag that Obsidian indexes as ONE tag:
+ * one leading `#`, then only tag characters (Unicode letters, digits, `_`, `-`,
+ * `/`), with at least one non-digit so a purely numeric `#2024` (which Obsidian
+ * renders as text) is rejected. Punctuation like `.`/`!`/space/comma ends a tag
+ * in Obsidian, so it is rejected here rather than spliced in as a broken tag. An
+ * optional Tracker `:value` suffix is allowed.
  */
 export function isValidTagToken(token: string): boolean {
-    return /^#[^\s,#]+$/.test(token);
+    if (!token.startsWith("#")) return false;
+
+    // Peel off an optional Tracker `:value` suffix; validate the tag part only.
+    const tracker = token.match(new RegExp(`^(#.+?):${TRACKER_VALUE}$`, "u"));
+    const body = (tracker ? tracker[1] : token).slice(1);
+
+    if (!/^[\p{L}\p{N}_/-]+$/u.test(body)) return false;
+    return /[^\d/]/u.test(body);
 }
 
 /**
@@ -131,7 +144,9 @@ export function spliceTag(
 
     let cutEnd = end;
     if (isTrackerToken(newToken)) {
-        const existingSuffix = content.slice(end).match(/^:[^\s]+/);
+        // Only consume a bounded Tracker value, never adjacent punctuation/markup:
+        // `#weight:80,#other` keeps `,#other`; `(#weight:80)` keeps `)`.
+        const existingSuffix = content.slice(end).match(new RegExp(`^:${TRACKER_VALUE}`));
         if (existingSuffix) cutEnd = end + existingSuffix[0].length;
     }
 
@@ -153,17 +168,22 @@ export function canonicalizeFrontmatterTag(value: string): string {
 /**
  * Split a frontmatter `tags` value into individual tags. Obsidian accepts a YAML
  * list, a single scalar, or a comma/whitespace-separated string - all collapse
- * to the same set of canonical (no-`#`, trimmed, non-empty) tags here.
+ * to the same set of canonical (no-`#`, trimmed, non-empty) tags. Every element
+ * (list item or scalar) is itself split on whitespace/comma, so a stray
+ * `"alpha beta"` becomes two tags rather than one invalid one. Non-primitive
+ * items (objects, nested arrays) are skipped, so a garbage value like `{x:1}`
+ * never stringifies into `"[object Object]"`.
  */
 export function splitFrontmatterTags(content: unknown): string[] {
-    const raw = Array.isArray(content)
-        ? content.map(v => (v ?? "").toString())
-        : (content ?? "").toString().split(/[\s,]+/);
+    const items = Array.isArray(content) ? content : [content];
 
     const out: string[] = [];
-    for (const token of raw) {
-        const tag = canonicalizeFrontmatterTag(token);
-        if (tag) out.push(tag);
+    for (const item of items) {
+        if (item === null || item === undefined || typeof item === "object") continue;
+        for (const token of String(item).split(/[\s,]+/)) {
+            const tag = canonicalizeFrontmatterTag(token);
+            if (tag) out.push(tag);
+        }
     }
     return out;
 }

--- a/src/tagEditing.ts
+++ b/src/tagEditing.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure, Obsidian-free helpers for editing tags. Kept separate from
+ * `metaController` so the token-rewrite and span-splice logic - where a wrong
+ * offset means data loss - can be unit-tested in the jsdom-free `node` env.
+ *
+ * Two distinct tag homes exist (see TAG_EDITING_DESIGN.md):
+ *  - Body `#tags`, parsed from `cache.tags` with a document-offset position.
+ *  - Frontmatter `tags:` / `tag:`, stored as a YAML list, scalar, or CSV string.
+ * These helpers serve both.
+ */
+
+/** A body tag's exact span in the note, as document offsets (`[start, end)`). */
+export interface TagPosition {
+    start: number;
+    end: number;
+}
+
+/**
+ * How a body tag edit reshapes the tag:
+ *  - `rename`  : replace the whole tag with what the user typed (the primary,
+ *                least-surprising action; a flat tag is renamed, not nested).
+ *  - `leaf`    : replace only the last `/`-segment of a nested tag.
+ *  - `tracker` : write Obsidian Tracker's `#tag:value` data syntax (body only).
+ */
+export type TagEditMode = "rename" | "leaf" | "tracker";
+
+/** Drop any leading `#` (Obsidian tolerates one; frontmatter omits it). */
+export function stripHash(tag: string): string {
+    return tag.replace(/^#+/, "");
+}
+
+/** A tag is nested when it has a `/` separator after the leading `#`. */
+export function isNestedTag(tag: string): boolean {
+    return stripHash(tag).includes("/");
+}
+
+/** Last `/`-segment of a tag (the "leaf"), without the `#`. */
+export function tagLeaf(tag: string): string {
+    const body = stripHash(tag);
+    return body.split("/").pop() ?? "";
+}
+
+/** Everything before the leaf, with the leading `#` kept: `#a/b/c` -> `#a/b`. */
+export function tagParent(tag: string): string {
+    const segments = stripHash(tag).split("/");
+    segments.pop();
+    return `#${segments.join("/")}`;
+}
+
+/**
+ * Compute the full replacement token for a body-tag edit. The result is the
+ * literal text that will occupy the tag's span - the writer never re-derives it,
+ * so the rename-vs-leaf-vs-tracker decision lives here, once.
+ *
+ * Returns an empty string when there is nothing meaningful to write (so callers
+ * can treat it as a cancel), e.g. a rename to blank.
+ */
+export function computeTagRewrite(oldTag: string, input: string, mode: TagEditMode): string {
+    const value = input.trim();
+
+    if (mode === "tracker") {
+        // Tracker reads `#tag:value`; an empty value is not a useful series point.
+        return value === "" ? "" : `${oldTag}:${value}`;
+    }
+
+    const normalized = stripHash(value);
+    if (normalized === "") return "";
+
+    if (mode === "leaf") {
+        return `${tagParent(oldTag)}/${normalized}`;
+    }
+
+    // rename: the typed value becomes the whole tag (nested input is honoured).
+    return `#${normalized}`;
+}
+
+/**
+ * Replace the tag occupying `position` with `newToken`, but only when the span
+ * still holds the expected tag text. Returns the rewritten content, or `null`
+ * when the span no longer matches (the note changed since it was parsed) so the
+ * caller refuses to write rather than corrupt unrelated prose.
+ *
+ * This is the body-tag counterpart to the inline-field splice in
+ * `parser.replaceInlineFieldValue`: it rewrites one exact occurrence and leaves
+ * everything else - other tags, surrounding text - byte-for-byte intact.
+ */
+export function spliceTag(
+    content: string,
+    position: TagPosition | undefined,
+    expectedTag: string,
+    newToken: string,
+): string | null {
+    if (!position) return null;
+
+    const {start, end} = position;
+    if (!Number.isInteger(start) || !Number.isInteger(end)) return null;
+    if (start < 0 || end > content.length || start >= end) return null;
+    if (content.slice(start, end) !== expectedTag) return null;
+
+    return content.slice(0, start) + newToken + content.slice(end);
+}
+
+const TAG_FRONTMATTER_KEYS: ReadonlySet<string> = new Set(["tags", "tag"]);
+
+/** Whether a frontmatter key holds tags (Obsidian treats `tags`/`tag` specially). */
+export function isTagsKey(key: string | undefined): boolean {
+    return !!key && TAG_FRONTMATTER_KEYS.has(key.toLowerCase());
+}
+
+/** Canonical frontmatter form of a single tag: trimmed, no leading `#`. */
+export function canonicalizeFrontmatterTag(value: string): string {
+    return stripHash(value.trim()).trim();
+}
+
+/**
+ * Split a frontmatter `tags` value into individual tags. Obsidian accepts a YAML
+ * list, a single scalar, or a comma/whitespace-separated string - all collapse
+ * to the same set of canonical (no-`#`, trimmed, non-empty) tags here.
+ */
+export function splitFrontmatterTags(content: unknown): string[] {
+    const raw = Array.isArray(content)
+        ? content.map(v => (v ?? "").toString())
+        : (content ?? "").toString().split(/[\s,]+/);
+
+    const out: string[] = [];
+    for (const token of raw) {
+        const tag = canonicalizeFrontmatterTag(token);
+        if (tag) out.push(tag);
+    }
+    return out;
+}

--- a/tests/e2e/metaedit-runtime.test.ts
+++ b/tests/e2e/metaedit-runtime.test.ts
@@ -29,6 +29,7 @@ describe("MetaEdit runtime", () => {
 		expect(state.apiMethods).toEqual([
 			"addOrUpdateProperty",
 			"addOrUpdateYamlPath",
+			"appendDataviewField",
 			"autoprop",
 			"createYamlProperty",
 			"getAutoProperties",

--- a/tests/e2e/tag-editing.test.ts
+++ b/tests/e2e/tag-editing.test.ts
@@ -150,6 +150,37 @@ describe("MetaEdit tag editing", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("rejects a purely numeric tag (Obsidian renders it as text)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await editBodyTag(
+			obsidian,
+			sandbox.path("numeric.md"),
+			"#topic here.\n",
+			"(t) => t.find((x) => x.key === '#topic')",
+			"#2024",
+		);
+
+		expect(result.error).toContain("not a valid tag");
+		expect(result.content).toBe("#topic here.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("Tracker re-edit keeps adjacent tags and markup intact", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await editBodyTag(
+			obsidian,
+			sandbox.path("tracker-adjacent.md"),
+			"#weight:80,#other and (#mood:3) end.\n",
+			"(t) => t.find((x) => x.key === '#weight')",
+			"#weight:85",
+		);
+
+		expect(result.error).toBe("");
+		// The bounded :value suffix stops at the comma; #other and (#mood:3) survive.
+		expect(result.content).toBe("#weight:85,#other and (#mood:3) end.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("api.update on a body tag normalizes a bare value into a safe rename", async () => {
 		const { obsidian, sandbox } = getContext();
 		const notePath = sandbox.path("api-rename.md");

--- a/tests/e2e/tag-editing.test.ts
+++ b/tests/e2e/tag-editing.test.ts
@@ -118,6 +118,63 @@ describe("MetaEdit tag editing", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("re-edits a Tracker #tag:value without stacking the old value", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await editBodyTag(
+			obsidian,
+			sandbox.path("tracker.md"),
+			"#weight:80 logged today.\n",
+			"(t) => t.find((x) => x.key === '#weight')",
+			"#weight:85",
+		);
+
+		expect(result.error).toBe("");
+		// Obsidian's tag span covers only #weight; the writer replaces the trailing
+		// :80 too, instead of producing #weight:85:80.
+		expect(result.content).toBe("#weight:85 logged today.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("rejects an invalid tag name (spaces) without corrupting the note", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await editBodyTag(
+			obsidian,
+			sandbox.path("invalid.md"),
+			"#topic here.\n",
+			"(t) => t.find((x) => x.key === '#topic')",
+			"#meeting notes",
+		);
+
+		expect(result.error).toContain("not a valid tag");
+		expect(result.content).toBe("#topic here.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("api.update on a body tag normalizes a bare value into a safe rename", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("api-rename.md");
+		const content = await evalJsonAsync<string>(
+			obsidian,
+			`
+			(async () => {
+				const path = ${JSON.stringify(notePath)};
+				const body = "#status here.\\n";
+				let f = app.vault.getAbstractFileByPath(path);
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise((r) => setTimeout(r, 300));
+				await app.plugins.plugins.${PLUGIN_ID}.api.update("#status", "done", f);
+				await new Promise((r) => setTimeout(r, 200));
+				return await app.vault.read(f);
+			})()
+		`,
+		);
+
+		// "done" -> "#done" (prepended #), spliced over the tag span - not "done"
+		// dropped in as prose.
+		expect(content).toBe("#done here.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("refuses to write when the tag's parsed span no longer matches the file", async () => {
 		const { obsidian, sandbox } = getContext();
 		const notePath = sandbox.path("stale.md");

--- a/tests/e2e/tag-editing.test.ts
+++ b/tests/e2e/tag-editing.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "vitest";
+import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID } from "./harness";
+
+const getContext = createMetaEditE2EHarness("tag-editing");
+
+/**
+ * Drive a body-tag edit through the real controller, exactly as the picker does:
+ * read the file's properties (so each tag carries its parsed span), find the
+ * target occurrence, and call updatePropertyInFile with the full replacement
+ * token. Returns the resulting file content (and any error message).
+ *
+ * `select` picks the occurrence to edit from the parsed tag properties.
+ */
+async function editBodyTag(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	notePath: string,
+	body: string,
+	select: string,
+	newToken: string,
+): Promise<{ content: string; error: string }> {
+	return await evalJsonAsync(
+		obsidian,
+		`
+		(async () => {
+			const plugin = app.plugins.plugins.${PLUGIN_ID};
+			const c = plugin.controller;
+			const path = ${JSON.stringify(notePath)};
+			const body = ${JSON.stringify(body)};
+			let f = app.vault.getAbstractFileByPath(path);
+			if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+
+			// Wait until the metadata cache's tag spans validate against disk, so
+			// this mirrors a single picker-open on a fresh cache.
+			let props = [];
+			for (let i = 0; i < 60; i++) {
+				await new Promise((r) => setTimeout(r, 50));
+				props = await c.getPropertiesInFile(f);
+				const tags = props.filter((p) => p.type === 2);
+				if (tags.length && tags.every((t) => t.position && body.slice(t.position.start, t.position.end) === t.key)) break;
+			}
+
+			const tags = props.filter((p) => p.type === 2);
+			const select = (${select});
+			const target = select(tags);
+			if (!target) throw new Error("target tag not found");
+
+			let error = "";
+			try { await c.updatePropertyInFile(target, ${JSON.stringify(newToken)}, f); }
+			catch (e) { error = e instanceof Error ? e.message : String(e); }
+			await new Promise((r) => setTimeout(r, 200));
+			return { content: await app.vault.read(f), error };
+		})()
+	`,
+	);
+}
+
+describe("MetaEdit tag editing", () => {
+	test("renames a line-start body tag in place, preserving the rest of the line (BUG-2 + Decision D)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await editBodyTag(
+			obsidian,
+			sandbox.path("rename.md"),
+			"#epsilon at line start with trailing prose.\n",
+			"(t) => t.find((x) => x.key === '#epsilon')",
+			"#renamed",
+		);
+
+		expect(result.error).toBe("");
+		// The whole tag is renamed (not turned into #epsilon/renamed) and the prose
+		// after it survives - the pre-fix writer destroyed everything after the tag.
+		expect(result.content).toBe("#renamed at line start with trailing prose.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("edits a mid-line body tag in place (BUG-3)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await editBodyTag(
+			obsidian,
+			sandbox.path("midline.md"),
+			"Mid-line tag #zeta should be editable too.\n",
+			"(t) => t.find((x) => x.key === '#zeta')",
+			"#omega",
+		);
+
+		expect(result.error).toBe("");
+		expect(result.content).toBe("Mid-line tag #omega should be editable too.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("edits only the selected occurrence when a tag repeats (BUG-3)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await editBodyTag(
+			obsidian,
+			sandbox.path("dup.md"),
+			"Dup #dup one and #dup two.\n",
+			"(t) => t.filter((x) => x.key === '#dup').sort((a, b) => a.position.start - b.position.start)[1]",
+			"#dup2",
+		);
+
+		expect(result.error).toBe("");
+		// Only the second #dup changed; the first is untouched.
+		expect(result.content).toBe("Dup #dup one and #dup2 two.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("replaces only the leaf of a nested tag (Decision D)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await editBodyTag(
+			obsidian,
+			sandbox.path("nested.md"),
+			"#area/old here.\n",
+			"(t) => t.find((x) => x.key === '#area/old')",
+			"#area/new",
+		);
+
+		expect(result.error).toBe("");
+		expect(result.content).toBe("#area/new here.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("refuses to write when the tag's parsed span no longer matches the file", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("stale.md");
+		const result = await evalJsonAsync<{ content: string; error: string }>(
+			obsidian,
+			`
+			(async () => {
+				const c = app.plugins.plugins.${PLUGIN_ID}.controller;
+				const path = ${JSON.stringify(notePath)};
+				const body = "#stable here.\\n";
+				let f = app.vault.getAbstractFileByPath(path);
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise((r) => setTimeout(r, 300));
+				const snapshot = await app.vault.read(f);
+
+				let error = "";
+				try {
+					// Position points at "#sta" (offsets 0-4), which does not equal "#stable".
+					await c.updatePropertyInFile({ key: "#stable", content: "#stable", type: 2, position: { start: 0, end: 4 } }, "#x", f);
+				} catch (e) { error = e instanceof Error ? e.message : String(e); }
+				await new Promise((r) => setTimeout(r, 150));
+				return { content: await app.vault.read(f), error, snapshot };
+			})()
+		`,
+		);
+
+		expect(result.error).toContain("could not locate the tag");
+		// The note is byte-for-byte unchanged: a stale edit never corrupts.
+		expect(result.content).toBe("#stable here.\n");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("canonicalises frontmatter tags and removes the key when emptied (Section 6.3 / Decision E)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("frontmatter-tags.md");
+		const result = await evalJsonAsync<{ scalarToList: string; emptied: string }>(
+			obsidian,
+			`
+			(async () => {
+				const c = app.plugins.plugins.${PLUGIN_ID}.controller;
+				const path = ${JSON.stringify(notePath)};
+				let f = app.vault.getAbstractFileByPath(path);
+				const body = "---\\ntags: alpha\\nstatus: keep\\n---\\nbody\\n";
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise((r) => setTimeout(r, 300));
+
+				const tagsProp = (await c.getPropertiesInFile(f)).find((p) => p.type === 0 && p.key === "tags" && !p.path);
+				// Edit a scalar tags value with a #, CSV and whitespace - stored as a clean list.
+				await c.updatePropertyInFile(tagsProp, "alpha, #beta gamma", f);
+				await new Promise((r) => setTimeout(r, 200));
+				const scalarToList = await app.vault.read(f);
+
+				// Emptying the tags removes the key entirely (status survives).
+				const tagsProp2 = (await c.getPropertiesInFile(f)).find((p) => p.type === 0 && p.key === "tags" && !p.path);
+				await c.updatePropertyInFile(tagsProp2, [], f);
+				await new Promise((r) => setTimeout(r, 200));
+				const emptied = await app.vault.read(f);
+
+				return { scalarToList, emptied };
+			})()
+		`,
+		);
+
+		expect(result.scalarToList).toContain("tags:\n  - alpha\n  - beta\n  - gamma");
+		expect(result.emptied).not.toContain("tags:");
+		expect(result.emptied).toContain("status: keep");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+});


### PR DESCRIPTION
Fixes #49

## Why
"Edit last value in tags" only ever touched body `#tags`, was undocumented, was built around the Tracker plugin, and carried real correctness bugs. Issue #49 was two users who couldn't figure out what it did - a symptom of a feature that was both confusing and partly broken. This PR makes tag editing correct, predictable, and documented, across both homes a tag can live in (note body and YAML frontmatter).

Design rationale: [`TAG_EDITING_DESIGN.md`](TAG_EDITING_DESIGN.md) (approved as Option B, Decision D = rename).

## What changed
**Decision D - clear semantics.** Selecting a body `#tag` now offers:
- **Rename tag** (primary) - renames the whole tag for that one occurrence (`#draft` → `#published`), preserving the rest of the line. A flat tag is renamed, not turned into a child.
- **Edit last segment** (nested tags only) - `#area/old` → `#area/new`.
- **Tracker value** (`#tag:value`) - only when the Tracker plugin is installed.

**Correctness fixes**
- **Data loss (BUG-2):** body-tag edits rewrote the *whole line*, destroying any prose after the tag. Now only the tag's exact span is rewritten.
- **Wrong/no-op occurrence (BUG-3):** the writer matched by key and could no-op a mid-line tag or rewrite the wrong duplicate. Each occurrence now carries its parsed document-offset span, validated against current content before writing - a stale span refuses to write rather than corrupt the note.
- **Session-wide Tracker leak (BUG-1):** `useTrackerPlugin` was set once on the singleton controller and never reset, so every later edit wrote Tracker syntax. The choice is now derived per edit; no Tracker state persists.
- **Broken delete/transform (BUG-5):** the ❌/🔃 actions silently no-op'd or mangled body tags (they match `key:`). They're no longer offered on body tags.
- **Frontmatter `tags:`** is now tag-aware: a leading `#` you type is stripped; list / scalar / comma- or space-separated shapes all normalize to a canonical `#`-free YAML list; multi-word entries split; objects are ignored; and the key is removed when the last tag is cleared.
- Tag-name validation rejects names Obsidian wouldn't index as one tag (spaces, commas, `.`/`!`, purely numeric) instead of writing broken text. Tracker re-edits no longer stack (`#weight:80` → `#weight:85`, not `:85:80`) and never eat adjacent tags/markup.
- Fixed two pre-existing `\s`→`\\s` regex-escape bugs (`lineMatch`, `deleteProperty`) and a dangling-promise hang when cancelling a suggester.

**Docs:** README "Editing tags" guide + an in-modal hint, documenting what MetaEdit handles vs. what it defers to native Obsidian (Properties tag widget, Tag-pane vault-wide rename), stated against Obsidian 1.12.7.

## Out of scope (deferred to native Obsidian)
Vault-wide tag rename (Tag pane), the rich frontmatter tag widget (Properties), and a large merged tag-management UI. See the design doc's recommendation.

## Testing
- `pnpm run lint`, `pnpm run build`, `pnpm run test` - green (287 unit tests; new pure `tagEditing` core fully covered).
- New `tests/e2e/tag-editing.test.ts` (11 cases) + full e2e suite - green against a live Obsidian **1.12.7** isolated instance. Every defect was reproduced first, then shown fixed.
- Two independent opposing-model adversarial reviews on the write path; all findings folded in (occurrence identity, token validation, Tracker-suffix bounds, batch offset ordering, Auto-Property back-compat, cancel hang).

## Release/migration impact
No settings or stored-data migration. Behavior changes are corrections (flat tags rename instead of nesting; edits no longer destroy line prose; frontmatter tags normalize to a list) - worth a release note. No changes to generated artifacts or `package.json`/lockfile. The public API surface is unchanged (tag `Property` objects gain an optional `position`, additive).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/metaedit/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->