### PR TITLE
fix(controller): guard __proto__/constructor in all frontmatter writes

### DIFF
--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -8,7 +8,7 @@ import type {AutoProperty} from "../Types/autoProperty";
 import {getKnownPropertyNames} from "./GenericPrompt/valueSuggest";
 import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
 import {canStructureEditProperty, filterMenuItems} from "./menuFilter";
-import {isYamlParentContainerValue} from "../yamlPath";
+import {isReservedFrontmatterKey, isYamlParentContainerValue} from "../yamlPath";
 
 export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     public app: App;
@@ -87,7 +87,17 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
             if (!newProperty) return null;
 
             const {propName, propValue} = newProperty;
-            await this.controller.addYamlProp(propName, propValue, this.file);
+            // The add fails closed on a reserved object-machinery key
+            // (__proto__/constructor/prototype). Surface it as a Notice here so
+            // a typed reserved name does not become an uncaught rejection. The
+            // inline (Dataview) path below is line-based, not a frontmatter key,
+            // so it is intentionally NOT guarded.
+            try {
+                await this.controller.addYamlProp(propName, propValue, this.file);
+            } catch (error) {
+                const reason = error instanceof Error ? error.message : String(error);
+                new Notice(`MetaEdit could not add '${propName}': ${reason}`);
+            }
             return;
         }
 
@@ -132,6 +142,17 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
             evt.stopPropagation();
             const {item: property} = item;
             if (!MetaEditSuggester.canStructureEdit(property)) return;
