### PR TITLE
fix(kanban): don't write to an ambiguous same-named note

### DIFF
--- a/__tests__/kanbanHelper.test.ts
+++ b/__tests__/kanbanHelper.test.ts
@@ -160,22 +160,49 @@ describe("KanbanHelper link resolution", () => {
     expect(app.metadataCache.getFirstLinkpathDest).toHaveBeenCalledWith("Folder/My Note", "Board.md");
   });
 
-  it("falls back to vault path resolution when metadata cache misses", () => {
+  it("falls back to vault path resolution when metadata cache misses for an explicit-path link", () => {
     const app = createApp();
     const plugin = createPlugin(app);
     const helper = new KanbanHelper(plugin as any);
 
-    const targetFile = new TFile("Note.md");
+    // Path resolution is only used for links that already name a folder path: such a
+    // path identifies exactly one file, so the direct lookup is unambiguous.
+    const targetFile = new TFile("Folder/Note.md");
     app.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
     app.vault.getAbstractFileByPath.mockImplementation((path: string) => {
-      return path === "Note.md" ? targetFile : null;
+      return path === "Folder/Note.md" ? targetFile : null;
     });
 
-    const link = {link: "Note", original: "[[Note]]"};
+    const link = {link: "Folder/Note", original: "[[Folder/Note]]"};
     const resolved = (helper as any).resolveLinkFile(link, "Board.md");
 
     expect(resolved).toBe(targetFile);
-    expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith("Note.md");
+    expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith("Folder/Note.md");
+  });
+
+  it("does not resolve a bare link via the vault-root path (defers to the unique-basename guard)", () => {
+    // The wrong-file-write class the deepsec finding (other-wrong-file-write) describes
+    // is wider than the basename fallback: direct path resolution would turn a bare
+    // [[Note]] into getAbstractFileByPath("Note.md") and pick the ROOT note even when
+    // the board displays a folder-local same-named note. A bare link must never resolve
+    // by that root guess, so when several "Note" notes exist the helper bails.
+    const app = createApp();
+    const plugin = createPlugin(app);
+    const helper = new KanbanHelper(plugin as any);
+
+    const rootNote = new TFile("Note.md");
+    const folderNote = new TFile("Areas/Note.md");
+    app.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
+    // The real vault WOULD return the root file here; the fix must not act on it.
+    app.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+      path === "Note.md" ? rootNote : null
+    );
+    app.vault.getMarkdownFiles.mockReturnValue([rootNote, folderNote]);
+
+    const link = {link: "Note", original: "[[Note]]"};
+    const resolved = (helper as any).resolveLinkFile(link, "Projects/Board.md");
+
+    expect(resolved).toBeNull();
   });
 
   it("falls back to basename match when direct path lookup fails for basename-only links", () => {
@@ -476,23 +503,26 @@ describe("KanbanHelper updates linked file properties", () => {
     expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
   });
 
-  it("does not write to any note when the card's basename is ambiguous (only the basename fallback resolves)", async () => {
-    // Cache + direct-path resolution both miss, so resolution would fall through to
-    // the basename fallback. Two notes share the basename "Task", so the helper must
-    // write to neither rather than corrupt an arbitrarily-chosen same-named note.
+  it("does not write to any note when the card's basename is ambiguous, even if a root file exists", async () => {
+    // End-to-end repro of deepsec other-wrong-file-write: cold cache, a bare [[Task]]
+    // card, and two notes sharing the basename "Task" - one of them at the vault root.
+    // The pre-fix code resolved the bare link straight to the root Task.md via the
+    // direct path lookup and silently wrote the lane there. The helper must instead
+    // write to neither, since it cannot know which "Task" the card meant.
     const app = createApp();
     const plugin = createPlugin(app, [{boardName: "Board", property: "status"}]);
     const helper = new KanbanHelper(plugin as any);
     const boardFile = new TFile("Board.md");
-    const noteA = new TFile("Areas/Task.md");
-    const noteB = new TFile("Archive/Task.md");
+    const rootTask = new TFile("Task.md");
+    const archiveTask = new TFile("Archive/Task.md");
 
     const board = "## Doing\n\n- [ ] [[Task]]\n";
     app.metadataCache.getFileCache.mockReturnValue(buildBoardCache(board));
     app.vault.cachedRead.mockResolvedValue(board);
     app.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
-    app.vault.getAbstractFileByPath.mockReturnValue(null);
-    app.vault.getMarkdownFiles.mockReturnValue([noteA, noteB]);
+    // The real vault returns the root note for "Task.md"; the fix must not act on it.
+    app.vault.getAbstractFileByPath.mockImplementation((p: string) => (p === "Task.md" ? rootTask : null));
+    app.vault.getMarkdownFiles.mockReturnValue([rootTask, archiveTask]);
     plugin.controller.getPropertiesInFile.mockResolvedValue([{key: "status", content: "Backlog", type: "YAML"}]);
 
     await helper.onFileModify(boardFile);

--- a/__tests__/kanbanHelper.test.ts
+++ b/__tests__/kanbanHelper.test.ts
@@ -194,6 +194,24 @@ describe("KanbanHelper link resolution", () => {
     expect(resolved).toBe(targetFile);
   });
 
+  it("does not fallback to basename when several notes share that name (ambiguous)", () => {
+    const app = createApp();
+    const plugin = createPlugin(app);
+    const helper = new KanbanHelper(plugin as any);
+
+    const noteA = new TFile("Areas/Note.md");
+    const noteB = new TFile("Archive/Note.md");
+    app.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
+    app.vault.getAbstractFileByPath.mockReturnValue(null);
+    app.vault.getMarkdownFiles.mockReturnValue([noteA, noteB]);
+
+    const link = {link: "Note", original: "[[Note]]"};
+    const resolved = (helper as any).resolveLinkFile(link, "Board.md");
+
+    // Two notes named "Note" -> cannot know which the card meant -> bail.
+    expect(resolved).toBeNull();
+  });
+
   it("does not fallback to basename when link includes a folder", () => {
     const app = createApp();
     const plugin = createPlugin(app);
@@ -456,6 +474,56 @@ describe("KanbanHelper updates linked file properties", () => {
     await helper.onFileModify(boardFile);
 
     expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
+  });
+
+  it("does not write to any note when the card's basename is ambiguous (only the basename fallback resolves)", async () => {
+    // Cache + direct-path resolution both miss, so resolution would fall through to
+    // the basename fallback. Two notes share the basename "Task", so the helper must
+    // write to neither rather than corrupt an arbitrarily-chosen same-named note.
+    const app = createApp();
+    const plugin = createPlugin(app, [{boardName: "Board", property: "status"}]);
+    const helper = new KanbanHelper(plugin as any);
+    const boardFile = new TFile("Board.md");
+    const noteA = new TFile("Areas/Task.md");
+    const noteB = new TFile("Archive/Task.md");
+
+    const board = "## Doing\n\n- [ ] [[Task]]\n";
+    app.metadataCache.getFileCache.mockReturnValue(buildBoardCache(board));
+    app.vault.cachedRead.mockResolvedValue(board);
+    app.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
+    app.vault.getAbstractFileByPath.mockReturnValue(null);
+    app.vault.getMarkdownFiles.mockReturnValue([noteA, noteB]);
+    plugin.controller.getPropertiesInFile.mockResolvedValue([{key: "status", content: "Backlog", type: "YAML"}]);
+
+    await helper.onFileModify(boardFile);
+
+    expect(plugin.controller.getPropertiesInFile).not.toHaveBeenCalled();
+    expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
+  });
+
+  it("still resolves and writes when exactly one note carries the basename (unique fallback)", async () => {
+    // The same fallback path, but only one note named "Task" exists -> safe to write.
+    const app = createApp();
+    const plugin = createPlugin(app, [{boardName: "Board", property: "status"}]);
+    const helper = new KanbanHelper(plugin as any);
+    const boardFile = new TFile("Board.md");
+    const note = new TFile("Areas/Task.md");
+
+    const board = "## Doing\n\n- [ ] [[Task]]\n";
+    app.metadataCache.getFileCache.mockReturnValue(buildBoardCache(board));
+    app.vault.cachedRead.mockResolvedValue(board);
+    app.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
+    app.vault.getAbstractFileByPath.mockReturnValue(null);
+    app.vault.getMarkdownFiles.mockReturnValue([note]);
+    plugin.controller.getPropertiesInFile.mockResolvedValue([{key: "status", content: "Backlog", type: "YAML"}]);
+
+    await helper.onFileModify(boardFile);
+
+    expect(plugin.controller.updatePropertyInFile).toHaveBeenCalledWith(
+      expect.objectContaining({key: "status"}),
+      "Doing",
+      note
+    );
   });
 
   it("processes multiple lanes and only the leading card link in each", async () => {

--- a/src/automators/onFileModifyAutomators/kanbanHelper.ts
+++ b/src/automators/onFileModifyAutomators/kanbanHelper.ts
@@ -190,14 +190,28 @@ export class KanbanHelper extends OnFileModifyAutomator {
         return null;
     }
 
+    // Last-resort fallback for links the metadata cache and direct path lookup both
+    // miss (e.g. an as-yet-unresolved link or a cold cache). A basename is only a
+    // safe target when exactly one note carries it: if several notes share it we
+    // cannot know which the card meant, so we bail rather than write the lane to an
+    // arbitrarily-chosen same-named note (silent data corruption). When the cache is
+    // warm Obsidian's own shortest-path resolution in resolveByMetadataCache already
+    // picked the note the board displays, so this path is reached only on a true miss.
     private resolveByBasenameCandidates(candidates: string[]): TFile | null {
         const markdownFiles: TFile[] = this.app.vault.getMarkdownFiles();
         for (const candidate of candidates) {
             if (candidate.includes("/")) continue;
             const basename = this.stripMarkdownExtension(candidate.split("/").pop() ?? "");
             if (!basename) continue;
-            const found = markdownFiles.find(f => f.basename === basename);
-            if (found) return found;
+            const matches = markdownFiles.filter(f => f.basename === basename);
+            if (matches.length === 1) return matches[0];
+            if (matches.length > 1) {
+                log.logMessage(
+                    `KanbanHelper: "${basename}" is ambiguous (${matches.length} notes share this name); ` +
+                    `skipping the card so its lane is not written to the wrong note.`
+                );
+                return null;
+            }
         }
         return null;
     }

--- a/src/automators/onFileModifyAutomators/kanbanHelper.ts
+++ b/src/automators/onFileModifyAutomators/kanbanHelper.ts
@@ -181,8 +181,15 @@ export class KanbanHelper extends OnFileModifyAutomator {
         return null;
     }
 
+    // Direct path resolution is only safe for links that already name a folder path:
+    // an explicit path identifies at most one file. A bare (folder-less) link must NOT
+    // be resolved here, because getAbstractFileByPath would guess the vault-root note of
+    // that name - silently picking the root note even when Obsidian would link a
+    // folder-local same-named note, and bypassing the strict ambiguity guard in
+    // resolveByBasenameCandidates. Bare links fall through to that guard instead.
     private resolveByPathCandidates(candidates: string[]): TFile | null {
         for (const candidate of candidates) {
+            if (!candidate.includes("/")) continue;
             const file = this.app.vault.getAbstractFileByPath(this.ensureMarkdownExtension(candidate));
             const markdownFile = abstractFileToMarkdownTFile(file);
             if (markdownFile) return markdownFile;
@@ -190,13 +197,13 @@ export class KanbanHelper extends OnFileModifyAutomator {
         return null;
     }
 
-    // Last-resort fallback for links the metadata cache and direct path lookup both
-    // miss (e.g. an as-yet-unresolved link or a cold cache). A basename is only a
-    // safe target when exactly one note carries it: if several notes share it we
-    // cannot know which the card meant, so we bail rather than write the lane to an
-    // arbitrarily-chosen same-named note (silent data corruption). When the cache is
-    // warm Obsidian's own shortest-path resolution in resolveByMetadataCache already
-    // picked the note the board displays, so this path is reached only on a true miss.
+    // Sole resolver for bare (folder-less) links the metadata cache misses (e.g. an
+    // as-yet-unresolved link or a cold cache). A basename is only a safe target when
+    // exactly one note carries it: if several notes share it we cannot know which the
+    // card meant, so we bail rather than write the lane to an arbitrarily-chosen
+    // same-named note (silent data corruption). The caller logs the skip once. When the
+    // cache is warm Obsidian's own shortest-path resolution in resolveByMetadataCache
+    // already picked the note the board displays, so this path is reached only on a miss.
     private resolveByBasenameCandidates(candidates: string[]): TFile | null {
         const markdownFiles: TFile[] = this.app.vault.getMarkdownFiles();
         for (const candidate of candidates) {
@@ -205,13 +212,8 @@ export class KanbanHelper extends OnFileModifyAutomator {
             if (!basename) continue;
             const matches = markdownFiles.filter(f => f.basename === basename);
             if (matches.length === 1) return matches[0];
-            if (matches.length > 1) {
-                log.logMessage(
-                    `KanbanHelper: "${basename}" is ambiguous (${matches.length} notes share this name); ` +
-                    `skipping the card so its lane is not written to the wrong note.`
-                );
-                return null;
-            }
+            // Ambiguous (>1): bail. Zero matches: keep checking remaining candidates.
+            if (matches.length > 1) return null;
         }
         return null;
     }


### PR DESCRIPTION
## Summary

The Kanban helper keeps a linked note's lane/status property in sync when a card moves lanes. To find the note a card links to, `resolveLinkFile` tries three strategies in order: Obsidian's metadata-cache resolution (`getFirstLinkpathDest`), direct path lookup, then a basename match across the vault.

When the cache and path strategies both miss (an unresolved link, or a cold/not-yet-built metadata cache), the helper could silently write the lane to the **wrong same-named note** - silent data corruption. This fixes that.

## What was wrong

Two distinct code paths produced the same wrong-file write for a bare `[[Note]]` link on a cold cache:

1. **`resolveByBasenameCandidates`** used `Array.find`, returning the *first* note whose basename matched - an arbitrary pick when several notes share the name.
2. **`resolveByPathCandidates`** (which runs *before* the basename guard) turned a bare `[[Note]]` into `getAbstractFileByPath("Note.md")`, resolving to the vault-**root** note of that name even when Obsidian would link a folder-local same-named note - bypassing the ambiguity check entirely.

## The fix

- **Basename fallback is now strict-unique:** it resolves only when exactly one note carries the basename; if several share it, the card is skipped rather than written to an arbitrarily-chosen note. Single-match behavior is unchanged.
- **Direct path resolution is restricted to explicit-path links** (those containing `/`), which identify at most one file. Bare links now resolve solely via Obsidian's own shortest-path `getFirstLinkpathDest` (warm cache) or the strict-unique basename guard (cold cache) - consistent with the note the board displays.
- Resolvers stay pure: a skipped ambiguous card emits exactly one log line via the caller's existing skip log (no duplicate logging).

## Approach validation

The strict-unique-basename slice shipped first; an adversarial review then surfaced the `resolveByPathCandidates` bypass (a separate path to the same data-corruption class), which the second slice closes. Both findings are addressed here.

## Tests

- Unit (`__tests__/kanbanHelper.test.ts`): two notes share a basename -> the helper writes to neither (bails on ambiguity); a unique basename still resolves and writes; an explicit-path link still resolves via direct path. Added a regression where `getAbstractFileByPath` returns the root file - it **fails** on the pre-fix code and passes now, proving it catches the bypass.
- `pnpm run lint`, `pnpm run build`, `pnpm run test` (311 passing) all green.
- Live Obsidian E2E (`tests/e2e/kanban-helper.test.ts`) re-run in an isolated worktree vault against the changed build: the happy path (card moves lanes -> status updates, trailing links untouched) and the unresolvable-card path both pass, confirming live behavior is preserved. The cold-cache fallback the fix hardens is not deterministically reproducible in a warm live vault, so it is covered by the unit suite.

## Risk / scope

Behavior changes only on the cold-cache/unresolved-link fallback path; warm-cache resolution (the common case) is unchanged. No settings, storage, or API impact.

Addresses deepsec finding `other-wrong-file-write`.