### PR TITLE
fix(automators): count only [x]/[X] tasks complete; null-guard Kanban lane display

### DIFF
--- a/src/Modals/KanbanHelperSetting/KanbanHelperSettingContent.svelte
+++ b/src/Modals/KanbanHelperSetting/KanbanHelperSettingContent.svelte
@@ -68,7 +68,7 @@
             return "FILE NOT FOUND";
         }
 
-        const headings = initialApp.metadataCache.getFileCache(file).headings;
+        const headings = initialApp.metadataCache.getFileCache(file)?.headings;
         if (!headings) return "";
 
         return headings.map(heading => heading.heading).join(", ");

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -213,7 +213,10 @@ export default class MetaController {
             let total: number = 0, complete: number = 0, incomplete: number = 0;
 
             total = tasks.length;
-            complete = tasks.filter(i => i.task != " ").length;
+            // Only a checked task ([x]/[X]) counts as complete. Custom markers like
+            // [/] in-progress, [-] cancelled, [>] forwarded or [?] are NOT complete;
+            // counting every non-blank marker as complete over-reported progress.
+            complete = tasks.filter(i => (i.task ?? "").toLowerCase() === "x").length;
             incomplete = total - complete;
 
             const props = await this.progressPropHelper(properties, meta, {total, complete, incomplete});

--- a/tests/e2e/audit-gaps.test.ts
+++ b/tests/e2e/audit-gaps.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID } from "./harness";
+import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID, WAIT_OPTS } from "./harness";
 
 const getContext = createMetaEditE2EHarness("audit-gaps");
 
