### PR TITLE
fix(bulk): reject __proto__/constructor as a bulk property key

### DIFF
--- a/src/bulk/bulkMetadata.test.ts
+++ b/src/bulk/bulkMetadata.test.ts
@@ -5,6 +5,7 @@ import {
 	decideBulkWrite,
 	emptySummary,
 	formatSummary,
+	isReservedFrontmatterKey,
 	recordOutcome,
 	toArray,
 	uniqueConcat,
@@ -46,6 +47,28 @@ describe("decideBulkWrite - add (key missing)", () => {
 			value: ["draft"],
 			outcome: "added",
 		});
+	});
+});
+
+describe("isReservedFrontmatterKey", () => {
+	it("flags the object-machinery keys that alias prototype slots", () => {
+		for (const key of ["__proto__", "constructor", "prototype"]) {
+			expect(isReservedFrontmatterKey(key)).toBe(true);
+		}
+	});
+
+	it("leaves ordinary keys alone, matching exactly (no trim, no case-folding)", () => {
+		for (const key of [
+			"status",
+			"proto",
+			"__proto__x",
+			" __proto__ ", // padded literal is an ordinary key - it aliases nothing
+			"__Proto__", // case-sensitive: only the exact lowercase form aliases
+			"Constructor",
+			"",
+		]) {
+			expect(isReservedFrontmatterKey(key)).toBe(false);
+		}
 	});
 });
 

--- a/src/bulk/bulkMetadata.ts
+++ b/src/bulk/bulkMetadata.ts
@@ -12,6 +12,30 @@
 /** How to treat notes that already define the target property. */
 export type ConflictPolicy = "skip" | "overwrite" | "merge";
 
+/**
+ * Property names that alias JavaScript object machinery when assigned through a
+ * dynamic `frontmatter[key] = value`, so they can never be written as ordinary
+ * frontmatter keys:
+ *
+ *  - `__proto__` is an accessor inherited from `Object.prototype`. Assigning a
+ *    string (`frontmatter["__proto__"] = "x"`) is silently dropped - no own key
+ *    is created - while assigning an array/object (the `wrapInArray`/`merge`
+ *    cases that produce `[rawValue]`) mutates the object's prototype instead.
+ *    Either way the note is left unchanged, yet `hasOwnProperty` reports the key
+ *    absent up front, so the bulk summary would claim it was "added": the report
+ *    disagrees with what was written. This is the concrete bug being fixed.
+ *  - `constructor`/`prototype` do create a real own enumerable property today,
+ *    but it shadows the inherited slot. They are refused alongside `__proto__`
+ *    so a bulk write never produces object-machinery-aliasing keys - the
+ *    standard reserved-key set, applied uniformly.
+ *
+ * Matching is exact: a padded literal such as `" __proto__ "` is an ordinary key
+ * (it aliases nothing) and is intentionally left alone.
+ */
+export function isReservedFrontmatterKey(key: string): boolean {
+	return key === "__proto__" || key === "constructor" || key === "prototype";
+}
+
 /** What happened to a single note during a bulk apply. */
 export type BulkOutcome =
 	| "added"

--- a/src/bulk/bulkMetadataEditor.test.ts
+++ b/src/bulk/bulkMetadataEditor.test.ts
@@ -202,3 +202,64 @@ describe("BulkMetadataEditor serialization through the controller write queue", 
 		expect(harness.files.get(path)!.content).toContain("reviewed:: yes");
 	});
 });
