### PR TITLE
fix(settings): validate before queueing and use compare-and-restore rollbacks

### DIFF
--- a/src/MetaEditApi.test.ts
+++ b/src/MetaEditApi.test.ts
@@ -1,0 +1,67 @@
+import {describe, it, expect} from "vitest";
+import {MetaEditApi} from "./MetaEditApi";
+import {SettingsWriter} from "./settingsWrites";
+import type {AutoProperty} from "./Types/autoProperty";
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+// Build the public API over a plugin double whose settings writes use the REAL
+// SettingsWriter, so these exercise the actual serialization + rollback path.
+function setupApi(flush: () => Promise<void>) {
+	const settings = {
+		AutoProperties: {enabled: true, properties: [{name: "status", choices: ["todo"]}] as AutoProperty[]},
+		EditMode: {mode: "AllSingle", properties: [] as string[]},
+	};
+	const writer = new SettingsWriter(flush);
+	const plugin = {
+		app: {},
+		settings,
+		saveSettings: () => writer.save(),
+		updateSettings: (mutate: () => (() => void) | false | void) => writer.update(mutate),
+	};
+	const api = new MetaEditApi(plugin as never).make();
+	return {api, plugin, settings};
+}
+
+describe("MetaEditApi.setAutoProperties", () => {
+	it("rejects invalid input immediately, without waiting behind a pending settings save", async () => {
+		let releaseSave!: () => void;
+		const ctx = setupApi(() => new Promise<void>((resolve) => { releaseSave = resolve; }));
+
+		// Occupy the settings queue with a save that has not resolved yet.
+		const pendingSave = ctx.plugin.saveSettings();
+		await tick();
+
+		// Validation is pure, so a bad payload must reject right away rather than queue
+		// behind the in-flight save.
+		await expect(
+			ctx.api.setAutoProperties([{name: "bad", choices: "not-an-array"} as unknown as AutoProperty]),
+		).rejects.toThrow(/array of strings/);
+
+		// The pending save was never touched by the rejected, un-queued validation.
+		releaseSave();
+		await pendingSave;
+	});
+
+	it("does not roll back over a concurrent write when its own flush fails (compare-and-restore)", async () => {
+		let failSave!: () => void;
+		const ctx = setupApi(() => new Promise<void>((_resolve, reject) => {
+			failSave = () => reject(new Error("disk full"));
+		}));
+
+		const original = ctx.settings.AutoProperties.properties;
+		const replacement = [{name: "status", choices: ["from-elsewhere"]}] as AutoProperty[];
+
+		const setPromise = ctx.api.setAutoProperties([{name: "status", choices: ["from-api"]}]);
+		await tick(); // the mutation has assigned its value and is awaiting the flush
+
+		// A concurrent writer replaces the list while the API flush is in flight.
+		ctx.settings.AutoProperties.properties = replacement;
+		failSave();
+
+		await expect(setPromise).rejects.toThrow("disk full");
+		// Rollback must NOT clobber the concurrent replacement back to the original.
+		expect(ctx.settings.AutoProperties.properties).toBe(replacement);
+		expect(ctx.settings.AutoProperties.properties).not.toBe(original);
+	});
+});

--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -183,17 +183,27 @@ export class MetaEditApi {
 
     private getSetAutoPropertiesFunction() {
         return async (autoProperties: AutoProperty[]): Promise<void> => {
+            // Validate up front, outside the queue: it is a pure check on the caller's
+            // input, so invalid input should reject immediately rather than wait behind
+            // unrelated settings saves.
+            const nextAutoProperties = this.validateAutoProperties(autoProperties);
+
             // Share the plugin's single settings write queue, so a full-list replace
             // here serializes with the controller's per-choice persistence instead of
-            // racing it. Validation runs inside the critical section so a reject leaves
-            // the live settings untouched.
+            // racing it.
             await this.plugin.updateSettings(() => {
-                const nextAutoProperties = this.validateAutoProperties(autoProperties);
                 const previousAutoProperties = this.plugin.settings.AutoProperties.properties;
 
                 this.plugin.settings.AutoProperties.properties = nextAutoProperties;
 
-                return () => { this.plugin.settings.AutoProperties.properties = previousAutoProperties; };
+                // Compare-and-restore: only undo OUR write. If a concurrent writer
+                // replaced the list after ours, leave their value in place rather than
+                // clobbering it with our stale snapshot.
+                return () => {
+                    if (this.plugin.settings.AutoProperties.properties === nextAutoProperties) {
+                        this.plugin.settings.AutoProperties.properties = previousAutoProperties;
+                    }
+                };
             });
         }
     }

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -454,7 +454,9 @@ export default class MetaController {
 
                 const previous = list[idx];
                 list[idx] = updated;
-                return () => { list[idx] = previous; }; // roll back if the save fails
+                // Compare-and-restore: only undo OUR write if the save fails, so a
+                // concurrent writer's change to the same slot is not clobbered.
+                return () => { if (list[idx] === updated) list[idx] = previous; };
             });
         } catch (error) {
             // The prompt's value is still valid for the note; only the choice-list save


### PR DESCRIPTION
## Summary
Two small hardening refinements to the settings write path introduced in #154 (deepsec slug `other-race-condition`), surfaced by a post-merge adversarial review of that change.

### 1. Fail-fast validation (low)
`setAutoProperties` ran its **pure** input validation *inside* the queued mutation, so an invalid payload would not reject until every earlier settings save resolved (and could hang behind a slow/stuck `saveData`). Validation now runs up front, outside the queue, so bad input rejects immediately - while the valid-value install + rollback stays inside the critical section.

### 2. Compare-and-restore rollbacks (medium)
`updateSettings` rollbacks restored the previous value unconditionally. If a concurrent writer replaced the value while our flush was in flight and the flush then *failed*, the rollback would clobber that other writer's change. Both the API (`setAutoProperties`) and controller (`persistAutoPropertyChoices`) rollbacks now compare-and-restore: they undo **only our own write**, leaving a concurrent replacement intact.

Neither is a regression in user-visible behavior (the rollback edge needs a disk-write failure concurrent with another settings edit), but both make the new serialization path correct under those edges and cheaper on the validation path.

## Not included
The Auto Properties **settings-tab editor** still holds a working copy cloned at mount and saves it wholesale, so it can overwrite a concurrently-added choice (the high-severity item both review rounds flagged). That is a stale-*read* in the Svelte component, not a write race; it needs its own change plus an E2E repro and is tracked separately.

## Testing
- `pnpm run lint` clean · `pnpm run build` 0 errors · `pnpm run test` 309 pass
- New `MetaEditApi.test.ts`: invalid input rejects without waiting behind a pending save; a failed flush does not roll back over a concurrent replacement.