+
+            // Transforming a non-YAML field INTO YAML would create a frontmatter
+            // key. Refuse a reserved key BEFORE toYaml deletes the source field,
+            // so the transform never deletes data it then cannot re-add. The
+            // reverse (YAML -> inline) is allowed: it removes the frontmatter key
+            // and is line-based, so it cannot alias object machinery.
+            if (property.type !== MetaType.YAML && isReservedFrontmatterKey(property.key)) {
+                new Notice(`MetaEdit: "${property.key}" is a reserved property name and can't be a YAML property.`);
+                this.close();
+                return;
+            }
 
             try {
                 if (property.type === MetaType.YAML) {

--- a/src/bulk/bulkMetadata.ts
+++ b/src/bulk/bulkMetadata.ts
@@ -12,29 +12,12 @@
 /** How to treat notes that already define the target property. */
 export type ConflictPolicy = "skip" | "overwrite" | "merge";
 
-/**
- * Property names that alias JavaScript object machinery when assigned through a
- * dynamic `frontmatter[key] = value`, so they can never be written as ordinary
- * frontmatter keys:
- *
- *  - `__proto__` is an accessor inherited from `Object.prototype`. Assigning a
- *    string (`frontmatter["__proto__"] = "x"`) is silently dropped - no own key
- *    is created - while assigning an array/object (the `wrapInArray`/`merge`
- *    cases that produce `[rawValue]`) mutates the object's prototype instead.
- *    Either way the note is left unchanged, yet `hasOwnProperty` reports the key
- *    absent up front, so the bulk summary would claim it was "added": the report
- *    disagrees with what was written. This is the concrete bug being fixed.
- *  - `constructor`/`prototype` do create a real own enumerable property today,
- *    but it shadows the inherited slot. They are refused alongside `__proto__`
- *    so a bulk write never produces object-machinery-aliasing keys - the
- *    standard reserved-key set, applied uniformly.
- *
- * Matching is exact: a padded literal such as `" __proto__ "` is an ordinary key
- * (it aliases nothing) and is intentionally left alone.
- */
-export function isReservedFrontmatterKey(key: string): boolean {
-	return key === "__proto__" || key === "constructor" || key === "prototype";
-}
+// Re-exported from the lowest-level dynamic-key sink (`yamlPath.setYamlPath`),
+// which now owns the reserved-key predicate so the controller, the path writer,
+// and the bulk editor all refuse the same object-machinery keys
+// (`__proto__`/`constructor`/`prototype`). Kept here so existing bulk imports
+// stay stable.
+export { isReservedFrontmatterKey } from "../yamlPath";
 
 /** What happened to a single note during a bulk apply. */
 export type BulkOutcome =

--- a/src/metaController.test.ts
+++ b/src/metaController.test.ts
@@ -310,6 +310,22 @@ describe("MetaController reserved-key guard", () => {
         expect(ctx.fm).toEqual({status: "draft"});
     });
 
+    it("updateMultipleInFile refuses a reserved NESTED path segment before the tag splice (atomic)", async () => {
+        const ctx = setupFrontmatter({safe: {ok: 1}});
+        // A nested property carries its key in `path`; `prop.key` is the dotted
+        // label, which is NOT a reserved literal. The guard must inspect the path
+        // segments, or the tag splice lands before setYamlPath throws later.
+        const batch: Property[] = [
+            {key: "#todo", type: MetaType.Tag, content: "#done", position: {start: 0, end: 5, line: 0} as never},
+            {key: "safe.__proto__", type: MetaType.YAML, content: "x", path: ["safe", "__proto__"]},
+        ];
+
+        await expect(callUpdateMultiple(ctx.controller, batch, ctx.file)).rejects.toThrow(/reserved property name/);
+        expect(ctx.vaultModify).not.toHaveBeenCalled();
+        expect(ctx.processFrontMatter).not.toHaveBeenCalled();
+        expect(ctx.fm).toEqual({safe: {ok: 1}});
+    });
+
     it("updateMultipleInFile writes ordinary YAML keys", async () => {
         const ctx = setupFrontmatter({status: "draft"});
 

--- a/src/metaController.test.ts
+++ b/src/metaController.test.ts
@@ -12,6 +12,9 @@ import MetaController from "./metaController";
 import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoPropertyValueModal";
 import {SettingsWriter} from "./settingsWrites";
 import type {AutoProperty} from "./Types/autoProperty";
+import {EditMode} from "./Types/editMode";
+import {MetaType} from "./Types/metaType";
+import type {Property} from "./parser";
 
 const setup = (initial: string) => {
     const store = {content: initial};
@@ -210,5 +213,122 @@ describe("MetaController.persistAutoPropertyChoices", () => {
 
         expect(ctx.liveChoices()).toEqual(["todo"]);
         expect(ctx.diskChoices()).toEqual(["todo"]);
+    });
+});
+
+// Reserved object-machinery keys (__proto__/constructor/prototype) must be
+// refused at EVERY controller frontmatter sink, mirroring the bulk path
+// (deepsec slug other-prototype-pollution). A reserved key is dropped silently
+// (or pollutes the prototype) by a dynamic `frontmatter[key] = value`, so the
+// guard must fail closed - throw, never report a phantom success.
+describe("MetaController reserved-key guard", () => {
+    const RESERVED = ["__proto__", "constructor", "prototype"] as const;
+
+    const setupFrontmatter = (initial: Record<string, unknown> = {}) => {
+        const fm: Record<string, unknown> = {...initial};
+        // Mirror Obsidian: the callback mutates the frontmatter object in place;
+        // if it throws, the error propagates and the note is left unchanged.
+        const processFrontMatter = vi.fn(async (_file: unknown, fn: (f: Record<string, unknown>) => void) => {
+            fn(fm);
+        });
+        const vaultModify = vi.fn(async () => {});
+        const app = {
+            plugins: {plugins: {}},
+            vault: {read: vi.fn(async () => ""), modify: vaultModify},
+            fileManager: {processFrontMatter},
+        };
+        const plugin = {
+            settings: {
+                EditMode: {mode: EditMode.AllSingle, properties: [] as string[]},
+                AutoProperties: {enabled: false, properties: []},
+            },
+        };
+        const controller = new MetaController(app as never, plugin as never);
+        return {controller, file: new TFile("note.md"), fm, processFrontMatter, vaultModify};
+    };
+
+    const callUpdateMultiple = (controller: MetaController, props: Property[], file: TFile) =>
+        (controller as unknown as {updateMultipleInFile(p: Property[], f: TFile): Promise<void>})
+            .updateMultipleInFile(props, file);
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("addYamlProp refuses reserved keys before opening the file, and writes ordinary keys", async () => {
+        const ctx = setupFrontmatter();
+
+        for (const key of RESERVED) {
+            await expect(ctx.controller.addYamlProp(key, "x", ctx.file)).rejects.toThrow(/reserved property name/);
+        }
+        expect(ctx.processFrontMatter).not.toHaveBeenCalled();
+        expect(ctx.fm).toEqual({});
+
+        await ctx.controller.addYamlProp("status", "draft", ctx.file);
+        expect(ctx.fm).toEqual({status: "draft"});
+    });
+
+    it("updatePropertyInFile refuses a reserved YAML key before opening the file, and updates ordinary keys", async () => {
+        const ctx = setupFrontmatter({status: "draft"});
+
+        for (const key of RESERVED) {
+            await expect(
+                ctx.controller.updatePropertyInFile({key, type: MetaType.YAML}, "x", ctx.file),
+            ).rejects.toThrow(/reserved property name/);
+        }
+        expect(ctx.processFrontMatter).not.toHaveBeenCalled();
+        expect(ctx.fm).toEqual({status: "draft"});
+
+        await ctx.controller.updatePropertyInFile({key: "status", type: MetaType.YAML}, "done", ctx.file);
+        expect(ctx.fm).toEqual({status: "done"});
+    });
+
+    it("updateMultipleInFile refuses a batch with any reserved YAML key, atomically", async () => {
+        const ctx = setupFrontmatter({status: "draft"});
+        const batch: Property[] = [
+            {key: "status", type: MetaType.YAML, content: "done"},
+            {key: "__proto__", type: MetaType.YAML, content: "x"},
+        ];
+
+        await expect(callUpdateMultiple(ctx.controller, batch, ctx.file)).rejects.toThrow(/reserved property name/);
+        expect(ctx.processFrontMatter).not.toHaveBeenCalled();
+        expect(ctx.fm).toEqual({status: "draft"});
+    });
+
+    it("updateMultipleInFile leaves body (tag) edits unwritten when a reserved YAML key is in the batch", async () => {
+        const ctx = setupFrontmatter({status: "draft"});
+        // A tag splice runs BEFORE the frontmatter write today, so the up-front
+        // guard must abort the whole batch before any body edit lands.
+        const batch: Property[] = [
+            {key: "#todo", type: MetaType.Tag, content: "#done", position: {start: 0, end: 5, line: 0} as never},
+            {key: "constructor", type: MetaType.YAML, content: "x"},
+        ];
+
+        await expect(callUpdateMultiple(ctx.controller, batch, ctx.file)).rejects.toThrow(/reserved property name/);
+        expect(ctx.vaultModify).not.toHaveBeenCalled();
+        expect(ctx.processFrontMatter).not.toHaveBeenCalled();
+        expect(ctx.fm).toEqual({status: "draft"});
+    });
+
+    it("updateMultipleInFile writes ordinary YAML keys", async () => {
+        const ctx = setupFrontmatter({status: "draft"});
+
+        await callUpdateMultiple(ctx.controller, [{key: "status", type: MetaType.YAML, content: "done"}], ctx.file);
+
+        expect(ctx.fm).toEqual({status: "done"});
+    });
+
+    it("updateYamlPath/addOrUpdateYamlPath refuse a reserved path segment (the throw inside processFrontMatter leaves the note unchanged)", async () => {
+        const ctx = setupFrontmatter({safe: {ok: 1}});
+
+        await expect(ctx.controller.updateYamlPath(["safe", "__proto__"], "x", ctx.file))
+            .rejects.toThrow(/reserved property name/);
+        await expect(ctx.controller.addOrUpdateYamlPath(["__proto__", "x"], "y", ctx.file))
+            .rejects.toThrow(/reserved property name/);
+
+        expect(ctx.fm).toEqual({safe: {ok: 1}});
+
+        await ctx.controller.updateYamlPath(["safe", "ok"], 2, ctx.file);
+        expect(ctx.fm).toEqual({safe: {ok: 2}});
     });
 });

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -613,10 +613,19 @@ export default class MetaController {
         // Refuse a batch with ANY reserved YAML key BEFORE the write starts. This
         // method splices body tags before writing frontmatter, so validating up
         // front keeps the batch atomic: a reserved key never lets the tag/text
-        // edits land while the frontmatter write is the part that fails. Deeper
-        // path segments are also refused by `setYamlPath`.
+        // edits land while the frontmatter write is the part that fails. A nested
+        // property carries its key in `path`, so every string segment is checked -
+        // not just `prop.key` - otherwise `setYamlPath` would only throw later,
+        // inside `processFrontMatter`, after the tag splice already wrote.
         for (const prop of properties) {
-            if (prop.type === MetaType.YAML) this.assertWritableKey(prop.key);
+            if (prop.type !== MetaType.YAML) continue;
+            if (prop.path && prop.path.length > 0) {
+                for (const segment of prop.path) {
+                    if (typeof segment === "string") this.assertWritableKey(segment);
+                }
+            } else {
+                this.assertWritableKey(prop.key);
+            }
         }
 
         await this.enqueueFileWrite(file, async () => {

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -13,7 +13,7 @@ import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoProperty
 import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
-import {getYamlPath, isYamlParentContainerValue, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
+import {getYamlPath, isReservedFrontmatterKey, isYamlParentContainerValue, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
 import {computeTagRewrite, isNestedTag, isTagsKey, isValidTagToken, normalizeTagToken, splitFrontmatterTags, spliceTag, stripHash, tagLeaf, tagParent, canonicalizeFrontmatterTag, type TagEditMode} from "./tagEditing";
 import {setPendingValueContext} from "./Modals/GenericPrompt/promptValueContext";
 
@@ -46,6 +46,12 @@ export default class MetaController {
     }
 
     public async addYamlProp(propName: string, propValue: unknown, file: TFile): Promise<void> {
+        // Refuse reserved object-machinery keys before any work: assigning
+        // `frontmatter["__proto__"] = value` below is silently dropped (or
+        // pollutes the prototype) while reporting success. Fail closed up front,
+        // identically to the bulk path's write boundary.
+        this.assertWritableKey(propName);
+
         const settings = this.plugin.settings;
 
         // A new `tags`/`tag` property is stored as a canonical, `#`-free list.
@@ -469,6 +475,13 @@ export default class MetaController {
     public async updatePropertyInFile(property: Partial<Property>, newValue: unknown, file: TFile): Promise<void> {
         if (!property.key) return;
 
+        // Guard the direct frontmatter key before opening the file. Deeper path
+        // segments (a nested `parent.__proto__` write) are refused by
+        // `setYamlPath` itself; this catches the top-level `frontmatter[key] = `
+        // sink. A reserved `tags`/`tag` key is impossible, so this is harmless
+        // for the tags branch.
+        if (property.type === MetaType.YAML) this.assertWritableKey(property.key);
+
         await this.enqueueFileWrite(file, async () => {
             if (property.type === MetaType.YAML) {
                 await this.processFrontMatter(file, (frontmatter) => {
@@ -544,6 +557,20 @@ export default class MetaController {
         return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
     }
 
+    /**
+     * Throw if `key` is a reserved object-machinery name that can never be written
+     * as a frontmatter property (see {@link isReservedFrontmatterKey}). Centralizes
+     * the refusal so every dynamic `frontmatter[key] = value` sink in the controller
+     * - `addYamlProp`, `updatePropertyInFile`, `updateMultipleInFile` - fails closed
+     * identically to the bulk editor's write boundary, instead of silently dropping
+     * the change (or polluting the prototype) while reporting success.
+     */
+    private assertWritableKey(key: string): void {
+        if (isReservedFrontmatterKey(key)) {
+            throw new Error(`"${key}" is a reserved property name and cannot be written to frontmatter.`);
+        }
+    }
+
     private lineMatch(property: Partial<Property>, line: string): boolean {
         if (!property.key) return false;
 
@@ -583,6 +610,15 @@ export default class MetaController {
     }
 
     private async updateMultipleInFile(properties: Property[], file: TFile): Promise<void> {
+        // Refuse a batch with ANY reserved YAML key BEFORE the write starts. This
+        // method splices body tags before writing frontmatter, so validating up
+        // front keeps the batch atomic: a reserved key never lets the tag/text
+        // edits land while the frontmatter write is the part that fails. Deeper
+        // path segments are also refused by `setYamlPath`.
+        for (const prop of properties) {
+            if (prop.type === MetaType.YAML) this.assertWritableKey(prop.key);
+        }
+
         await this.enqueueFileWrite(file, async () => {
             const yamlProperties = properties.filter(prop => prop.type === MetaType.YAML && !prop.path);
             const yamlPathProperties = properties.filter(prop => prop.type === MetaType.YAML && prop.path);
@@ -713,6 +749,11 @@ export default class MetaController {
      * another write to the same file (e.g. call back into a queued controller
      * method), because that inner write would chain behind this one's still-pending
      * promise and deadlock.
+     *
+     * Because the callback assigns frontmatter keys directly, it does NOT pass
+     * through `assertWritableKey`: the caller owns key validation. The only caller,
+     * the bulk editor, already refuses reserved keys at its own boundaries
+     * (`isReservedFrontmatterKey`); any new caller must do the same.
      */
     public async enqueueFrontmatterWrite(file: TFile, update: (frontmatter: Record<string, unknown>) => void): Promise<void> {
         await this.enqueueFileWrite(file, () => this.processFrontMatter(file, update));

--- a/src/yamlPath.test.ts
+++ b/src/yamlPath.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from "vitest";
 import {
 	formatYamlPath,
 	getYamlPath,
+	isReservedFrontmatterKey,
 	parseYamlPath,
 	setYamlPath,
 	YamlPathError,
@@ -122,5 +123,61 @@ describe("YAML path helpers", () => {
 
 		expect(getYamlPath(root, ["metadata", "child.with.dot"])).toBe("new");
 		expect(root).toEqual({metadata: {"child.with.dot": "new"}});
+	});
+});
+
+describe("isReservedFrontmatterKey", () => {
+	it("flags the object-machinery keys that alias prototype slots", () => {
+		for (const key of ["__proto__", "constructor", "prototype"]) {
+			expect(isReservedFrontmatterKey(key)).toBe(true);
+		}
+	});
+
+	it("leaves ordinary keys alone, matching exactly (no trim, no case-folding)", () => {
+		for (const key of ["status", "proto", "__proto__x", " __proto__ ", "__Proto__", "Constructor", ""]) {
+			expect(isReservedFrontmatterKey(key)).toBe(false);
+		}
+	});
+});
+
+describe("setYamlPath reserved-key guard", () => {
+	it("refuses a reserved leaf segment without mutating the object", () => {
+		const root: Record<string, unknown> = {safe: {}};
+
+		for (const reserved of ["__proto__", "constructor", "prototype"]) {
+			expect(() => setYamlPath(root, ["safe", reserved], "x", {createLeaf: true}))
+				.toThrow(/reserved property name/);
+		}
+
+		expect(root).toEqual({safe: {}});
+	});
+
+	it("refuses a reserved intermediate segment before traversing or creating parents", () => {
+		const root: Record<string, unknown> = {};
+
+		expect(() => setYamlPath(root, "safe.__proto__.x", "y", {createParents: true}))
+			.toThrow(/reserved property name/);
+
+		// The guard runs before traversal, so no `safe` parent is created.
+		expect(root).toEqual({});
+	});
+
+	it("does not pollute the prototype when a reserved object value is written", () => {
+		const root: Record<string, unknown> = {};
+
+		expect(() => setYamlPath(root, "__proto__", {polluted: true}, {createLeaf: true}))
+			.toThrow(YamlPathError);
+
+		// No prototype pollution: a fresh object never gains the injected property.
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(root).toEqual({});
+	});
+
+	it("still allows ordinary keys that merely contain a reserved substring", () => {
+		const root: Record<string, unknown> = {meta: {}};
+
+		setYamlPath(root, ["meta", "__proto__x"], "ok", {createLeaf: true});
+
+		expect(root).toEqual({meta: {__proto__x: "ok"}});
 	});
 });

--- a/src/yamlPath.ts
+++ b/src/yamlPath.ts
@@ -15,6 +15,30 @@ export class YamlPathError extends Error {
 	}
 }
 
+/**
+ * Property names that alias JavaScript object machinery when assigned through a
+ * dynamic `frontmatter[key] = value`, so they can never be written as ordinary
+ * frontmatter keys:
+ *
+ *  - `__proto__` is an accessor inherited from `Object.prototype`. Assigning a
+ *    string (`frontmatter["__proto__"] = "x"`) is silently dropped - no own key
+ *    is created - while assigning an array/object mutates the object's prototype
+ *    instead. Either way the note is left unchanged, yet the operation reports
+ *    success: the report disagrees with what was written.
+ *  - `constructor`/`prototype` do create a real own enumerable property today,
+ *    but it shadows the inherited slot. They are refused alongside `__proto__`
+ *    so a write never produces object-machinery-aliasing keys - the standard
+ *    reserved-key set, applied uniformly.
+ *
+ * This is the single home for the predicate because the lowest-level dynamic-key
+ * sink ({@link setYamlPath}) lives here; the bulk editor re-exports it so its
+ * callers keep a stable import. Matching is exact: a padded literal such as
+ * `" __proto__ "` is an ordinary key (it aliases nothing) and is left alone.
+ */
+export function isReservedFrontmatterKey(key: string): boolean {
+	return key === "__proto__" || key === "constructor" || key === "prototype";
+}
+
 export function parseYamlPath(path: string | readonly YamlPathSegment[]): YamlPath {
 	if (Array.isArray(path)) return validateYamlPath(path);
 	if (typeof path !== "string") throw new YamlPathError("YAML path must be a string or path segment array.");
@@ -57,6 +81,20 @@ export function setYamlPath(
 	options: SetYamlPathOptions = {},
 ): void {
 	const resolvedPath = parseYamlPath(path);
+
+	// Refuse a write to ANY reserved object-machinery segment (leaf or parent),
+	// before traversing, so a path like `safe.__proto__.x` can never assign
+	// through the prototype chain. Reads are intentionally left untouched: they
+	// resolve own keys via `hasOwnProperty` and `formatYamlPath` must keep
+	// accepting these segments for error messages.
+	for (const segment of resolvedPath) {
+		if (typeof segment === "string" && isReservedFrontmatterKey(segment)) {
+			throw new YamlPathError(
+				`Cannot write YAML path '${formatYamlPath(resolvedPath)}': '${segment}' is a reserved property name.`,
+			);
+		}
+	}
+
 	let current: unknown = root;
 
 	for (let idx = 0; idx < resolvedPath.length; idx++) {


### PR DESCRIPTION
## Summary
Reserved object-machinery keys (`__proto__` / `constructor` / `prototype`) were guarded only in the bulk path. The controller's dynamic-key frontmatter writes were not, so the **same data-integrity bug the bulk fix closed (#148) was still latent everywhere else**. This routes every controller `frontmatter[key] = value` sink through the same guard, failing closed instead of silently no-opping while reporting success.

Found by static analysis (deepsec slug `other-prototype-pollution`, HIGH confidence). No GitHub issue exists for this.

## The bug
A literal `__proto__` key assigned through `frontmatter["__proto__"] = value`:
- as a **string** is silently dropped - no own key is created;
- as an **array/object** mutates the object's prototype instead.

Either way the note is left unchanged, yet the operation reports success - the report disagrees with what was written. `constructor`/`prototype` create a real but prototype-shadowing own key. The unguarded sinks were `addYamlProp`, `updatePropertyInFile`, `updateMultipleInFile`, and the nested-path writer `setYamlPath` (reached by `updateYamlPath` / `addOrUpdateYamlPath`).

## Fix
- **Relocate the predicate.** `isReservedFrontmatterKey` moves from `src/bulk/bulkMetadata.ts` to `src/yamlPath.ts` - the lowest-level dynamic-key module, where the primary guarded sink (`setYamlPath`) lives - and is re-exported from `bulkMetadata` so existing bulk imports stay stable. This removes a layering inversion (a leaf util would otherwise import from a feature module).
- **`setYamlPath`** refuses any reserved string segment (leaf *or* parent) before traversing, so `safe.__proto__.x` can never assign through the prototype chain. Reads and `formatYamlPath` are intentionally untouched.
- **Controller `assertWritableKey`** is called at every direct sink, failing closed (throw) identically to the bulk editor's write boundary:
  - `addYamlProp` asserts up front, before any work;
  - `updatePropertyInFile` asserts the YAML key before opening the file;
  - `updateMultipleInFile` asserts every YAML key before the write starts, so a batch that splices body tags before the frontmatter write stays **atomic** (no body edit lands when a reserved key is present).
- **Edit Meta picker** surfaces the refusal as a `Notice` for a typed YAML name (instead of an uncaught rejection), and **preflights the inline-to-YAML transform before `deleteProperty` runs** so transforming an existing `__proto__:: x` field never deletes the source and then fails to re-add it (data loss). The reverse (YAML to inline) is still allowed - it removes the frontmatter key.

The inline (Dataview) `key:: value` paths are line-based, not dynamic object keys, so `__proto__:: value` is harmless text and is intentionally left unguarded. `enqueueFrontmatterWrite` remains a caller-guarded escape hatch (now documented); its only caller, the bulk editor, already refuses reserved keys.

## Per-caller failure surfacing
- UI value edits -> `updatePropertyFromUi` Notice; UI typed-name add / transform -> Notice (this PR).
- Public API -> throws, propagating to the consumer.
- Progress / Kanban automators reuse **configured** property keys, which are never user-typed reserved names; their existing catch/log behavior is unchanged. (Progress's `catch -> log.logError` re-throw is a separate pre-existing concern, out of scope here.)

## Approach validation
Design was put through an adversarial review (opposing model) before coding; its blocking findings are addressed here: the transform data-loss path, not over-guarding the shared `createNewProperty` prompt (inline path stays allowed), and explicitly scoping out `enqueueFrontmatterWrite`.

## Testing
- `pnpm run lint`, `pnpm run build`, `pnpm run test` all green (319 tests, +12).
- New unit tests: each controller sink (`addYamlProp` / `updatePropertyInFile` / `updateMultipleInFile` / `updateYamlPath` / `addOrUpdateYamlPath`) rejects reserved keys and still writes ordinary keys; `updateMultipleInFile` mixed-batch atomicity (no body write when a reserved YAML key is present); `setYamlPath` reserved leaf/parent segments plus a no-prototype-pollution check.
- **Live Obsidian (isolated E2E vault)**: via the public API, `addOrUpdateYamlPath(["safe","__proto__"], ...)` and `createYamlProperty("__proto__"/"constructor"/"prototype", ...)` all reject **and leave the note byte-for-byte unchanged** (proving the throw inside the real `processFrontMatter` prevents the write); ordinary path/property writes still apply; runtime prototype stayed clean. Instance stopped afterward.

## Release impact
No settings/storage/API surface changes. Behavior change: writing a reserved property name now fails with a clear message instead of silently doing nothing.