+
+/**
+ * Proves the deepsec finding `other-proto-key-unguarded`: a reserved
+ * object-machinery key (`__proto__`/`constructor`/`prototype`) is refused rather
+ * than silently dropped (or prototype-mutated) while the summary claims it was
+ * added. The bulk write must never report success/added for such a key, and the
+ * note must be left byte-for-byte untouched.
+ */
+describe("BulkMetadataEditor reserved-key guard", () => {
+	const RESERVED = ["__proto__", "constructor", "prototype"];
+	const ORIGINAL = "---\ntitle: Note\n---\nbody\n";
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("rejects a reserved key at the public apply() boundary without touching any note", async () => {
+		for (const key of RESERVED) {
+			const path = `reserved-apply-${key}.md`;
+			const harness = makeHarness({ [path]: ORIGINAL });
+			const file = new TFile(path);
+
+			// apply() refuses the whole batch once - it rejects rather than returning
+			// a summary that overstates the refusal as N per-note write failures.
+			await expect(harness.bulkEditor.apply([file], key, "draft", "skip")).rejects.toThrow(
+				/reserved property name/,
+			);
+
+			// processFrontMatter was never invoked and the note is byte-for-byte intact.
+			expect(harness.fmStarted).not.toContain(path);
+			expect(harness.files.get(path)!.content).toBe(ORIGINAL);
+		}
+	});
+
+	it("fails closed at the applyToFile write boundary when called directly (bypassing apply)", async () => {
+		// TS `private` is not runtime-private and `plugin.bulkEditor` is public, so
+		// applyToFile is reachable on its own. The write-boundary guard must still
+		// keep "__proto__" from reaching `frontmatter[key] = ...`.
+		const path = "reserved-applyToFile.md";
+		const harness = makeHarness({ [path]: ORIGINAL });
+		const file = new TFile(path);
+
+		await expect(
+			(harness.bulkEditor as any).applyToFile(file, "__proto__", "draft", "skip", false),
+		).rejects.toThrow(/reserved property name/);
+
+		expect(harness.fmStarted).not.toContain(path);
+		expect(harness.files.get(path)!.content).toBe(ORIGINAL);
+	});
+
+	it("still writes an ordinary key normally", async () => {
+		const path = "reserved-normal-key.md";
+		const harness = makeHarness({ [path]: ORIGINAL });
+
+		const summary = await harness.bulkEditor.apply([new TFile(path)], "status", "draft", "skip");
+
+		expect(summary.added).toBe(1);
+		expect(summary.failed).toBe(0);
+		expect(harness.files.get(path)!.content).toContain("status: draft");
+	});
+});

--- a/src/bulk/bulkMetadataEditor.test.ts
+++ b/src/bulk/bulkMetadataEditor.test.ts
@@ -13,6 +13,7 @@ vi.mock("./BulkOptionModal", () => ({ BulkOptionModal: { Choose: vi.fn() } }));
 
 import MetaController from "../metaController";
 import { BulkMetadataEditor } from "./bulkMetadataEditor";
