### PR TITLE
fix(api): guard reserved keys in cloneValue for clone fidelity

### DIFF
--- a/src/MetaEditApi.test.ts
+++ b/src/MetaEditApi.test.ts
@@ -23,6 +23,46 @@ function setupApi(flush: () => Promise<void>) {
 	return {api, plugin, settings};
 }
 
+function setupPrivateApi() {
+	return new MetaEditApi({app: {}} as never) as unknown as {
+		cloneValue(value: unknown): unknown;
+	};
+}
+
+describe("MetaEditApi.cloneValue", () => {
+	it("copies an own enumerable __proto__ data key without changing the clone prototype", () => {
+		const api = setupPrivateApi();
+		const source = {
+			normal: {
+				nested: ["value", {deep: 1}],
+			},
+		} as Record<string, unknown>;
+		const protoValue = {x: 1};
+		Object.defineProperty(source, "__proto__", {
+			value: protoValue,
+			enumerable: true,
+			configurable: true,
+			writable: true,
+		});
+
+		const clone = api.cloneValue(source) as Record<string, unknown>;
+		const clonedProtoValue = Object.getOwnPropertyDescriptor(clone, "__proto__")?.value;
+
+		expect(Object.getPrototypeOf(clone)).toBe(Object.prototype);
+		expect(Object.prototype.hasOwnProperty.call(clone, "__proto__")).toBe(true);
+		expect(clonedProtoValue).toEqual({x: 1});
+		expect(clonedProtoValue).not.toBe(protoValue);
+		expect(clone.normal).toEqual(source.normal);
+		expect(clone.normal).not.toBe(source.normal);
+
+		const clonedNormal = clone.normal as {nested: unknown[]};
+		const sourceNormal = source.normal as {nested: unknown[]};
+		expect(clonedNormal.nested).toEqual(sourceNormal.nested);
+		expect(clonedNormal.nested).not.toBe(sourceNormal.nested);
+		expect(clonedNormal.nested[1]).not.toBe(sourceNormal.nested[1]);
+	});
+});
+
 describe("MetaEditApi.setAutoProperties", () => {
 	it("rejects invalid input immediately, without waiting behind a pending settings save", async () => {
 		let releaseSave!: () => void;

--- a/src/MetaEditApi.ts
+++ b/src/MetaEditApi.ts
@@ -376,10 +376,16 @@ export class MetaEditApi {
         }
 
         if (value && typeof value === "object") {
-            return Object.entries(value as Record<string, unknown>).reduce((clone, [key, item]) => {
-                clone[key] = this.cloneValue(item);
-                return clone;
-            }, {} as Record<string, unknown>);
+            const clone: Record<string, unknown> = {};
+            for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+                Object.defineProperty(clone, key, {
+                    value: this.cloneValue(item),
+                    enumerable: true,
+                    configurable: true,
+                    writable: true,
+                });
+            }
+            return clone;
         }
 
         return value;


### PR DESCRIPTION
Preserve clone fidelity when `cloneValue()` sees enumerable own keys that overlap JavaScript object machinery.

The object clone path now defines each cloned entry as an own data property instead of assigning through `clone[key]`, so an own enumerable `__proto__` value is copied without invoking the inherited prototype setter. This addresses deepsec slug `other-clone-proto-key` as a consistency hardening fix, not a security issue.

Adds regression coverage for an own-enumerable `__proto__` data key and keeps normal nested object/array clone isolation covered.

Validation:
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`

Runtime verification: not run; this is a pure API clone helper change covered by unit tests and does not alter Obsidian runtime write behavior.

Release/migration impact: none.