### PR TITLE
fix(core,api): safe command no-op, block-list deletion, presence-based property lookups

### DIFF
--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -167,7 +167,10 @@ export class MetaEditApi {
     private getGetPropertiesInFile() {
         return async (file: TFile | string): Promise<Property[]>  => {
             const targetFile = this.getFileFromTFileOrPath(file);
-            if (!targetFile) return;
+            // Honor the declared Promise<Property[]> contract: an unresolved path
+            // returns an empty array, never undefined, so callers can iterate the
+            // result without a TypeError.
+            if (!targetFile) return [];
 
             return await this.plugin.controller.getPropertiesInFile(targetFile);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,7 +123,10 @@ export default class MetaEdit extends Plugin {
             if (fileCache) {
                 const fileFrontmatter = fileCache.frontmatter;
 
-                if (fileFrontmatter && fileFrontmatter[property]) {
+                // Match on key PRESENCE, not truthiness, so a note that defines
+                // the property with a falsy value (false, 0, "", null) is still
+                // returned. A truthy check silently dropped `published: false`.
+                if (fileFrontmatter && Object.prototype.hasOwnProperty.call(fileFrontmatter, property)) {
                     files.push(file);
                 }
             }

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -249,18 +249,36 @@ export default class MetaController {
             return;
         }
 
-        const fileContent = await this.app.vault.read(file);
-        const splitContent = fileContent.split("\n");
-        // Escape the key (so a key like `c++` is not read as regex) and use a real
-        // `\s` so an indented property line still matches its own line, not another.
-        const regexp = new RegExp(`^\\s*${this.escapeSpecialCharacters(property.key)}\\s*:`);
+        // Serialize with every other MetaEdit write to this file. The previous
+        // implementation read/modified outside the queue and could race a queued
+        // write (lost update), and the transform-property flow deletes-then-adds.
+        await this.enqueueFileWrite(file, async () => {
+            // A top-level YAML key is removed through the frontmatter primitive so
+            // a multi-line block value (a block list or map) is deleted whole. The
+            // old single-line regex stripped only the `key:` line and orphaned its
+            // `- a` / `- b` continuation lines, corrupting the frontmatter.
+            if (property.type === MetaType.YAML) {
+                await this.processFrontMatter(file, (frontmatter) => {
+                    delete frontmatter[property.key];
+                });
+                return;
+            }
 
-        const idx = splitContent.findIndex(s => s.match(regexp));
-        const newFileContent = splitContent.filter((v, i) => {
-            if (i != idx) return true;
-        }).join("\n");
+            // Inline (Dataview) and other line-based fields: remove the matching
+            // line, preserving the file's existing newline so a CRLF note keeps it.
+            const fileContent = await this.app.vault.read(file);
+            const newline = fileContent.includes("\r\n") ? "\r\n" : "\n";
+            const splitContent = fileContent.split(/\r?\n/);
+            // Escape the key (so a key like `c++` is not read as regex) and use a real
+            // `\s` so an indented property line still matches its own line, not another.
+            const regexp = new RegExp(`^\\s*${this.escapeSpecialCharacters(property.key)}\\s*:`);
 
-        await this.app.vault.modify(file, newFileContent);
+            const idx = splitContent.findIndex(s => s.match(regexp));
+            if (idx === -1) return;
+            splitContent.splice(idx, 1);
+
+            await this.app.vault.modify(file, splitContent.join(newline));
+        });
     }
 
     private async progressPropHelper(progressProps: ProgressProperty[], meta: Property[], counts: {total: number, complete: number, incomplete: number}) {

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -269,9 +269,10 @@ export default class MetaController {
             const fileContent = await this.app.vault.read(file);
             const newline = fileContent.includes("\r\n") ? "\r\n" : "\n";
             const splitContent = fileContent.split(/\r?\n/);
-            // Escape the key (so a key like `c++` is not read as regex) and use a real
-            // `\s` so an indented property line still matches its own line, not another.
-            const regexp = new RegExp(`^\\s*${this.escapeSpecialCharacters(property.key)}\\s*:`);
+            // Escape the key (so a key like `c++` is not read as regex) and require
+            // the inline `::` separator, so deleting an inline `key:: value` never
+            // matches a same-named YAML frontmatter `key:` line earlier in the file.
+            const regexp = new RegExp(`^\\s*${this.escapeSpecialCharacters(property.key)}\\s*::`);
 
             const idx = splitContent.findIndex(s => s.match(regexp));
             if (idx === -1) return;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,11 +1,15 @@
 import {type App, type TAbstractFile, TFile} from "obsidian";
+import {log} from "./logger/logManager";
 
 export function getActiveMarkdownFile(app: App): TFile {
     const activeFile: TFile = app.workspace.getActiveFile();
     const activeMarkdownFile = abstractFileToMarkdownTFile(activeFile);
 
     if (!activeMarkdownFile) {
-        this.logError("could not get current file.");
+        // No active markdown file: log and return null so the caller (the Run
+        // command) cleanly no-ops. This was `this.logError(...)`, but a plain
+        // exported function has no `this`, so it threw a TypeError instead.
+        log.logMessage("MetaEdit: no active markdown file.");
         return null;
     }
 

--- a/tests/e2e/audit-api.test.ts
+++ b/tests/e2e/audit-api.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "vitest";
+import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID } from "./harness";
+
+const getContext = createMetaEditE2EHarness("audit-api");
+
+// Drive the public API exactly as another plugin would: app.plugins.plugins.metaedit.api.
+async function api<T>(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	notePath: string,
+	body: string,
+	expr: string,
+): Promise<T> {
+	return await evalJsonAsync<T>(
+		obsidian,
+		`
+		(async () => {
+			const api = app.plugins.plugins.${PLUGIN_ID}.api;
+			const path = ${JSON.stringify(notePath)};
+			const body = ${JSON.stringify(body)};
+			let f = app.vault.getAbstractFileByPath(path);
+			if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+			await new Promise((r) => setTimeout(r, 300));
+			const result = await (${expr});
+			await new Promise((r) => setTimeout(r, 150));
+			return result;
+		})()
+	`,
+	);
+}
+
+describe("MetaEdit public API", () => {
+	test("API-getPropertyValue + getPropertiesInFile read frontmatter, inline, and tags", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await api<{ status: unknown; props: string[] }>(
+			obsidian,
+			sandbox.path("api-get.md"),
+			"---\nstatus: active\n---\n#mytag\ninline:: 42\n",
+			`(async () => {
+				const status = await api.getPropertyValue("status", f);
+				const props = (await api.getPropertiesInFile(f)).map(p => p.key + ":" + p.type);
+				return { status, props };
+			})()`,
+		);
+		expect(result.status).toBe("active");
+		expect(result.props).toContain("status:0");
+		expect(result.props).toContain("inline:1");
+		expect(result.props.some((p) => p.startsWith("#mytag:2"))).toBe(true);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("API-createYamlProperty adds a key; refuses to clobber an existing one", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await api<{ added: string; afterDup: string }>(
+			obsidian,
+			sandbox.path("api-create.md"),
+			"---\nexisting: 1\n---\nbody\n",
+			`(async () => {
+				await api.createYamlProperty("fresh", "v", f);
+				await new Promise(r => setTimeout(r, 150));
+				const added = await app.vault.read(f);
+				await api.createYamlProperty("existing", "SHOULD_NOT_OVERWRITE", f);
+				await new Promise(r => setTimeout(r, 150));
+				const afterDup = await app.vault.read(f);
+				return { added, afterDup };
+			})()`,
+		);
+		expect(result.added).toContain("fresh: v");
+		// createYamlProperty must not overwrite an existing key.
+		expect(result.afterDup).toContain("existing: 1");
+		expect(result.afterDup).not.toContain("SHOULD_NOT_OVERWRITE");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("API-addOrUpdateProperty updates an existing key and creates a missing one", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await api<{ content: string }>(
+			obsidian,
+			sandbox.path("api-upsert.md"),
+			"---\nstatus: old\n---\nbody\n",
+			`(async () => {
+				await api.addOrUpdateProperty("status", "new", f);
+				await api.addOrUpdateProperty("added", "yes", f);
+				await new Promise(r => setTimeout(r, 200));
+				return { content: await app.vault.read(f) };
+			})()`,
+		);
+		expect(result.content).toContain("status: new");
+		expect(result.content).not.toContain("status: old");
+		expect(result.content).toContain("added: yes");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("API-update on a non-existent property is a safe no-op", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await api<{ before: string; after: string; threw: string }>(
+			obsidian,
+			sandbox.path("api-update-missing.md"),
+			"---\na: 1\n---\nbody\n",
+			`(async () => {
+				const before = await app.vault.read(f);
+				let threw = "";
+				try { await api.update("nope", "x", f); } catch (e) { threw = String(e && e.message || e); }
+				await new Promise(r => setTimeout(r, 150));
+				return { before, after: await app.vault.read(f), threw };
+			})()`,
+		);
+		expect(result.threw).toBe("");
+		expect(result.after).toBe(result.before);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("API-appendDataviewField appends a new instance without replacing existing ones", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await api<{ content: string }>(
+			obsidian,
+			sandbox.path("api-append.md"),
+			"start\nfield:: one\nmiddle\n",
+			`(async () => {
+				await api.appendDataviewField("field", "two", f);
+				await new Promise(r => setTimeout(r, 200));
+				return { content: await app.vault.read(f) };
+			})()`,
+		);
+		// Both instances exist (append, not replace).
+		expect(result.content).toContain("field:: one");
+		expect(result.content).toContain("field:: two");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("API-getYamlPath / addOrUpdateYamlPath / updateYamlPath handle nested YAML", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await api<{
+			read: unknown;
+			afterUpsert: unknown;
+			afterUpdate: unknown;
+			content: string;
+		}>(
+			obsidian,
+			sandbox.path("api-yamlpath.md"),
+			"---\nmeta:\n  nested: original\n---\nbody\n",
+			`(async () => {
+				const read = await api.getYamlPath("meta.nested", f);
+				// Upsert a brand-new nested path with createParents.
+				await api.addOrUpdateYamlPath(["meta", "added"], "created", f, { createParents: true });
+				await new Promise(r => setTimeout(r, 150));
+				const afterUpsert = await api.getYamlPath("meta.added", f);
+				// Update an existing nested path.
+				await api.updateYamlPath("meta.nested", "changed", f);
+				await new Promise(r => setTimeout(r, 150));
+				const afterUpdate = await api.getYamlPath("meta.nested", f);
+				return { read, afterUpsert, afterUpdate, content: await app.vault.read(f) };
+			})()`,
+		);
+		expect(result.read).toBe("original");
+		expect(result.afterUpsert).toBe("created");
+		expect(result.afterUpdate).toBe("changed");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("API-getFilesWithProperty returns files whose frontmatter has the key", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("api-haskey.md");
+		const result = await api<{ found: boolean }>(
+			obsidian,
+			notePath,
+			"---\nuniqueAuditKey: 1\n---\nbody\n",
+			`(async () => {
+				await new Promise(r => setTimeout(r, 300));
+				const files = api.getFilesWithProperty("uniqueAuditKey").map(x => x.path);
+				return { found: files.includes(${JSON.stringify(notePath)}) };
+			})()`,
+		);
+		expect(result.found).toBe(true);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("API-getAutoProperties returns an isolated clone; setAutoProperties persists and validates", async () => {
+		const { obsidian } = getContext();
+		const result = await evalJsonAsync<{
+			cloneIsolated: boolean;
+			persisted: string[];
+			rejectedBad: string;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const api = app.plugins.plugins.${PLUGIN_ID}.api;
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+
+				// Mutating the returned clone must not affect stored settings.
+				const clone = api.getAutoProperties();
+				clone.push({ name: "ghost", choices: ["x"] });
+				const cloneIsolated = !plugin.settings.AutoProperties.properties.some(a => a.name === "ghost");
+
+				// Valid set persists.
+				await api.setAutoProperties([{ name: "auditAP", choices: ["a", "b"], type: "Single" }]);
+				const persisted = plugin.settings.AutoProperties.properties.map(a => a.name);
+
+				// Invalid set is rejected (choices not strings).
+				let rejectedBad = "";
+				try { await api.setAutoProperties([{ name: "bad", choices: [1, 2] }]); }
+				catch (e) { rejectedBad = String(e && e.message || e); }
+
+				return { cloneIsolated, persisted, rejectedBad };
+			})()
+		`,
+		);
+		expect(result.cloneIsolated).toBe(true);
+		expect(result.persisted).toContain("auditAP");
+		expect(result.rejectedBad).toMatch(/choices|string/i);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("API-onMetadataChange fires on change with prev/next props and stops after unsubscribe", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("api-onchange.md");
+		const result = await evalJsonAsync<{
+			firedCount: number;
+			sawNewValue: boolean;
+			afterUnsubCount: number;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				const api = app.plugins.plugins.${PLUGIN_ID}.api;
+				const path = ${JSON.stringify(notePath)};
+				let f = app.vault.getAbstractFileByPath(path);
+				const body = "---\\nstate: one\\n---\\nbody\\n";
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise(r => setTimeout(r, 300));
+
+				let firedCount = 0;
+				let sawNewValue = false;
+				const unsub = api.onMetadataChange((change) => {
+					if (change.file.path !== path) return;
+					firedCount++;
+					if (change.properties.some(p => p.key === "state" && p.content === "two")) sawNewValue = true;
+				});
+
+				await api.update("state", "two", f);
+				await new Promise(r => setTimeout(r, 600));
+				const firedAfterChange = firedCount;
+
+				unsub();
+				await api.update("state", "three", f);
+				await new Promise(r => setTimeout(r, 600));
+				const afterUnsubCount = firedCount - firedAfterChange;
+
+				return { firedCount: firedAfterChange, sawNewValue, afterUnsubCount };
+			})()
+		`,
+		);
+		expect(result.firedCount).toBeGreaterThan(0);
+		expect(result.sawNewValue).toBe(true);
+		// No callbacks after unsubscribe.
+		expect(result.afterUnsubCount).toBe(0);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+});

--- a/tests/e2e/audit-repro.test.ts
+++ b/tests/e2e/audit-repro.test.ts
@@ -4,6 +4,33 @@ import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID } from "./harness";
 const getContext = createMetaEditE2EHarness("audit-repro");
 
 describe("AUDIT repro: confirmed bug candidates", () => {
+	test("CTRL: deleting an inline field does not remove a same-named frontmatter key", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("delete-inline-collision.md");
+		const content = await evalJsonAsync<string>(
+			obsidian,
+			`
+			(async () => {
+				const c = app.plugins.plugins.${PLUGIN_ID}.controller;
+				const path = ${JSON.stringify(notePath)};
+				const body = "---\\nkey: yaml-value\\n---\\nkey:: inline-value\\n";
+				let f = app.vault.getAbstractFileByPath(path);
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise((r) => setTimeout(r, 300));
+				// The inline Dataview field (type 1), not the YAML key (type 0).
+				const inline = (await c.getPropertiesInFile(f)).find((p) => p.key === "key" && p.type === 1);
+				await c.deleteProperty(inline, f);
+				await new Promise((r) => setTimeout(r, 200));
+				return await app.vault.read(f);
+			})()
+		`,
+		);
+		// The inline field is gone; the same-named frontmatter key survives.
+		expect(content).toContain("key: yaml-value");
+		expect(content).not.toContain("key:: inline-value");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("CTRL: deleteProperty on a block-style YAML list must not orphan value lines", async () => {
 		const { obsidian, sandbox } = getContext();
 		const notePath = sandbox.path("delete-block-list.md");

--- a/tests/e2e/audit-repro.test.ts
+++ b/tests/e2e/audit-repro.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID } from "./harness";
+
+const getContext = createMetaEditE2EHarness("audit-repro");
+
+describe("AUDIT repro: confirmed bug candidates", () => {
+	test("CTRL: deleteProperty on a block-style YAML list must not orphan value lines", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("delete-block-list.md");
+		const result = await evalJsonAsync<{ content: string; error: string }>(
+			obsidian,
+			`
+			(async () => {
+				const c = app.plugins.plugins.${PLUGIN_ID}.controller;
+				const path = ${JSON.stringify(notePath)};
+				const body = "---\\ntags:\\n  - a\\n  - b\\nstatus: keep\\n---\\nbody text\\n";
+				let f = app.vault.getAbstractFileByPath(path);
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise((r) => setTimeout(r, 300));
+				const tagsProp = (await c.getPropertiesInFile(f)).find((p) => p.type === 0 && p.key === "tags" && !p.path);
+				let error = "";
+				try { await c.deleteProperty(tagsProp, f); } catch (e) { error = e instanceof Error ? e.message : String(e); }
+				await new Promise((r) => setTimeout(r, 200));
+				return { content: await app.vault.read(f), error };
+			})()
+		`,
+		);
+
+		// The tags key (and its block list) should be gone, status: keep preserved,
+		// and the frontmatter must stay valid - no orphaned "- a" / "- b" lines.
+		expect(result.error).toBe("");
+		expect(result.content).not.toMatch(/^\s*-\s*a\s*$/m);
+		expect(result.content).not.toMatch(/^\s*-\s*b\s*$/m);
+		expect(result.content).toContain("status: keep");
+		expect(result.content).toContain("body text");
+	});
+
+	test("RUN: running the command with no active markdown file is a clean no-op (no thrown error)", async () => {
+		const { obsidian } = getContext();
+		// Start from a clean diagnostics buffer so we only see errors this run causes.
+		await obsidian.dev.resetDiagnostics().catch(() => undefined);
+
+		// Use obsidian.dev.eval directly (evalJsonAsync's nested-eval wrapper is
+		// unreliable around executeCommandById). Stub getActiveFile to null for one
+		// command run, then restore it.
+		// Run the command as a pure side effect via dev.eval (the fix emits a
+		// console.log, which would break evalJsonAsync's envelope), then assert via
+		// diagnostics. Stub getActiveFile to null for the one command run.
+		await obsidian.dev.eval(`
+			(() => {
+				const orig = app.workspace.getActiveFile;
+				app.workspace.getActiveFile = () => null;
+				try {
+					app.commands.executeCommandById("${PLUGIN_ID}:metaEditRun");
+				} finally {
+					app.workspace.getActiveFile = orig;
+				}
+			})()
+		`);
+		// Let any async command rejection settle into diagnostics.
+		await new Promise((r) => setTimeout(r, 300));
+
+		// The command must produce no "this.logError is not a function" unhandled
+		// rejection (the pre-fix bug), and indeed no runtime error at all.
+		const errors = await obsidian.dev.runtimeErrors();
+		expect(errors).toEqual([]);
+	});
+});

--- a/tests/e2e/audit-repro2.test.ts
+++ b/tests/e2e/audit-repro2.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID } from "./harness";
+
+const getContext = createMetaEditE2EHarness("audit-repro2");
+
+describe("AUDIT repro batch 2: candidate bugs", () => {
+	test("API-03: getFilesWithProperty must include a note whose property value is falsy (false/0)", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("falsy-prop.md");
+		const result = await evalJsonAsync<{ found: boolean }>(
+			obsidian,
+			`
+			(async () => {
+				const api = app.plugins.plugins.${PLUGIN_ID}.api;
+				const path = ${JSON.stringify(notePath)};
+				let f = app.vault.getAbstractFileByPath(path);
+				const body = "---\\npublishedAudit: false\\n---\\nbody\\n";
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise(r => setTimeout(r, 400));
+				const found = api.getFilesWithProperty("publishedAudit").map(x => x.path).includes(path);
+				return { found };
+			})()
+		`,
+		);
+		// A note that DEFINES the key (value false) should be returned; presence, not truthiness.
+		expect(result.found).toBe(true);
+	});
+
+	test("API-07: getPropertiesInFile on an unresolved path returns an array, not undefined", async () => {
+		const { obsidian } = getContext();
+		const result = await evalJsonAsync<{ isArray: boolean; isUndefined: boolean }>(
+			obsidian,
+			`
+			(async () => {
+				const api = app.plugins.plugins.${PLUGIN_ID}.api;
+				const r = await api.getPropertiesInFile("does-not-exist-audit-xyz.md");
+				return { isArray: Array.isArray(r), isUndefined: r === undefined };
+			})()
+		`,
+		);
+		// Declared Promise<Property[]>; a caller iterating the result must not crash.
+		expect(result.isArray).toBe(true);
+		expect(result.isUndefined).toBe(false);
+	});
+
+	test("API-02: updating an inline field in a CRLF note preserves CRLF line endings", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("crlf-inline.md");
+		const result = await evalJsonAsync<{ crBefore: number; crAfter: number; content: string }>(
+			obsidian,
+			`
+			(async () => {
+				const api = app.plugins.plugins.${PLUGIN_ID}.api;
+				const path = ${JSON.stringify(notePath)};
+				let f = app.vault.getAbstractFileByPath(path);
+				const body = "line one\\r\\nfield:: one\\r\\nline three\\r\\n";
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise(r => setTimeout(r, 400));
+				const crBefore = (await app.vault.read(f)).split("\\r").length - 1;
+				await api.update("field", "two", f);
+				await new Promise(r => setTimeout(r, 250));
+				const content = await app.vault.read(f);
+				const crAfter = content.split("\\r").length - 1;
+				return { crBefore, crAfter, content };
+			})()
+		`,
+		);
+		// The edit changed the value; line endings should remain CRLF throughout.
+		expect(result.content).toContain("field:: two");
+		expect(result.crAfter).toBe(result.crBefore);
+	});
+});


### PR DESCRIPTION
Part of the end-to-end audit. Fixes four code-derived defects in the core read/write path and public API, each reproduced live in the isolated Obsidian E2E harness before the fix and covered by a new regression test.

## Fixes

**`getActiveMarkdownFile` threw on no active file (`utility.ts`)**
It called `this.logError(...)` from a plain exported function, so `this` was `undefined` and the `MetaEdit: Run` command threw `TypeError: this.logError is not a function` (an unhandled rejection) whenever it ran with no active markdown file. Now routes through the real logger and returns `null`, so the command cleanly no-ops.

**`deleteProperty` corrupted block-style YAML and bypassed the write queue (`metaController.ts`)**
Deleting a property stripped only the matching `key:` line via regex. For a multi-line block value (e.g. a `tags:` list rendered as `- a` / `- b`), it orphaned the value lines and corrupted the frontmatter. It also ran outside the per-file write queue, so it could race a queued write. Top-level YAML keys are now deleted via `processFrontMatter` inside `enqueueFileWrite` (block values removed whole); the inline/Dataview fallback stays line-based and CRLF-safe.

**`getFilesWithProperty` excluded falsy values (`main.ts`)**
Used a truthy check (`fileFrontmatter[property]`), silently dropping notes whose property value is `false`, `0`, `""`, or `null`. Now matches on key presence (`hasOwnProperty`).

**`getPropertiesInFile` returned `undefined` for an unresolved path (`MetaEditApi.ts`)**
Despite its `Promise<Property[]>` contract, it returned `undefined` for a bad path, crashing callers that iterate the result. Now returns `[]`.

## Testing
- `pnpm run lint && pnpm run build && pnpm run test` green (287 unit).
- New live E2E regression coverage: `tests/e2e/audit-repro.test.ts`, `tests/e2e/audit-api.test.ts`, `tests/e2e/audit-repro2.test.ts` (the last also confirms CRLF line endings are preserved across inline updates - a refuted candidate bug).
- Verified live on desktop (isolated worktree Obsidian) and on Android 15 / Obsidian 1.12.7 via CDP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/metaedit/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->