+import GenericPrompt from "../Modals/GenericPrompt/GenericPrompt";
 import { EditMode } from "../Types/editMode";
 
 /**
@@ -249,6 +250,24 @@ describe("BulkMetadataEditor reserved-key guard", () => {
 		).rejects.toThrow(/reserved property name/);
 
 		expect(harness.fmStarted).not.toContain(path);
+		expect(harness.files.get(path)!.content).toBe(ORIGINAL);
+	});
+
+	it("run() aborts on a reserved key before applying, so no summary can report it added", async () => {
+		// The original bug was the completion summary disagreeing with the write:
+		// "__proto__" was reported "added" though nothing landed. apply() is what
+		// produces that summary, so the interactive flow must never reach it.
+		const path = "reserved-run.md";
+		const harness = makeHarness({ [path]: ORIGINAL });
+		(GenericPrompt.Prompt as ReturnType<typeof vi.fn>).mockResolvedValueOnce("  __proto__  ");
+		const applySpy = vi.spyOn(harness.bulkEditor, "apply");
+
+		await harness.bulkEditor.run([new TFile(path)], "Folder");
+
+		// Trimmed to "__proto__", refused before the value prompt: apply (and thus
+		// any added/success summary) is never reached, and the note is untouched.
+		expect(GenericPrompt.Prompt).toHaveBeenCalledTimes(1); // key prompt only, no value prompt
+		expect(applySpy).not.toHaveBeenCalled();
 		expect(harness.files.get(path)!.content).toBe(ORIGINAL);
 	});
 

--- a/src/bulk/bulkMetadataEditor.ts
+++ b/src/bulk/bulkMetadataEditor.ts
@@ -10,6 +10,7 @@ import {
 	decideBulkWrite,
 	emptySummary,
 	formatSummary,
+	isReservedFrontmatterKey,
 	recordOutcome,
 } from "./bulkMetadata";
 
@@ -76,6 +77,15 @@ export class BulkMetadataEditor {
 		)?.trim();
 		if (!key) return;
 
+		// Refuse reserved object-machinery keys up front: writing them via the
+		// dynamic `frontmatter[key] = value` below would silently drop the change
+		// (or mutate the prototype) while the summary still claimed success. Abort
+		// with a clear Notice rather than prompting for a value we can never write.
+		if (isReservedFrontmatterKey(key)) {
+			new Notice(`MetaEdit: "${key}" is a reserved property name and can't be used.`);
+			return;
+		}
+
 		const rawValue = await GenericPrompt.Prompt(this.app, `Value for "${key}"`, "Value").catch(
 			() => null,
 		);
@@ -139,6 +149,12 @@ export class BulkMetadataEditor {
 		rawValue: string,
 		policy: ConflictPolicy,
 	): Promise<BulkSummary> {
+		// Reject a reserved key once for the whole batch, before any note is
+		// touched, so the result never disagrees with what was written. Doing this
+		// here (rather than letting each note fail individually) keeps one invalid
+		// argument from masquerading as N independent per-note write failures.
+		this.assertWritableKey(key);
+
 		const wrapInArray = this.wrapInArrayFor(key);
 		const summary = emptySummary(files.length);
 
@@ -174,6 +190,13 @@ export class BulkMetadataEditor {
 		policy: ConflictPolicy,
 		wrapInArray: boolean,
 	): Promise<BulkOutcome> {
+		// Defense in depth at the write boundary: `apply` already rejects reserved
+		// keys before the loop, but `applyToFile` is reachable on its own (TS
+		// `private` is not runtime-private and `plugin.bulkEditor` is public), so
+		// fail closed here too rather than letting a reserved key reach the
+		// `frontmatter[key] = ...` assignment below.
+		this.assertWritableKey(key);
+
 		let outcome: BulkOutcome = "skipped";
 
 		// Serialize through the controller's per-file write queue so this write is
@@ -245,6 +268,18 @@ export class BulkMetadataEditor {
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
 
 		return parsed as Record<string, unknown>;
+	}
+
+	/**
+	 * Throw if `key` is a reserved object-machinery name that cannot be written as
+	 * a frontmatter property (see `isReservedFrontmatterKey`). Centralizes the
+	 * refusal so the public `apply` boundary and the `applyToFile` write boundary
+	 * reject identically.
+	 */
+	private assertWritableKey(key: string): void {
+		if (isReservedFrontmatterKey(key)) {
+			throw new Error(`"${key}" is a reserved property name and cannot be written to frontmatter.`);
+		}
 	}
 
 	private wrapInArrayFor(key: string): boolean {


### PR DESCRIPTION
## Summary

The bulk "add/update a YAML property across many notes" flow wrote `frontmatter[key] = value` with a user-controlled `key` inside Obsidian's `processFrontMatter` callback. When the key is a reserved object-machinery name the bracket assignment doesn't behave like a normal key:

- `__proto__` is an accessor inherited from `Object.prototype`. Assigning a string (`frontmatter["__proto__"] = "x"`) is **silently dropped** - no own key is created - and assigning an array/object (the `wrapInArray`/`merge` cases that produce `[rawValue]`) **mutates the object's prototype** instead. Either way the note is left unchanged, yet `hasOwnProperty` reports the key absent up front, so `decideBulkWrite` labels the outcome `added` and the completion summary claims the note changed. **The report disagreed with what was written to disk.**
- `constructor`/`prototype` do create a real own enumerable property today, but it shadows the inherited slot.

Obsidian's YAML layer prevents real prototype pollution downstream, so this is a correctness/reporting (data-integrity) bug, not a security hole.

Addresses deepsec finding `other-proto-key-unguarded` (BUG / data-integrity, low). There is no GitHub issue for this.

## Changes

- **`isReservedFrontmatterKey(key)`** - new pure, exact-match predicate in `src/bulk/bulkMetadata.ts` (`__proto__` / `constructor` / `prototype`). Exact match: a padded literal like `" __proto__ "` aliases nothing and is left alone.
- **`run()`** - refuses a reserved key with a clear `Notice` and aborts *before* prompting for a value, so the interactive path never reaches a write it can't honor.
- **`apply()`** - rejects the whole batch **once**, before the per-note loop, so one invalid key never masquerades as N independent per-note write failures (and `apply([], "__proto__", …)` still signals rather than silently reporting "no changes").
- **`applyToFile()`** - fails closed at the actual write boundary as well. TS `private` is not runtime-private and `plugin.bulkEditor` is public, so `bulkEditor["applyToFile"](file, "__proto__", …)` is reachable directly; the guard keeps a reserved key from ever reaching `frontmatter[key] = …`.
- Refusal is centralized in a private `assertWritableKey` helper shared by both boundaries.
- Regression tests: pure predicate coverage; `apply()` rejects each reserved key and leaves the note byte-for-byte intact; the `applyToFile` direct-bypass also fails closed; an ordinary key still writes and reports `added`.

`constructor`/`prototype` write a real own property today, so refusing them is a small, deliberate behavior change (you can no longer *bulk*-edit a property literally named `constructor`/`prototype`). They're refused alongside `__proto__` so a bulk write never produces object-machinery-aliasing keys - the standard reserved-key set, applied uniformly. The downside is negligible (single-note editing and Obsidian's native properties UI are unaffected) and the user gets a clear Notice rather than silent weirdness.

