### PR TITLE
fix(parser): preserve [[wikilinks]] in multi-value inline edits

### DIFF
--- a/src/autoProperties.test.ts
+++ b/src/autoProperties.test.ts
@@ -156,8 +156,29 @@ describe("toValueArray", () => {
         expect(toValueArray("a, b ,c")).toEqual(["a", "b", "c"]);
     });
 
-    it("strips YAML inline-array brackets", () => {
+    it("unwraps bracketed comma lists", () => {
         expect(toValueArray("[a, b]")).toEqual(["a", "b"]);
+    });
+
+    it("preserves a single inline wikilink", () => {
+        expect(toValueArray("[[Note]]")).toEqual(["[[Note]]"]);
+    });
+
+    it("splits wikilink lists without stripping wikilink brackets", () => {
+        expect(toValueArray("[[A]], [[B]]")).toEqual(["[[A]]", "[[B]]"]);
+    });
+
+    it("does not split commas inside wikilinks", () => {
+        expect(toValueArray("[[A, B]]")).toEqual(["[[A, B]]"]);
+        expect(toValueArray("[[A|B, C]]")).toEqual(["[[A|B, C]]"]);
+    });
+
+    it("unwraps bracketed comma lists without splitting wikilink commas", () => {
+        expect(toValueArray("[a, [[B, C]]]")).toEqual(["a", "[[B, C]]"]);
+    });
+
+    it("preserves non-list bracketed values", () => {
+        expect(toValueArray("[bracketed]")).toEqual(["[bracketed]"]);
     });
 
     it("passes through arrays", () => {

--- a/src/autoProperties.test.ts
+++ b/src/autoProperties.test.ts
@@ -160,6 +160,11 @@ describe("toValueArray", () => {
         expect(toValueArray("[a, b]")).toEqual(["a", "b"]);
     });
 
+    it("keeps empty bracketed lists empty", () => {
+        expect(toValueArray("[]")).toEqual([]);
+        expect(toValueArray("[ ]")).toEqual([]);
+    });
+
     it("preserves a single inline wikilink", () => {
         expect(toValueArray("[[Note]]")).toEqual(["[[Note]]"]);
     });

--- a/src/autoProperties.ts
+++ b/src/autoProperties.ts
@@ -108,17 +108,70 @@ export function withChoicesPasted(choices: string[], index: number, tokens: stri
     return [...before, ...inserted, ...after];
 }
 
+// Historical string values are loose comma lists, not parsed YAML/JSON. Keep the
+// coercion narrow: only commas outside Obsidian wikilinks divide elements.
+function splitCommaSeparatedValues(value: string): string[] {
+    const parts: string[] = [];
+    let start = 0;
+    let wikilinkDepth = 0;
+
+    for (let i = 0; i < value.length; i++) {
+        if (value.startsWith("[[", i)) {
+            wikilinkDepth++;
+            i++;
+            continue;
+        }
+        if (wikilinkDepth > 0 && value.startsWith("]]", i)) {
+            wikilinkDepth--;
+            i++;
+            continue;
+        }
+        if (value[i] === "," && wikilinkDepth === 0) {
+            parts.push(value.slice(start, i));
+            start = i + 1;
+        }
+    }
+
+    parts.push(value.slice(start));
+    return parts;
+}
+
+function matchingOuterBracketIndex(value: string): number | null {
+    let depth = 0;
+
+    for (let i = 0; i < value.length; i++) {
+        const char = value[i];
+        if (char === "[") {
+            depth++;
+        } else if (char === "]") {
+            depth--;
+            if (depth === 0) return i;
+            if (depth < 0) return null;
+        }
+    }
+
+    return null;
+}
+
+function shouldUnwrapBracketedList(value: string): boolean {
+    if (!value.startsWith("[") || !value.endsWith("]")) return false;
+    if (value.startsWith("[[")) return false;
+    if (matchingOuterBracketIndex(value) !== value.length - 1) return false;
+
+    return splitCommaSeparatedValues(value.slice(1, -1)).length > 1;
+}
+
 /** Coerce a stored property value (string, CSV, YAML array, or list) into values. */
 export function toValueArray(content: unknown): string[] {
     if (content === null || content === undefined) return [];
     if (Array.isArray(content)) {
         return content.map((v) => (v ?? "").toString().trim()).filter(Boolean);
     }
-    return content
-        .toString()
-        .replace(/^\s*\[/, "")
-        .replace(/\]\s*$/, "")
-        .split(",")
+
+    const value = content.toString().trim();
+    const splitValue = shouldUnwrapBracketedList(value) ? value.slice(1, -1) : value;
+
+    return splitCommaSeparatedValues(splitValue)
         .map((s) => s.trim())
         .filter(Boolean);
 }

--- a/src/autoProperties.ts
+++ b/src/autoProperties.ts
@@ -158,7 +158,10 @@ function shouldUnwrapBracketedList(value: string): boolean {
     if (value.startsWith("[[")) return false;
     if (matchingOuterBracketIndex(value) !== value.length - 1) return false;
 
-    return splitCommaSeparatedValues(value.slice(1, -1)).length > 1;
+    const innerValue = value.slice(1, -1);
+    if (innerValue.trim() === "") return true;
+
+    return splitCommaSeparatedValues(innerValue).length > 1;
 }
 
 /** Coerce a stored property value (string, CSV, YAML array, or list) into values. */


### PR DESCRIPTION
Preserve Obsidian wikilinks when inline Dataview fields are edited through the multi-value flow.

`toValueArray` previously stripped one leading `[` and one trailing `]` before splitting string values, so an inline field like `key:: [[Note]]` could be rewritten as `key:: [Note]` after a multi-value edit. This keeps MetaEdit's historical loose comma-list coercion, but only unwraps a bracketed list when the outer bracket pair actually encloses the whole value, preserves empty `[]` lists, and ignores commas inside `[[wikilinks]]`.

Deepsec: `other-data-corruption`.

Review follow-up:
- Addressed Codex P2 feedback by preserving the previous `toValueArray("[]") -> []` behavior for empty bracketed lists.

Validation:
- Adversarial design review attempted through Claude; unavailable due weekly quota. Oracle Gemini was unavailable and Oracle ChatGPT browser was logged out, so I used a read-only fallback reviewer. Accepted feedback: avoid naive bracket-shape detection, keep the parser boundary narrow, and add helper-level tests for wikilinks and wikilink commas.
- `pnpm exec vitest run src/autoProperties.test.ts` (40 tests)
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` (20 files, 332 tests)
- Isolated Obsidian vault `metaedit-deepsec-wikilink`: edited `key:: [[Note]]` through `plugin.controller.multiValueMode`; file remained `key:: [[Note]]`.
- Isolated Obsidian vault `metaedit-deepsec-wikilink`: edited `key:: [[A]], [[B]]` through `plugin.controller.multiValueMode`; file remained `key:: [[A]], [[B]]`.
- `pnpm run obsidian:e2e -- dev:errors` reported no captured errors.
- `pnpm run stop:e2e-obsidian` stopped the isolated instance after each runtime proof.

Release impact: patch bug fix; no settings or migration changes.