### PR TITLE
fix(bulk): serialize bulk frontmatter writes through the controller write queue

### DIFF
--- a/src/bulk/bulkMetadata.ts
+++ b/src/bulk/bulkMetadata.ts
@@ -2,9 +2,10 @@
  * Pure decision logic for applying a single YAML frontmatter property across a
  * set of notes. This module is intentionally free of any Obsidian dependency so
  * it can be unit-tested in the jsdom-free node environment, and so the
- * read-decide-write step can run atomically inside
- * `app.fileManager.processFrontMatter` (the same safe frontmatter primitive the
- * controller write path uses) - never against the eventually-consistent
+ * read-decide-write step can run atomically inside a single
+ * `processFrontMatter` callback - dispatched through the controller's per-file
+ * write queue (`MetaController.enqueueFrontmatterWrite`) so it serializes with
+ * every other MetaEdit write to the note - never against the eventually-consistent
  * metadata cache.
  */
 

--- a/src/bulk/bulkMetadataEditor.test.ts
+++ b/src/bulk/bulkMetadataEditor.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TFile } from "obsidian";
+
+// MetaController and BulkMetadataEditor transitively import Svelte-backed modals
+// (and BulkOptionModal extends obsidian's Modal), which the node test environment
+// cannot transform. None of those are touched by the write paths under test, so
+// replace the modal modules with light stubs to keep this suite jsdom-free
+// (mirrors metaController.test.ts).
+vi.mock("../Modals/GenericPrompt/GenericPrompt", () => ({ default: { Prompt: vi.fn() } }));
+vi.mock("../Modals/GenericSuggester/GenericSuggester", () => ({ default: { Suggest: vi.fn() } }));
+vi.mock("../Modals/AutoPropertyValueModal/AutoPropertyValueModal", () => ({ default: { Show: vi.fn() } }));
+vi.mock("./BulkOptionModal", () => ({ BulkOptionModal: { Choose: vi.fn() } }));
+
+import MetaController from "../metaController";
+import { BulkMetadataEditor } from "./bulkMetadataEditor";
+import { EditMode } from "../Types/editMode";
+
+/**
+ * Proves the deepsec finding `other-write-serialization-race`: bulk frontmatter
+ * writes now run through the controller's per-file write queue
+ * (`MetaController.enqueueFrontmatterWrite` -> `enqueueFileWrite`), so a bulk
+ * `processFrontMatter` write can no longer race - and lose to - a controller
+ * `vault.read`+`vault.modify` whole-file write to the SAME note.
+ *
+ * The race partner is a REAL whole-file controller write (`appendDataviewField`,
+ * which Obsidian does not serialize against a bare `processFrontMatter`), not a
+ * YAML/`processFrontMatter` path that would already be safe. Each test uses a
+ * unique path so the module-level `fileWriteQueues` map never leaks state across
+ * tests, and every gate is released so each queue fully drains.
+ */
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+// Minimal but faithful frontmatter <-> string round-trip for the in-memory vault:
+// `processFrontMatter` mutates the parsed object, the inline/whole-file path edits
+// the raw string, and both share one content store - exactly the two write
+// primitives that race in production.
+function parseContent(content: string): { fm: Record<string, unknown>; body: string } {
+	const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+	if (!match) return { fm: {}, body: content };
+
+	const fm: Record<string, unknown> = {};
+	for (const line of match[1].split("\n")) {
+		const idx = line.indexOf(":");
+		if (idx === -1) continue;
+		const key = line.slice(0, idx).trim();
+		if (!key) continue;
+		fm[key] = line.slice(idx + 1).trim();
+	}
+	return { fm, body: match[2] };
+}
+
+function serializeContent(fm: Record<string, unknown>, body: string): string {
+	const lines = Object.entries(fm).map(([key, value]) => `${key}: ${String(value)}`);
+	return `---\n${lines.join("\n")}\n---\n${body}`;
+}
+
+type Harness = {
+	app: any;
+	plugin: any;
+	controller: MetaController;
+	bulkEditor: BulkMetadataEditor;
+	files: Map<string, { content: string }>;
+	/** Paths whose `processFrontMatter` callback (the bulk write) has started. */
+	fmStarted: string[];
+	/** Optional hook run before each `vault.modify`, used to gate a controller write. */
+	hooks: { beforeModify?: (file: TFile, content: string) => Promise<void> | void };
+};
+
+function makeHarness(initial: Record<string, string>): Harness {
+	const files = new Map<string, { content: string }>();
+	for (const [path, content] of Object.entries(initial)) files.set(path, { content });
+
+	const fmStarted: string[] = [];
+	const hooks: Harness["hooks"] = {};
+
+	const app: any = {
+		plugins: { plugins: {} },
+		vault: {
+			read: async (file: TFile) => files.get(file.path)!.content,
+			cachedRead: async (file: TFile) => files.get(file.path)!.content,
+			modify: async (file: TFile, content: string) => {
+				if (hooks.beforeModify) await hooks.beforeModify(file, content);
+				files.get(file.path)!.content = content;
+			},
+		},
+		fileManager: {
+			processFrontMatter: async (file: TFile, fn: (fm: Record<string, unknown>) => void) => {
+				fmStarted.push(file.path);
+				const store = files.get(file.path)!;
+				const { fm, body } = parseContent(store.content);
+				fn(fm);
+				store.content = serializeContent(fm, body);
+			},
+		},
+	};
+
+	const plugin: any = {
+		app,
+		settings: { EditMode: { mode: EditMode.AllSingle, properties: [] as string[] } },
+	};
+	const controller = new MetaController(app, plugin);
+	plugin.controller = controller;
+	const bulkEditor = new BulkMetadataEditor(app, plugin);
+
+	return { app, plugin, controller, bulkEditor, files, fmStarted, hooks };
+}
+
+/**
+ * Park a controller whole-file write (`appendDataviewField`) at its `vault.modify`
+ * step (its stale snapshot already read), then start a bulk frontmatter write to
+ * the same note. Snapshot whether the bulk write has begun while the controller is
+ * still parked, release the gate, and return the drained result. Uses bounded
+ * `tick()`s and an unconditional release so it never blocks on bulk completing -
+ * which post-fix cannot happen until the gate opens (it is queued behind).
+ */
+async function runGatedRace(harness: Harness, file: TFile) {
+	let releaseModify!: () => void;
+	const modifyGate = new Promise<void>((resolve) => {
+		releaseModify = resolve;
+	});
+	// One-shot: gate only the first modify (the controller's), then step aside.
+	harness.hooks.beforeModify = async () => {
+		harness.hooks.beforeModify = undefined;
+		await modifyGate;
+	};
+
+	const pController = harness.controller.appendDataviewField("reviewed", "yes", file, {
+		location: "end",
+	});
+	await tick(); // controller reads its snapshot and parks at the modify gate
+
+	const pBulk = harness.bulkEditor.apply([file], "status", "draft", "skip");
+	await tick(); // post-fix: bulk is queued; pre-fix: bulk's write already ran
+
+	const bulkStartedWhileParked = harness.fmStarted.includes(file.path);
+	releaseModify();
+	const [, summary] = await Promise.all([pController, pBulk]);
+
+	return {
+		bulkStartedWhileParked,
+		summary,
+		finalContent: harness.files.get(file.path)!.content,
+	};
+}
+
+describe("BulkMetadataEditor serialization through the controller write queue", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("queues the bulk frontmatter write behind an in-flight controller write to the same note", async () => {
+		const path = "race-order.md";
+		const harness = makeHarness({ [path]: "---\ntitle: Note\n---\nbody\n" });
+
+		const result = await runGatedRace(harness, new TFile(path));
+
+		// The bulk write must NOT have begun while the controller write held the
+		// queue. Pre-fix (direct processFrontMatter, unqueued) this is true and the
+		// assertion fails - which is the regression this proves.
+		expect(result.bulkStartedWhileParked).toBe(false);
+		// Once the controller write completes, the bulk write runs.
+		expect(harness.fmStarted).toContain(path);
+	});
+
+	it("does not lose the bulk frontmatter change when it races a controller whole-file write", async () => {
+		const path = "race-loss.md";
+		const harness = makeHarness({ [path]: "---\ntitle: Note\n---\nbody\n" });
+
+		const result = await runGatedRace(harness, new TFile(path));
+
+		// Both writes survive: the controller's appended inline field AND the bulk
+		// frontmatter property. Pre-fix the controller's stale snapshot overwrites
+		// and silently drops `status: draft`.
+		expect(result.finalContent).toContain("status: draft");
+		expect(result.finalContent).toContain("reviewed:: yes");
+		expect(result.summary.added).toBe(1);
+	});
+
+	it("isolates a failing bulk write and keeps the per-file queue usable for the next write", async () => {
+		const path = "race-error.md";
+		const harness = makeHarness({ [path]: "---\ntitle: Note\n---\nbody\n" });
+		const file = new TFile(path);
+
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		// The queued bulk write rejects. enqueueFileWrite must still propagate the
+		// failure to apply's per-file guard AND clean up the queue entry so the next
+		// write to the same path is not poisoned by the rejection.
+		harness.app.fileManager.processFrontMatter = vi.fn(async () => {
+			throw new Error("boom");
+		});
+
+		const summary = await harness.bulkEditor.apply([file], "status", "draft", "skip");
+
+		expect(summary.failed).toBe(1);
+		expect(summary.failures).toEqual([{ path, error: "boom" }]);
+		expect(warn).toHaveBeenCalledTimes(1);
+
+		// A subsequent same-file controller write still runs to completion, proving
+		// the queue recovered from the rejected bulk write.
+		await harness.controller.appendDataviewField("reviewed", "yes", file, { location: "end" });
+		expect(harness.files.get(path)!.content).toContain("reviewed:: yes");
+	});
+});