## Design review

The design was run through an adversarial review (opposing-model reviewers, three lenses) before coding. Two corrections were adopted: (1) guard the **write boundary** (`applyToFile`), not just the caller - TS `private` isn't runtime-private; (2) reject **once** at `apply()` rather than fanning one invalid key into N synthetic per-note "failed" entries. The reviewers also flagged that the same dynamic-key assignment exists in the single-note controller paths (`createYamlProperty`, `updatePropertyInFile`); that is intentionally **out of scope** here (the finding is scoped to `src/bulk/`) and is a candidate follow-up.

## Testing / validation

- `pnpm run lint` - clean.
- `pnpm run build` (tsc + svelte-check + esbuild) - clean.
- `pnpm run test` - 295 passing.
- **Live Obsidian (isolated E2E vault via the worktree harness):** a raw `processFrontMatter` `__proto__` assignment is confirmed silently dropped (the premise); the fixed bulk apply rejects `__proto__`, leaving the note byte-for-byte intact, while an ordinary key still writes:

  ```json
  {"rawProtoSilentlyDropped":true,"bulkProtoRejected":true,
   "rejectErr":"\"__proto__\" is a reserved property name and cannot be written to frontmatter.",
   "bulkProtoNoteUntouched":true,"normalKeyAdded":1,"normalKeyWritten":true}
  ```

  `dev:errors`: none captured. Instance stopped after (no leak).

## Checklist

- [x] PR title follows Conventional Commits - it becomes the squash-merge commit and drives the released version.
- [x] No related issue (deepsec finding `other-proto-key-unguarded`; no GitHub issue exists).
- [x] Release/migration impact: none (no settings/storage/API shape change). Minor behavior change: reserved keys are refused in the bulk flow.