@@ -98,9 +98,11 @@ describe("MetaEdit audit gap coverage", () => {
 				plugin.toggleAutomators();
 			})()
 		`);
-		const content = await evalJsonAsync<string>(
-			obsidian,
-			`(async () => app.vault.read(app.vault.getAbstractFileByPath(${JSON.stringify(notePath)})))()`,
+		// Read the result through the sandbox API (no eval-string construction).
+		const content = await sandbox.waitForContent(
+			"drawing.excalidraw.md",
+			(v) => v.includes("taskCount"),
+			WAIT_OPTS,
 		);
 		// taskCount stays 0: the Excalidraw frontmatter key makes the automator skip it.
 		expect(content).toContain("taskCount: 0");

--- a/tests/e2e/audit-gaps.test.ts
+++ b/tests/e2e/audit-gaps.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "vitest";
+import { createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID } from "./harness";
+
+const getContext = createMetaEditE2EHarness("audit-gaps");
+
+describe("MetaEdit audit gap coverage", () => {
+	test("AUTO-01: with Auto Properties disabled, autoprop() returns null and opens no modal", async () => {
+		const { obsidian } = getContext();
+		const result = await evalJsonAsync<{ resultWhenDisabled: unknown; modalOpened: boolean }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const prevEnabled = plugin.settings.AutoProperties.enabled;
+				const prevProps = plugin.settings.AutoProperties.properties;
+				plugin.settings.AutoProperties.enabled = false;
+				plugin.settings.AutoProperties.properties = [{ name: "mood", choices: ["good", "bad"] }];
+				try {
+					const before = document.querySelectorAll(".modal").length;
+					const r = await plugin.api.autoprop("mood");
+					await new Promise(res => setTimeout(res, 150));
+					const after = document.querySelectorAll(".modal").length;
+					return { resultWhenDisabled: r, modalOpened: after > before };
+				} finally {
+					plugin.settings.AutoProperties.enabled = prevEnabled;
+					plugin.settings.AutoProperties.properties = prevProps;
+				}
+			})()
+		`,
+		);
+		expect(result.resultWhenDisabled).toBeNull();
+		expect(result.modalOpened).toBe(false);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("RUN-08: duplicate body #tags are disambiguated with line and ordinal in the suggester", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("dup-tags.md");
+		const labels = await evalJsonAsync<string[]>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const path = ${JSON.stringify(notePath)};
+				let f = app.vault.getAbstractFileByPath(path);
+				const body = "First #dup here.\\nSecond #dup there.\\n";
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				// Wait for tag spans to validate against disk.
+				for (let i = 0; i < 60; i++) {
+					await new Promise(r => setTimeout(r, 50));
+					const props = await plugin.controller.getPropertiesInFile(f);
+					const tags = props.filter(p => p.type === 2 && p.key === "#dup");
+					if (tags.length === 2 && tags.every(t => t.position && body.slice(t.position.start, t.position.end) === t.key)) break;
+				}
+				// Open the real suggester and read the disambiguated row labels from the DOM.
+				await plugin.runMetaEditForFile(f);
+				const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+				let items = [];
+				for (let i = 0; i < 60; i++) {
+					await sleep(80);
+					items = Array.from(document.querySelectorAll(".suggestion-item"));
+					if (items.length) break;
+				}
+				const texts = items.map(el => ((el.querySelector(".suggestion-item-text") || el).textContent || "").trim());
+				app.workspace.activeModal?.close?.();
+				for (const el of Array.from(document.querySelectorAll(".suggestion-container, .suggestion-item"))) el.remove();
+				return texts.filter(t => t.startsWith("#dup"));
+			})()
+		`,
+		);
+		// Each occurrence is labelled with its line and ordinal (1/2 and 2/2).
+		expect(labels.length).toBe(2);
+		expect(labels.some((t) => /1\/2/.test(t))).toBe(true);
+		expect(labels.some((t) => /2\/2/.test(t))).toBe(true);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("PROG-04: Excalidraw files are skipped by the on-modify automators", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("drawing.excalidraw.md");
+		// Drive the automator with dev.eval (toggleAutomators may log, which would
+		// break evalJsonAsync), then read the file with a clean eval.
+		await obsidian.dev.eval(`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const path = ${JSON.stringify(notePath)};
+				let f = app.vault.getAbstractFileByPath(path);
+				const body = "---\\nexcalidraw-plugin: parsed\\ntaskCount: 0\\n---\\n# Tasks\\n- [ ] one\\n- [x] two\\n";
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise(r => setTimeout(r, 400));
+				plugin.settings.ProgressProperties.enabled = true;
+				plugin.settings.ProgressProperties.properties = [{ name: "taskCount", type: "Total Tasks" }];
+				plugin.toggleAutomators();
+				await app.vault.modify(f, body + "more body\\n");
+				await new Promise(r => setTimeout(r, 1400));
+				plugin.settings.ProgressProperties.enabled = false;
+				plugin.settings.ProgressProperties.properties = [];
+				plugin.toggleAutomators();
+			})()
+		`);
+		const content = await evalJsonAsync<string>(
+			obsidian,
+			`(async () => app.vault.read(app.vault.getAbstractFileByPath(${JSON.stringify(notePath)})))()`,
+		);
+		// taskCount stays 0: the Excalidraw frontmatter key makes the automator skip it.
+		expect(content).toContain("taskCount: 0");
+		expect(content).not.toMatch(/taskCount: "?2"?/);
+	});
+
+	test("YAML-06: updateMultipleInFile writes nested YAML paths without creating new keys", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("multi-nested.md");
+		const result = await evalJsonAsync<{ cache: Record<string, unknown> }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const path = ${JSON.stringify(notePath)};
+				let f = app.vault.getAbstractFileByPath(path);
+				const body = "---\\nmeta:\\n  a: 1\\n  b: 2\\n---\\nbody\\n";
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise(r => setTimeout(r, 300));
+				// Build nested-path Property objects (existing leaves) and write in one batch.
+				const props = [
+					{ key: "meta.a", content: "10", type: 0, path: ["meta", "a"], rootKey: "meta", isNested: true },
+					{ key: "meta.b", content: "20", type: 0, path: ["meta", "b"], rootKey: "meta", isNested: true },
+				];
+				await plugin.controller.updateMultipleInFile(props, f);
+				await new Promise(r => setTimeout(r, 300));
+				return { cache: app.metadataCache.getFileCache(f)?.frontmatter ?? {} };
+			})()
+		`,
+		);
+		// Both existing nested leaves are updated in a single batched frontmatter write
+		// (values written verbatim as the strings provided).
+		expect(result.cache.meta).toEqual({ a: "10", b: "20" });
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("PROG-03: only [x]/[X] tasks count as complete; custom markers count as incomplete", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("task-counts.md");
+		const result = await evalJsonAsync<{ done: unknown; todo: unknown; total: unknown }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const path = ${JSON.stringify(notePath)};
+				let f = app.vault.getAbstractFileByPath(path);
+				const body = "---\\ndone: 0\\ntodo: 0\\ntotal: 0\\n---\\n- [ ] a\\n- [x] b\\n- [/] c\\n- [-] d\\n- [X] e\\n";
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				// Wait for the listItems/tasks cache to populate.
+				for (let i = 0; i < 60; i++) {
+					await new Promise(r => setTimeout(r, 50));
+					const li = app.metadataCache.getFileCache(f)?.listItems?.filter(x => x.task);
+					if (li && li.length === 5) break;
+				}
+				const prevEnabled = plugin.settings.ProgressProperties.enabled;
+				plugin.settings.ProgressProperties.enabled = true;
+				plugin.settings.ProgressProperties.properties = [
+					{ name: "done", type: "Completed Tasks" },
+					{ name: "todo", type: "Incomplete Tasks" },
+					{ name: "total", type: "Total Tasks" },
+				];
+				try {
+					const props = await plugin.controller.getPropertiesInFile(f);
+					await plugin.controller.handleProgressProps(props, f);
+					await new Promise(r => setTimeout(r, 300));
+					const fm = app.metadataCache.getFileCache(f)?.frontmatter ?? {};
+					return { done: fm.done, todo: fm.todo, total: fm.total };
+				} finally {
+					plugin.settings.ProgressProperties.enabled = prevEnabled;
+					plugin.settings.ProgressProperties.properties = [];
+				}
+			})()
+		`,
+		);
+		// [x] b and [X] e are complete (2); [ ] a, [/] c, [-] d are incomplete (3); total 5.
+		expect(String(result.done)).toBe("2");
+		expect(String(result.todo)).toBe("3");
+		expect(String(result.total)).toBe("5");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("BULK-05: merge policy appends uniquely into a list and is idempotent", async () => {
+		const { obsidian, sandbox } = getContext();
+		const result = await evalJsonAsync<{ first: unknown; second: unknown }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const dir = ${JSON.stringify(sandbox.path("bulk-merge"))};
+				const path = dir + "/note.md";
+				if (!app.vault.getAbstractFileByPath(dir)) await app.vault.createFolder(dir).catch(() => {});
+				let f = app.vault.getAbstractFileByPath(path);
+				const body = "---\\ntags: [a, b]\\n---\\nbody\\n";
+				if (f) { await app.vault.modify(f, body); } else { f = await app.vault.create(path, body); }
+				await new Promise(r => setTimeout(r, 300));
+				const files = [f];
+				// merge "b" (dup) and "c" (new) into the existing list.
+				await plugin.bulkEditor.apply(files, "tags", "b", "merge");
+				await plugin.bulkEditor.apply(files, "tags", "c", "merge");
+				await new Promise(r => setTimeout(r, 200));
+				const first = app.metadataCache.getFileCache(f)?.frontmatter?.tags;
+				// Re-run "c": should not duplicate (idempotent).
+				await plugin.bulkEditor.apply(files, "tags", "c", "merge");
+				await new Promise(r => setTimeout(r, 200));
+				const second = app.metadataCache.getFileCache(f)?.frontmatter?.tags;
+				return { first, second };
+			})()
+		`,
+		);
+		expect(result.first).toEqual(["a", "b", "c"]);
+		expect(result.second).toEqual(["a", "b", "c"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+});