--- a/src/bulk/bulkMetadataEditor.ts
+++ b/src/bulk/bulkMetadataEditor.ts
@@ -17,12 +17,18 @@ import {
  * Drives the bulk "add/update a YAML property across many notes" flow shared by
  * the folder context-menu item and the multi-select (`files-menu`) item.
  *
- * Writes go through Obsidian's `app.fileManager.processFrontMatter` - the exact
- * frontmatter primitive the rewritten controller write path is built on (see
- * metaController.processFrontMatter) - never hand-rolled YAML text edits. The
- * read, the conflict decision, and the write all happen inside a single
- * processFrontMatter callback per note, so each note's decision is made against
- * its live frontmatter rather than the lazily-updated metadata cache.
+ * Writes go through `MetaController.enqueueFrontmatterWrite`, which wraps
+ * Obsidian's `app.fileManager.processFrontMatter` in the controller's per-file
+ * write queue (`enqueueFileWrite`, keyed by normalized path). Routing through the
+ * queue is what makes bulk safe: Obsidian only serializes processFrontMatter
+ * against another processFrontMatter, so a bare bulk write could otherwise be lost
+ * when it raced a controller `vault.read`+`vault.modify` whole-file edit to the
+ * same note (a concurrent public-API write, or a user-invoked Edit-Meta command).
+ * On the queue, bulk serializes with every other MetaEdit controller/API write to
+ * that note (not arbitrary third-party vault writes MetaEdit never sees). The read,
+ * the conflict decision, and the write still all happen inside a single
+ * processFrontMatter callback per note, so each note's decision is made against its
+ * live frontmatter rather than the lazily-updated metadata cache.
  */
 export class BulkMetadataEditor {
 	constructor(private app: App, private plugin: MetaEdit) {}
@@ -170,7 +176,11 @@ export class BulkMetadataEditor {
 	): Promise<BulkOutcome> {
 		let outcome: BulkOutcome = "skipped";
 
-		await this.app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+		// Serialize through the controller's per-file write queue so this write is
+		// never lost to a concurrent controller `vault.read`+`vault.modify` edit to
+		// the same note (see the module docstring). The decision is still made
+		// against live frontmatter inside the single processFrontMatter callback.
+		await this.plugin.controller.enqueueFrontmatterWrite(file, (frontmatter: Record<string, unknown>) => {
 			const exists = Object.prototype.hasOwnProperty.call(frontmatter, key);
 			const decision = decideBulkWrite({
 				exists,

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -682,6 +682,26 @@ export default class MetaController {
         });
     }
 
+    /**
+     * Run a `processFrontMatter` mutation serialized through this file's write
+     * queue, so it interleaves safely with every other MetaEdit write to the same
+     * file (the inline/tag `vault.read`+`vault.modify` paths in particular, which
+     * Obsidian does NOT serialize against a bare `processFrontMatter`). This is the
+     * queue-aware entry point for collaborators that compute and apply a frontmatter
+     * change in one callback - e.g. the bulk editor - rather than reimplementing the
+     * queue.
+     *
+     * Internal: reachable via the public `plugin.controller` but NOT part of the
+     * `IMetaEditApi` contract; treat it as a controller-internal escape hatch. The
+     * `update` callback runs at the top of the queue and MUST NOT itself enqueue
+     * another write to the same file (e.g. call back into a queued controller
+     * method), because that inner write would chain behind this one's still-pending
+     * promise and deadlock.
+     */
+    public async enqueueFrontmatterWrite(file: TFile, update: (frontmatter: Record<string, unknown>) => void): Promise<void> {
+        await this.enqueueFileWrite(file, () => this.processFrontMatter(file, update));
+    }
+
     private async processFrontMatter(file: TFile, update: (frontmatter: Record<string, unknown>) => void): Promise<void> {
         await this.app.fileManager.processFrontMatter(file, update);
     }


### PR DESCRIPTION
## Summary

`BulkMetadataEditor.applyToFile` wrote frontmatter via `app.fileManager.processFrontMatter` **directly**, bypassing `MetaController`'s per-file write queue (`enqueueFileWrite`, keyed by `normalizePath(file.path)`) that serializes every other MetaEdit write to a note (the inline/tag `vault.read`+`vault.modify` paths, `appendDataviewField`, `updateMultipleInFile`, the public API writes).

Obsidian only serializes `processFrontMatter` against another `processFrontMatter`, so bulk-vs-bulk and bulk-vs-controller-YAML were already safe. The **unguarded** case was bulk's `processFrontMatter` racing a controller `vault.read`+`vault.modify` whole-file write to the *same* note: the controller computes whole-file content from a snapshot read taken **before** bulk's write, so if its `modify` lands after bulk's `processFrontMatter`, it overwrites with stale content and **silently drops bulk's frontmatter change** (lost update - the codebase's top-ranked data-integrity risk).

Realistic triggers (not malicious-content reachable; this is a latent data-integrity bug, not a security hole):
- a concurrent public-API write (`MetaEditApi.update` / `appendDataviewField`) from another plugin during a bulk run, or
- a user-invoked Edit-Meta command during bulk's I/O window.

## Fix

Route bulk's write through a new `MetaController.enqueueFrontmatterWrite(file, update)`, which wraps the private `processFrontMatter` in the private `enqueueFileWrite`. Bulk now participates in the shared per-file queue, so its frontmatter write serializes against all other MetaEdit controller/API writes to that note.

- The read, the conflict decision (`decideBulkWrite`), and the write **still** all happen inside a single `processFrontMatter` callback per note - per-note atomicity and the live-frontmatter decision are unchanged. Only the *write* becomes queue-serialized.
- The new method is documented as an **internal, non-reentrant** queue entry point (reachable via the public `plugin.controller` but **not** part of the `IMetaEditApi` contract; the `update` callback must not enqueue another same-file write or it would deadlock).
- Fixes two module docstrings (`bulkMetadataEditor.ts`, `bulkMetadata.ts`) that claimed parity with the controller's frontmatter primitive while omitting that the controller wraps every such write in `enqueueFileWrite`.

### Scope of the guarantee
This serializes **MetaEdit-controlled** writes (controller + public API). A third-party plugin doing its own `vault.read`+`vault.modify` directly can still race bulk - MetaEdit cannot queue writes it never sees. `countExisting` (the conflict-count preflight) remains intentionally advisory; the authoritative decision is made live inside the queued `processFrontMatter` callback, and the overwrite confirmation is already framed against the selection size, not the cache-derived count.

### Considered and deferred
Extracting a standalone `FileWriteQueue` collaborator injected into both `MetaController` and `BulkMetadataEditor` (raised in design review) - a reasonable future refactor, but it widens the blast radius (construction wiring, API surface, tests) beyond this focused data-integrity fix. The controller method is the minimal correct change.

## Tests

New `src/bulk/bulkMetadataEditor.test.ts` - deterministic, gated, racing a bulk frontmatter write against a **real** controller `vault.read`+`vault.modify` write (`appendDataviewField`) on the same note (unique path per test so the module-level queue never leaks across tests):

1. **queues the bulk write behind an in-flight controller write to the same note** (serialization/ordering).
2. **does not lose the bulk frontmatter change when it races a controller whole-file write** (the lost-update regression - reproduces the literal data loss).
3. **isolates a failing bulk write and keeps the per-file queue usable for the next write** (error propagation + queue recovery via `enqueueFileWrite`'s `previous.catch` + `finally` cleanup).

Tests 1 and 2 **fail before this change** and pass after (verified by temporarily reverting the write to the direct unqueued call).

## Verification

- `pnpm run lint` - clean
- `pnpm run build` (typecheck + svelte-check + bundle) - clean
- `pnpm run test` - 290 passed (incl. the 3 new tests)
- **Live, isolated Obsidian E2E** (worktree vault, then `pnpm run stop:e2e-obsidian`): ran bulk edits across several notes - `skip` correctly skipped a note that already had the key; `merge` seeded a list; and a **concurrent bulk frontmatter write + controller `appendDataviewField` whole-file write to the same note both landed** (`phase: one` in frontmatter **and** `reviewed:: yes` in the body) - no lost update.

## Notes

Addresses deepsec finding `other-write-serialization-race` (BUG / data-integrity). There is no GitHub issue for this finding.