### PR TITLE
fix(kanban): single notice for a card missing the board property

### DIFF
--- a/__tests__/kanbanHelper.test.ts
+++ b/__tests__/kanbanHelper.test.ts
@@ -1,10 +1,26 @@
-import {describe, it, expect, vi} from "vitest";
+import {afterEach, beforeEach, describe, it, expect, vi} from "vitest";
 import {KanbanHelper} from "../src/automators/onFileModifyAutomators/kanbanHelper";
-import {TFile} from "obsidian";
+import {Notice, TFile} from "obsidian";
+import {log} from "../src/logger/logManager";
+import {GuiLogger} from "../src/logger/guiLogger";
 
 type MockFn = ReturnType<typeof vi.fn>;
 
 vi.spyOn(console, "debug").mockImplementation(() => {});
+
+const resetRegisteredLoggers = () => {
+  (log.constructor as {loggers: unknown[]}).loggers = [];
+};
+
+beforeEach(() => {
+  resetRegisteredLoggers();
+  Notice.messages = [];
+});
+
+afterEach(() => {
+  resetRegisteredLoggers();
+  Notice.messages = [];
+});
 
 type MockApp = {
   metadataCache: {
@@ -582,15 +598,18 @@ describe("KanbanHelper updates linked file properties", () => {
     expect(plugin.controller.updatePropertyInFile).toHaveBeenCalledTimes(1);
   });
 
-  it("emits a notice naming the linked file when the tracked property is missing", async () => {
+  it("emits one GUI notice naming the linked file when the tracked property is missing", async () => {
     const board = "## Doing\n\n- [ ] [[Note]]\n";
     const {helper, plugin, boardFile} = setupBoard(board, {
       Note: {status: undefined}, // note exists but has no status property
     });
+    log.register(new GuiLogger({} as any));
 
     await helper.onFileModify(boardFile);
 
     expect(plugin.controller.updatePropertyInFile).not.toHaveBeenCalled();
+    expect(Notice.messages).toHaveLength(1);
+    expect(Notice.messages[0]).toContain("'status' not found in \"Note\" (Kanban board 'Board').");
   });
 
   it("does nothing when the modified file is not a configured board", async () => {

--- a/src/automators/onFileModifyAutomators/kanbanHelper.ts
+++ b/src/automators/onFileModifyAutomators/kanbanHelper.ts
@@ -1,4 +1,4 @@
-import {type CachedMetadata, type HeadingCache, type LinkCache, Notice, type TFile, getLinkpath, normalizePath} from "obsidian";
+import {type CachedMetadata, type HeadingCache, type LinkCache, type TFile, getLinkpath, normalizePath} from "obsidian";
 import type MetaEdit from "../../main";
 import type {KanbanProperty} from "../../Types/kanbanProperty";
 import {abstractFileToMarkdownTFile} from "../../utility";
@@ -120,7 +120,6 @@ export class KanbanHelper extends OnFileModifyAutomator {
             // Only real card notes reach this point, so the warning is now actionable.
             const message = `'${board.property}' not found in "${linkFile.basename}" (Kanban board '${board.boardName}').`;
             log.logWarning(message);
-            new Notice(message); // This notice helps users debug "property not found" errors.
             return;
         }
 

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -21,10 +21,13 @@ export class TFile {
 }
 
 export class Notice {
+  static messages: string[] = [];
+
   message: string;
 
   constructor(message: string) {
     this.message = message;
+    Notice.messages.push(message);
   }
 }
 


### PR DESCRIPTION
Drop the redundant direct `Notice` in the Kanban missing-property branch.

`log.logWarning` already reaches the registered GUI logger, which surfaces a user-facing Notice. Keeping both paths meant a board edit could show two near-identical notices for every linked card note missing the configured Kanban property.

Refs deepsec slug: `other-duplicate-notice`.

Validation:
- `pnpm exec vitest run __tests__/kanbanHelper.test.ts --testNamePattern "emits one GUI notice"` failed before the production fix with two Notices, then passed after the fix.
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- Isolated Obsidian vault `metaedit-deepsec-dup-notice`: seeded a `Roadmap` board and linked `Card Missing` note without `status`, modified the board, and observed exactly one matching Notice: `MetaEdit: (ERROR) 'status' not found in "Card Missing" (Kanban board 'Roadmap').`
- `pnpm run obsidian:e2e -- dev:errors` reported `No errors captured.`
- `pnpm run stop:e2e-obsidian` stopped the worktree instance.

Release impact: patch-level UX fix; no settings, storage, or API migration.