### PR DESCRIPTION
Part of the end-to-end audit. Two automator/helper fixes, each reproduced live before the fix.

## Fixes

**Progress Properties over-counted completed tasks (`metaController.ts`)**
The "Completed Tasks" count treated every non-blank checkbox marker as complete, so custom states - `[/]` in progress, `[-]` cancelled, `[>]` forwarded, `[?]` - inflated the completed count. Now only checked-done tasks (`[x]`/`[X]`) count as complete; all other markers are incomplete. (Product decision confirmed with the maintainer: only `[x]`/`[X]` = complete.)

**Kanban settings panel could crash on a null cache (`KanbanHelperSettingContent.svelte`)**
`getHeadingsInBoard` called `getFileCache(file).headings` with no null check, so a board whose metadata cache was momentarily null threw and broke the Kanban settings panel render. Now uses optional chaining (the existing `!headings` guard handles the rest).

## Testing
- `pnpm run lint && pnpm run build && pnpm run test` green (287 unit).
- New live E2E `tests/e2e/audit-gaps.test.ts` includes a PROG-03 case (`[x]`/`[X]` => done=2, others => incomplete=2) plus gap coverage for AUTO-01, RUN-08, PROG-04 (Excalidraw skip), YAML-06, BULK-05. Kanban lane display + null-safety verified in the audit modal suite.
- Verified live on desktop and on Android 15 / Obsidian 1.12.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/metaedit/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->