### PR TITLE
fix(settings): serialize Auto Property choice persistence to prevent lost updates

### DIFF
--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -15,7 +15,6 @@ import {MetaType} from "./Types/metaType";
 import type {AutoProperty} from "./Types/autoProperty";
 
 export class MetaEditApi {
-    private settingsWriteQueue: Promise<unknown> = Promise.resolve();
     private parser: MetaEditParser;
 
     constructor(private plugin: MetaEdit) {
@@ -184,19 +183,17 @@ export class MetaEditApi {
 
     private getSetAutoPropertiesFunction() {
         return async (autoProperties: AutoProperty[]): Promise<void> => {
-            await this.enqueueSettingsWrite(async () => {
+            // Share the plugin's single settings write queue, so a full-list replace
+            // here serializes with the controller's per-choice persistence instead of
+            // racing it. Validation runs inside the critical section so a reject leaves
+            // the live settings untouched.
+            await this.plugin.updateSettings(() => {
                 const nextAutoProperties = this.validateAutoProperties(autoProperties);
-                const previousAutoProperties = this.cloneAutoProperties(this.plugin.settings.AutoProperties.properties);
+                const previousAutoProperties = this.plugin.settings.AutoProperties.properties;
 
                 this.plugin.settings.AutoProperties.properties = nextAutoProperties;
 
-                try {
-                    await this.plugin.saveSettings();
-                }
-                catch (error) {
-                    this.plugin.settings.AutoProperties.properties = previousAutoProperties;
-                    throw error;
-                }
+                return () => { this.plugin.settings.AutoProperties.properties = previousAutoProperties; };
             });
         }
     }
@@ -326,12 +323,6 @@ export class MetaEditApi {
             if (autoProperty.type !== undefined) validated.type = autoProperty.type;
             return validated;
         });
-    }
-
-    private enqueueSettingsWrite<T>(task: () => Promise<T>): Promise<T> {
-        const queued = this.settingsWriteQueue.catch(() => undefined).then(task);
-        this.settingsWriteQueue = queued.catch(() => undefined);
-        return queued;
     }
 
     private cloneProperties(properties: Property[]): Property[] {

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {GuiLogger} from "./logger/guiLogger";
 import {log} from "./logger/logManager";
 import {OnFileModifyAutomatorManager} from "./automators/onFileModifyAutomatorManager";
 import type {IAutomatorManager} from "./automators/IAutomatorManager";
+import {SettingsWriter, type SettingsMutationResult} from "./settingsWrites";
 import {KanbanHelper} from "./automators/onFileModifyAutomators/kanbanHelper";
 import {ProgressPropertyHelper} from "./automators/onFileModifyAutomators/progressPropertyHelper";
 import {OnModifyAutomatorType} from "./automators/onFileModifyAutomators/onModifyAutomatorType";
@@ -26,6 +27,11 @@ export default class MetaEdit extends Plugin {
     public controller: MetaController;
     public bulkEditor: BulkMetadataEditor;
     private automatorManager: IAutomatorManager;
+    // Every settings write - the settings tab, the API, and the controller's Auto
+    // Property choice persistence - runs through this one serialization point, so two
+    // concurrent writers can't lost-update a shared in-memory snapshot and two disk
+    // flushes can't complete out of order.
+    private readonly settingsWriter = new SettingsWriter(() => this.saveData(this.settings));
 
     async onload() {
         console.log('Loading MetaEdit');
@@ -110,7 +116,22 @@ export default class MetaEdit extends Plugin {
     }
 
     async saveSettings() {
-        await this.saveData(this.settings);
+        await this.settingsWriter.save();
+    }
+
+    /**
+     * Atomically read-modify-write the settings, serialized with every other settings
+     * write. `mutate` runs at the head of the write queue - so it re-reads the freshest
+     * `this.settings` and no other writer can interleave between its read and the save -
+     * and applies its change in place. It returns a rollback to undo the in-memory
+     * change if the disk write fails, or `false` to skip the write when nothing changed.
+     *
+     * Use this for any read-modify-write of shared settings (e.g. appending an Auto
+     * Property choice) instead of mutating `settings` and calling `saveSettings()`
+     * separately, which would race a concurrent writer.
+     */
+    public updateSettings(mutate: () => SettingsMutationResult): Promise<void> {
+        return this.settingsWriter.update(mutate);
     }
 
     public getFilesWithProperty(property: string): TFile[] {

--- a/src/metaController.test.ts
+++ b/src/metaController.test.ts
@@ -9,6 +9,9 @@ vi.mock("./Modals/GenericSuggester/GenericSuggester", () => ({default: {Suggest:
 vi.mock("./Modals/AutoPropertyValueModal/AutoPropertyValueModal", () => ({default: {Show: vi.fn()}}));
 
 import MetaController from "./metaController";
+import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoPropertyValueModal";
+import {SettingsWriter} from "./settingsWrites";
+import type {AutoProperty} from "./Types/autoProperty";
 
 const setup = (initial: string) => {
     const store = {content: initial};
@@ -91,5 +94,121 @@ describe("MetaController.appendDataviewField", () => {
         ]);
 
         expect(store.content).toBe(["body", "watch:: 1", "watch:: 2"].join("\n"));
+    });
+});
+
+// Persisting a chosen Auto Property value back into the settings is a read-modify-write
+// on the shared `AutoProperties.properties`. These cover the serialization fix (deepsec
+// slug other-race-condition): the controller routes that write through the plugin's one
+// settings write queue, re-reads the live list inside the critical section, and rolls
+// back in memory if the disk write fails.
+describe("MetaController.persistAutoPropertyChoices", () => {
+    const setupAutoProps = (options: {failFlush?: boolean; initialChoices?: string[]} = {}) => {
+        const settings = {
+            AutoProperties: {
+                enabled: true,
+                properties: [{name: "status", choices: [...(options.initialChoices ?? ["todo"])]} as AutoProperty],
+            },
+            EditMode: {mode: "AllSingle", properties: [] as string[]},
+        };
+        // The modeled disk snapshots `settings` synchronously at write time, exactly like
+        // Obsidian's saveData, so a lost update would be visible here and not just in memory.
+        let disk = structuredClone(settings);
+        let flushes = 0;
+        const writer = new SettingsWriter(async () => {
+            flushes++;
+            if (options.failFlush) throw new Error("disk full");
+            disk = structuredClone(settings);
+        });
+        const plugin = {
+            settings,
+            saveSettings: () => writer.save(),
+            updateSettings: (mutate: () => (() => void) | false | void) => writer.update(mutate),
+        };
+        const app = {plugins: {plugins: {}}, vault: {}};
+        const controller = new MetaController(app as never, plugin as never);
+        const persist = (autoProp: AutoProperty, values: string[]) =>
+            (controller as unknown as {persistAutoPropertyChoices(a: AutoProperty, v: string[]): Promise<void>})
+                .persistAutoPropertyChoices(autoProp, values);
+        return {
+            controller,
+            plugin,
+            settings,
+            persist,
+            liveChoices: () => settings.AutoProperties.properties[0].choices,
+            diskChoices: () => disk.AutoProperties.properties[0].choices,
+            flushes: () => flushes,
+        };
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("persists a newly chosen value through the modal's save callback", async () => {
+        const ctx = setupAutoProps();
+        (AutoPropertyValueModal.Show as ReturnType<typeof vi.fn>).mockImplementation(
+            async (_app: unknown, autoProp: AutoProperty, opts: {onSaveChoices: (v: string[]) => Promise<void>}) => {
+                await opts.onSaveChoices(["doing"]);
+                return "doing";
+            },
+        );
+
+        await ctx.controller.handleAutoProperties("status");
+
+        expect(ctx.liveChoices()).toEqual(["todo", "doing"]);
+        expect(ctx.diskChoices()).toEqual(["todo", "doing"]);
+    });
+
+    it("does not lose a choice when two adds to the same property interleave", async () => {
+        const ctx = setupAutoProps();
+        const autoProp = ctx.settings.AutoProperties.properties[0];
+
+        await Promise.all([
+            ctx.persist(autoProp, ["doing"]),
+            ctx.persist(autoProp, ["done"]),
+        ]);
+
+        expect(ctx.liveChoices()).toEqual(["todo", "doing", "done"]);
+        expect(ctx.diskChoices()).toEqual(["todo", "doing", "done"]);
+    });
+
+    it("re-resolves the live entry by name when a concurrent write replaced the list", async () => {
+        const ctx = setupAutoProps();
+        const staleAutoProp = ctx.settings.AutoProperties.properties[0]; // captured before the replace
+
+        // A concurrent setAutoProperties-style replace and a choice-add are enqueued
+        // together; the persist must append to the REPLACED entry, not the stale one.
+        await Promise.all([
+            ctx.plugin.updateSettings(() => {
+                ctx.settings.AutoProperties.properties = [{name: "status", choices: ["backlog"]} as AutoProperty];
+                return () => undefined;
+            }),
+            ctx.persist(staleAutoProp, ["doing"]),
+        ]);
+
+        expect(ctx.liveChoices()).toEqual(["backlog", "doing"]);
+        expect(ctx.diskChoices()).toEqual(["backlog", "doing"]);
+    });
+
+    it("skips the disk write when every chosen value already exists", async () => {
+        const ctx = setupAutoProps({initialChoices: ["todo", "doing"]});
+        const autoProp = ctx.settings.AutoProperties.properties[0];
+
+        await ctx.persist(autoProp, ["todo", "doing"]);
+
+        expect(ctx.flushes()).toBe(0);
+        expect(ctx.liveChoices()).toEqual(["todo", "doing"]);
+    });
+
+    it("rolls back in memory and surfaces a notice when the save fails", async () => {
+        const ctx = setupAutoProps({failFlush: true});
+        const autoProp = ctx.settings.AutoProperties.properties[0];
+
+        // persist swallows the failure (the note value is still valid) after rolling back.
+        await expect(ctx.persist(autoProp, ["doing"])).resolves.toBeUndefined();
+
+        expect(ctx.liveChoices()).toEqual(["todo"]);
+        expect(ctx.diskChoices()).toEqual(["todo"]);
     });
 });

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -432,22 +432,38 @@ export default class MetaController {
     }
 
     private async persistAutoPropertyChoices(autoProp: AutoProperty, values: string[]): Promise<void> {
-        const list = this.plugin.settings.AutoProperties.properties;
-        // Prefer the exact object, but fall back to name so we still resolve if the
-        // settings tab replaced the entry while the prompt was open.
-        const idx = list.indexOf(autoProp) !== -1 ? list.indexOf(autoProp) : list.findIndex(a => a.name === autoProp.name);
-        if (idx === -1) return;
+        // Serialize this read-modify-write with every other settings write (the public
+        // API's setAutoProperties, the settings tab) so two concurrent choice-adds can't
+        // lost-update each other. The mutation runs at the head of the write queue, so it
+        // re-reads the freshest list and resolves the entry there.
+        try {
+            await this.plugin.updateSettings(() => {
+                const list = this.plugin.settings.AutoProperties.properties;
+                // Prefer the exact object, but fall back to name so we still resolve if a
+                // concurrent write replaced the entry while the prompt was open.
+                const idx = list.indexOf(autoProp) !== -1 ? list.indexOf(autoProp) : list.findIndex(a => a.name === autoProp.name);
+                if (idx === -1) return false;
 
-        // Append to the LIVE entry's current choices so a concurrent settings-tab
-        // edit is preserved rather than overwritten with a stale snapshot.
-        let updated = list[idx];
-        for (const value of values) {
-            updated = withChoiceAdded(updated, value);
+                // Append to the LIVE entry's current choices so a concurrent edit is
+                // preserved rather than overwritten with a stale snapshot.
+                let updated = list[idx];
+                for (const value of values) {
+                    updated = withChoiceAdded(updated, value);
+                }
+                if (updated === list[idx]) return false; // nothing new
+
+                const previous = list[idx];
+                list[idx] = updated;
+                return () => { list[idx] = previous; }; // roll back if the save fails
+            });
+        } catch (error) {
+            // The prompt's value is still valid for the note; only the choice-list save
+            // failed. updateSettings already rolled the in-memory list back, so surface
+            // the failure rather than letting the choice silently vanish on reload.
+            const reason = error instanceof Error ? error.message : String(error);
+            new Notice(`MetaEdit could not save the Auto Property choice: ${reason}`);
+            log.logMessage(`MetaEdit could not save Auto Property choices for '${autoProp.name}': ${reason}`);
         }
-        if (updated === list[idx]) return; // nothing new
-
-        list[idx] = updated;
-        await this.plugin.saveSettings();
     }
 
     public async updatePropertyInFile(property: Partial<Property>, newValue: unknown, file: TFile): Promise<void> {

--- a/src/settingsWrites.test.ts
+++ b/src/settingsWrites.test.ts
@@ -1,0 +1,175 @@
+import {describe, it, expect} from "vitest";
+import {SettingsWriter} from "./settingsWrites";
+
+interface Settings {
+	enabled: boolean;
+	choices: string[];
+}
+
+// A controllable "disk": each flush() takes a SYNCHRONOUS snapshot of the live
+// settings (mirroring Obsidian's saveData, which serializes its argument up front and
+// writes asynchronously) and commits that snapshot only when its deferred is released.
+// Tests can therefore release flushes in any order and observe what landed on disk.
+function makeDisk(settings: Settings) {
+	const pending: Array<{snapshot: Settings; release: () => void}> = [];
+	let inFlight = 0;
+	let maxInFlight = 0;
+	let flushCount = 0;
+	const committed: Settings = {enabled: settings.enabled, choices: [...settings.choices]};
+
+	const flush = (): Promise<void> => {
+		flushCount++;
+		const snapshot: Settings = {enabled: settings.enabled, choices: [...settings.choices]};
+		inFlight++;
+		maxInFlight = Math.max(maxInFlight, inFlight);
+		return new Promise<void>((resolve) => {
+			pending.push({
+				snapshot,
+				release: () => {
+					committed.enabled = snapshot.enabled;
+					committed.choices = [...snapshot.choices];
+					inFlight--;
+					resolve();
+				},
+			});
+		});
+	};
+
+	const failingFlush = (): Promise<void> => {
+		flushCount++;
+		return Promise.reject(new Error("disk full"));
+	};
+
+	return {
+		flush,
+		failingFlush,
+		committed,
+		pending,
+		get maxInFlight() { return maxInFlight; },
+		get flushCount() { return flushCount; },
+	};
+}
+
+// Drain pending microtasks so queued tasks reach their flush() call.
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("SettingsWriter", () => {
+	it("CONTROL: unserialized out-of-order flushes silently drop an update (the bug)", async () => {
+		const settings: Settings = {enabled: false, choices: ["a"]};
+		const disk = makeDisk(settings);
+
+		// Two writers flush directly, without serialization.
+		settings.choices = ["a", "X"];
+		const choiceFlush = disk.flush();      // snapshot {enabled:false, choices:[a,X]}
+		settings.enabled = true;
+		const toggleFlush = disk.flush();      // snapshot {enabled:true,  choices:[a,X]}
+
+		// The toggle's write resolves FIRST, the choice write resolves LAST.
+		disk.pending[1].release();
+		disk.pending[0].release();
+		await Promise.all([choiceFlush, toggleFlush]);
+
+		// The later-resolving choice flush overwrote disk with its stale snapshot, so
+		// the toggle (enabled=true) is lost even though memory says true.
+		expect(disk.maxInFlight).toBe(2);
+		expect(disk.committed.enabled).toBe(false);
+	});
+
+	it("serializes update() writes so flushes never overlap and no update is lost", async () => {
+		const settings: Settings = {enabled: false, choices: ["a"]};
+		const disk = makeDisk(settings);
+		const writer = new SettingsWriter(disk.flush);
+
+		const p1 = writer.update(() => {
+			settings.choices = ["a", "X"];
+			return () => { settings.choices = ["a"]; };
+		});
+		const p2 = writer.update(() => {
+			settings.enabled = true;
+			return () => { settings.enabled = false; };
+		});
+
+		await tick();
+		// Serialized: only the first flush has started even though both are enqueued.
+		expect(disk.pending.length).toBe(1);
+
+		disk.pending[0].release();
+		await tick();
+		expect(disk.pending.length).toBe(2);
+		disk.pending[1].release();
+
+		await Promise.all([p1, p2]);
+		expect(disk.maxInFlight).toBe(1);
+		expect(disk.committed).toEqual({enabled: true, choices: ["a", "X"]});
+	});
+
+	it("serializes save() against update()", async () => {
+		const settings: Settings = {enabled: false, choices: ["a"]};
+		const disk = makeDisk(settings);
+		const writer = new SettingsWriter(disk.flush);
+
+		const p1 = writer.update(() => { settings.choices = ["a", "X"]; });
+		settings.enabled = true; // a scalar toggle mutates in place, then flushes
+		const p2 = writer.save();
+
+		await tick();
+		expect(disk.pending.length).toBe(1);
+		disk.pending[0].release();
+		await tick();
+		disk.pending[1].release();
+
+		await Promise.all([p1, p2]);
+		expect(disk.maxInFlight).toBe(1);
+		expect(disk.committed).toEqual({enabled: true, choices: ["a", "X"]});
+	});
+
+	it("skips the flush when a mutation reports no change (returns false)", async () => {
+		const settings: Settings = {enabled: false, choices: ["a"]};
+		const disk = makeDisk(settings);
+		const writer = new SettingsWriter(disk.flush);
+
+		await writer.update(() => false);
+
+		expect(disk.flushCount).toBe(0);
+		expect(disk.committed).toEqual({enabled: false, choices: ["a"]});
+	});
+
+	it("rolls back the in-memory change when the flush fails", async () => {
+		const settings: Settings = {enabled: false, choices: ["a"]};
+		const disk = makeDisk(settings);
+		const writer = new SettingsWriter(disk.failingFlush);
+
+		await expect(writer.update(() => {
+			settings.choices = ["a", "X"];
+			return () => { settings.choices = ["a"]; };
+		})).rejects.toThrow("disk full");
+
+		// Rollback restored memory so it stays consistent with (unchanged) disk.
+		expect(settings.choices).toEqual(["a"]);
+		expect(disk.committed.choices).toEqual(["a"]);
+	});
+
+	it("keeps serving later writers after one task rejects", async () => {
+		const settings: Settings = {enabled: false, choices: ["a"]};
+		const disk = makeDisk(settings);
+		let failNext = true;
+		const writer = new SettingsWriter(() => {
+			if (failNext) { failNext = false; return Promise.reject(new Error("transient")); }
+			return disk.flush();
+		});
+
+		const failed = writer.update(() => {
+			settings.choices = ["a", "X"];
+			return () => { settings.choices = ["a"]; };
+		});
+		const succeeded = writer.update(() => { settings.choices = ["a", "Y"]; });
+
+		await expect(failed).rejects.toThrow("transient");
+		await tick();
+		expect(disk.pending.length).toBe(1);
+		disk.pending[0].release();
+		await succeeded;
+
+		expect(disk.committed.choices).toEqual(["a", "Y"]);
+	});
+});

--- a/src/settingsWrites.ts
+++ b/src/settingsWrites.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure, Obsidian-free serialization for plugin settings writes.
+ *
+ * Every settings mutation and disk flush runs through one queue, so two concurrent
+ * writers cannot lost-update a shared in-memory snapshot, and two flushes cannot
+ * complete out of order. The latter matters because Obsidian's `Plugin.saveData`
+ * serializes its argument synchronously at call time and then writes asynchronously:
+ * two unserialized `saveData(settings)` calls each capture a snapshot up front, so
+ * whichever write resolves LAST overwrites disk with its (possibly older) snapshot -
+ * a silent lost update. Serializing every flush removes that window entirely.
+ *
+ * This mirrors the controller's per-file `enqueueFileWrite` queue, kept separate from
+ * `main.ts` so it stays jsdom-free and directly unit-testable in the `node` env.
+ */
+
+/**
+ * What a {@link SettingsWriter.update} mutation returns:
+ * - a rollback function: the flush will run; if it fails, the function is called to
+ *   undo the in-memory change so memory stays consistent with disk;
+ * - `false`: nothing changed, so skip the flush (no redundant `data.json` write);
+ * - `void`: the flush will run with no rollback available.
+ */
+export type SettingsMutationResult = (() => void) | false | void;
+
+export class SettingsWriter {
+    private tail: Promise<unknown> = Promise.resolve();
+
+    /**
+     * @param flush Persist the current in-memory settings to disk. Invoked only at the
+     * head of the queue, so it never overlaps another flush.
+     */
+    constructor(private readonly flush: () => Promise<void>) {}
+
+    /** Flush the current settings, serialized with every other settings write. */
+    public save(): Promise<void> {
+        return this.enqueue(() => this.flush());
+    }
+
+    /**
+     * Atomically read-modify-write the settings. `mutate` runs at the head of the
+     * queue - so it observes the freshest settings and no other writer can interleave
+     * between its read and the flush - then the change is persisted.
+     *
+     * `mutate` is intentionally SYNCHRONOUS: it applies its change in place and returns
+     * a {@link SettingsMutationResult}. Keeping it synchronous is what makes this queue
+     * deadlock-free - a mutation can never await a nested settings write while already
+     * holding the queue.
+     */
+    public update(mutate: () => SettingsMutationResult): Promise<void> {
+        return this.enqueue(async () => {
+            const rollback = mutate();
+            if (rollback === false) return; // nothing changed - skip the flush
+            try {
+                await this.flush();
+            } catch (error) {
+                if (typeof rollback === "function") rollback();
+                throw error;
+            }
+        });
+    }
+
+    private enqueue<T>(task: () => Promise<T> | T): Promise<T> {
+        const queued = this.tail.catch(() => undefined).then(task);
+        // A rejected task must not break the chain for the next writer, so the tail
+        // tracks a swallowed copy while the caller still sees the real rejection.
+        this.tail = queued.catch(() => undefined);
+        return queued;
+    }
+}


### PR DESCRIPTION
## Summary
Serializes Auto Property choice persistence so concurrent settings writers can no longer silently drop a choice the user just added.

Addresses deepsec finding **`other-race-condition`** - "Unsynchronized settings read-modify-write can silently drop an Auto Property choice." (No GitHub issue is associated with this finding.)

## The bug
`MetaController.persistAutoPropertyChoices` did an **unserialized** read-modify-write on `settings.AutoProperties.properties` and then `saveSettings()`, while the public API's `setAutoProperties` used its **own separate** private queue. With no shared serialization between them - and because `Plugin.saveData` snapshots its argument synchronously and writes asynchronously - two concurrent writers could complete out of order and overwrite disk from a stale in-memory snapshot, dropping a just-added choice.

## The fix
Route **every** settings write through one serialization point on the plugin:

- New `SettingsWriter` (`src/settingsWrites.ts`): a single promise-chain queue (mirrors the controller's per-file `enqueueFileWrite`) for all flushes and read-modify-writes, with optional in-memory rollback and a no-op skip.
- `MetaEdit.saveSettings()` now flushes through the queue, so **all** existing writers (settings-tab toggles, the load-time migration save) are serialized too - no two `saveData` calls can interleave or land out of order.
- New `MetaEdit.updateSettings(mutate)` for atomic read-modify-write.
- `persistAutoPropertyChoices` re-reads the live list **inside** the critical section, rolls back in memory and surfaces a `Notice` if the save fails (previously a failed save left memory ahead of disk with no signal).
- `setAutoProperties` shares the plugin queue; the API's private settings queue is removed.

The settings **shape and migration are unchanged**, so there is no storage/migration impact.

## Design validated adversarially first
Before coding, the design was reviewed by three opposing-model (Codex) reviewers (Skeptic / Architect / Minimalist). They caught that my original "leave scalar toggles outside the queue" scoping was unsafe (synchronous `saveData` snapshots can complete out of order), which is why `saveSettings()` itself is now serialized. Rollback-on-failure was added on their recommendation.

## Out of scope (separate, pre-existing issue)
The Auto Properties **settings-tab editor** holds a working copy cloned at mount and auto-saves it wholesale on any edit, so it can still overwrite a concurrently-added choice. That is a stale-*read* in the Svelte component, distinct from the unserialized-*write* this PR fixes; its flush is now ordered, but eliminating it needs its own change plus an E2E repro. Flagging rather than folding it in to keep this change scoped.

## Testing
- `pnpm run lint` - clean
- `pnpm run build` - typecheck + svelte-check, 0 errors
- `pnpm run test` - 301 passing, including:
  - `settingsWrites.test.ts` - serialization, a **control test that demonstrates the out-of-order lost update**, rollback, skip, error-isolation.
  - `metaController.test.ts` - interleaved choice-adds both survive, re-resolution by name after a concurrent list replace, idempotent skip, rollback-on-failure.
- **Live isolated-vault run** (Obsidian 1.x): seeded an Auto Property, fired two concurrent choice-adds through the real controller path, then read `data.json` from disk: `MEM=["todo","doing","done"] DISK=["todo","doing","done"]`. `dev:errors`: none. Instance stopped after.
