### PR TITLE
fix(settings): settings tab no longer clobbers concurrently-added Auto Property choices

### DIFF
--- a/src/Modals/AutoPropertiesSettingModal/AutoPropertiesModalContent.svelte
+++ b/src/Modals/AutoPropertiesSettingModal/AutoPropertiesModalContent.svelte
@@ -2,18 +2,35 @@
     import {untrack} from "svelte";
     import {setIcon} from "obsidian";
     import type {AutoProperty, AutoPropertyType} from "../../Types/autoProperty";
-    import {splitPastedChoices, withChoicesPasted} from "../../autoProperties";
+    import {
+        cloneAutoProperty,
+        cloneAutoProperties,
+        splitPastedChoices,
+        withChoicesPasted,
+        type AutoPropertyOperationTarget,
+        type AutoPropertySettingsOperation,
+    } from "../../autoProperties";
+
+    interface EditableAutoProperty {
+        id: number;
+        property: AutoProperty;
+        targetName: string;
+        choiceTargets: string[];
+    }
 
     let {
         save,
         autoProperties: initialAutoProperties = [],
     }: {
-        save: (autoProperties: AutoProperty[]) => void;
+        save: (operation: AutoPropertySettingsOperation) => void | Promise<void>;
         autoProperties?: AutoProperty[];
     } = $props();
 
     const types: AutoPropertyType[] = ["Single", "Multi"];
-    let autoProperties = $state<AutoProperty[]>(untrack(() => cloneAutoProperties(initialAutoProperties)));
+    let nextPropertyId = 0;
+    let autoProperties = $state<EditableAutoProperty[]>(
+        untrack(() => createEditableAutoProperties(initialAutoProperties)),
+    );
 
     // Svelte action: render a lucide icon into an element via Obsidian's setIcon.
     function icon(node: HTMLElement, name: string) {
@@ -25,58 +42,110 @@
         return {update: render};
     }
 
-    function cloneAutoProperties(properties: AutoProperty[]): AutoProperty[] {
-        if (!Array.isArray(properties)) return [];
-
-        return properties.map(property => ({
-            ...property,
-            choices: Array.isArray(property.choices) ? [...property.choices] : [],
-        }));
-    }
-
     function indexes<T>(values: T[]): number[] {
         return values.map((_, i) => i);
     }
 
-    function saveProperties() {
-        save($state.snapshot(autoProperties) as AutoProperty[]);
+    function createEditableAutoProperties(properties: AutoProperty[]): EditableAutoProperty[] {
+        return cloneAutoProperties(properties).map(property => createEditableAutoProperty(property));
+    }
+
+    function createEditableAutoProperty(property: AutoProperty): EditableAutoProperty {
+        return {
+            id: nextPropertyId++,
+            property,
+            targetName: property.name,
+            choiceTargets: [...property.choices],
+        };
+    }
+
+    function targetFor(entry: EditableAutoProperty, index: number): AutoPropertyOperationTarget {
+        return {name: entry.targetName, index};
+    }
+
+    function persist(operation: AutoPropertySettingsOperation) {
+        void Promise.resolve(save(operation)).catch(error => {
+            console.error("MetaEdit could not save Auto Properties settings.", error);
+        });
     }
 
     function addNewProperty() {
-        autoProperties = [...autoProperties, {name: "", choices: [""], type: "Single"}];
-        saveProperties();
+        const property: AutoProperty = {name: "", choices: [""], type: "Single"};
+        const entry = createEditableAutoProperty(cloneAutoProperty(property));
+        const index = autoProperties.length;
+        autoProperties = [...autoProperties, entry];
+        persist({kind: "addProperty", index, property});
     }
 
-    function removeProperty(property: AutoProperty) {
-        autoProperties = autoProperties.filter(ac => ac !== property);
-        saveProperties();
+    function removeProperty(entry: EditableAutoProperty, index: number) {
+        const target = targetFor(entry, index);
+        autoProperties = autoProperties.filter(candidate => candidate !== entry);
+        persist({kind: "removeProperty", target});
     }
 
-    function removeChoice(property: AutoProperty, i: number) {
-        property.choices = property.choices.filter((_, index) => index !== i);
-        saveProperties();
+    function removeChoice(entry: EditableAutoProperty, propertyIndex: number, choiceIndex: number) {
+        const value = entry.choiceTargets[choiceIndex] ?? entry.property.choices[choiceIndex] ?? "";
+        entry.property.choices = entry.property.choices.filter((_, index) => index !== choiceIndex);
+        entry.choiceTargets = entry.choiceTargets.filter((_, index) => index !== choiceIndex);
+        persist({kind: "removeChoice", target: targetFor(entry, propertyIndex), index: choiceIndex, value});
     }
 
-    function addChoice(property: AutoProperty) {
-        property.choices = [...property.choices, ""];
-        saveProperties();
+    function addChoice(entry: EditableAutoProperty, propertyIndex: number) {
+        const index = entry.property.choices.length;
+        entry.property.choices = [...entry.property.choices, ""];
+        entry.choiceTargets = [...entry.choiceTargets, ""];
+        persist({kind: "addChoice", target: targetFor(entry, propertyIndex), index, value: ""});
     }
 
     // Paste a whole list (newline- or comma-separated) into a single value box and
     // have it become individual choices (issue #47). A paste that yields a single
     // token falls through to the browser's default, so pasting one value still works.
-    function pasteChoices(property: AutoProperty, index: number, event: ClipboardEvent) {
+    function pasteChoices(entry: EditableAutoProperty, propertyIndex: number, index: number, event: ClipboardEvent) {
         const tokens = splitPastedChoices(event.clipboardData?.getData("text") ?? "");
         if (tokens.length < 2) return;
 
         event.preventDefault();
-        property.choices = withChoicesPasted(property.choices, index, tokens);
-        saveProperties();
+        const previousValue = entry.choiceTargets[index] ?? entry.property.choices[index] ?? "";
+        entry.property.choices = withChoicesPasted(entry.property.choices, index, tokens);
+        entry.choiceTargets = withChoicesPasted(entry.choiceTargets, index, tokens);
+        persist({
+            kind: "replaceChoiceWithChoices",
+            target: targetFor(entry, propertyIndex),
+            index,
+            previousValue,
+            values: tokens,
+        });
     }
 
-    function setType(property: AutoProperty, value: string) {
-        property.type = value as AutoPropertyType;
-        saveProperties();
+    function setName(entry: EditableAutoProperty, index: number, value: string) {
+        const target = targetFor(entry, index);
+        entry.property.name = value;
+        entry.targetName = value;
+        persist({kind: "setName", target, value});
+    }
+
+    function setDescription(entry: EditableAutoProperty, index: number, value: string) {
+        entry.property.description = value;
+        persist({kind: "setDescription", target: targetFor(entry, index), value});
+    }
+
+    function setType(entry: EditableAutoProperty, index: number, value: string) {
+        const type = value as AutoPropertyType;
+        entry.property.type = type;
+        persist({kind: "setType", target: targetFor(entry, index), value: type});
+    }
+
+    function setChoice(entry: EditableAutoProperty, propertyIndex: number, choiceIndex: number, value: string) {
+        const previousValue = entry.choiceTargets[choiceIndex] ?? entry.property.choices[choiceIndex] ?? "";
+        entry.property.choices[choiceIndex] = value;
+        entry.choiceTargets[choiceIndex] = value;
+        persist({
+            kind: "setChoice",
+            target: targetFor(entry, propertyIndex),
+            index: choiceIndex,
+            previousValue,
+            value,
+        });
     }
 </script>
 
@@ -87,19 +156,21 @@
         </p>
     {/if}
 
-    {#each autoProperties as property (property)}
+    {#each autoProperties as entry, propertyIndex (entry.id)}
+        {@const property = entry.property}
         <div class="metaedit-ap-card">
             <div class="metaedit-ap-header">
                 <input
                     class="metaedit-ap-name"
                     type="text"
                     placeholder="Property name"
-                    bind:value={property.name}
-                    onchange={saveProperties}
+                    value={property.name}
+                    oninput={(e) => property.name = e.currentTarget.value}
+                    onchange={(e) => setName(entry, propertyIndex, e.currentTarget.value)}
                 />
                 <select
                     class="dropdown metaedit-ap-type"
-                    onchange={(e) => setType(property, e.currentTarget.value)}
+                    onchange={(e) => setType(entry, propertyIndex, e.currentTarget.value)}
                     aria-label="How many values this property holds"
                 >
                     {#each types as t (t)}
@@ -109,7 +180,7 @@
                 <button
                     class="clickable-icon metaedit-ap-icon"
                     aria-label="Remove this auto property"
-                    onclick={() => removeProperty(property)}
+                    onclick={() => removeProperty(entry, propertyIndex)}
                 >
                     <span use:icon={"trash-2"}></span>
                 </button>
@@ -119,8 +190,9 @@
                 class="metaedit-ap-description"
                 type="text"
                 placeholder="Description (shown when you pick a value) - optional"
-                bind:value={property.description}
-                onchange={saveProperties}
+                value={property.description ?? ""}
+                oninput={(e) => property.description = e.currentTarget.value}
+                onchange={(e) => setDescription(entry, propertyIndex, e.currentTarget.value)}
             />
 
             <div class="metaedit-ap-values">
@@ -130,20 +202,21 @@
                         <input
                             type="text"
                             placeholder="Value (or paste a list)"
-                            bind:value={property.choices[i]}
-                            onchange={saveProperties}
-                            onpaste={(e) => pasteChoices(property, i, e)}
+                            value={property.choices[i]}
+                            oninput={(e) => property.choices[i] = e.currentTarget.value}
+                            onchange={(e) => setChoice(entry, propertyIndex, i, e.currentTarget.value)}
+                            onpaste={(e) => pasteChoices(entry, propertyIndex, i, e)}
                         />
                         <button
                             class="clickable-icon metaedit-ap-icon"
                             aria-label="Remove value"
-                            onclick={() => removeChoice(property, i)}
+                            onclick={() => removeChoice(entry, propertyIndex, i)}
                         >
                             <span use:icon={"x"}></span>
                         </button>
                     </div>
                 {/each}
-                <button class="metaedit-ap-add-value" onclick={() => addChoice(property)}>
+                <button class="metaedit-ap-add-value" onclick={() => addChoice(entry, propertyIndex)}>
                     <span use:icon={"plus"}></span>
                     Add value
                 </button>

--- a/src/Settings/metaEditSettingsTab.ts
+++ b/src/Settings/metaEditSettingsTab.ts
@@ -1,4 +1,4 @@
-import {type App, PluginSettingTab, Setting} from "obsidian";
+import {type App, Notice, PluginSettingTab, Setting} from "obsidian";
 import type MetaEdit from "../main";
 import {EditMode} from "../Types/editMode";
 import ProgressPropertiesModalContent
@@ -7,9 +7,9 @@ import AutoPropertiesModalContent from "../Modals/AutoPropertiesSettingModal/Aut
 import KanbanHelperSettingContent from "../Modals/KanbanHelperSetting/KanbanHelperSettingContent.svelte";
 import SingleValueTableEditorContent from "../Modals/shared/SingleValueTableEditorContent.svelte";
 import type {ProgressProperty} from "../Types/progressProperty";
-import type {AutoProperty} from "../Types/autoProperty";
 import type {KanbanProperty} from "../Types/kanbanProperty";
 import {type MountedSvelteComponent, mountSvelteComponent, unmountSvelteComponent} from "../svelteMount";
+import {applyAutoPropertySettingsOperation, type AutoPropertySettingsOperation} from "../autoProperties";
 
 function toggleHiddenEl(el: HTMLElement | undefined, hidden: boolean) {
     if (!el) return hidden;
@@ -110,14 +110,34 @@ export class MetaEditSettingsTab extends PluginSettingTab {
             div,
             {
                 autoProperties: this.plugin.settings.AutoProperties.properties,
-                save: async (autoProperties: AutoProperty[]) => {
-                    this.plugin.settings.AutoProperties.properties = autoProperties;
-                    await this.plugin.saveSettings();
-                }
+                save: (operation: AutoPropertySettingsOperation) => this.saveAutoPropertiesOperation(operation),
             },
         );
 
         this.svelteElements.push(modal);
+    }
+
+    private async saveAutoPropertiesOperation(operation: AutoPropertySettingsOperation) {
+        try {
+            await this.plugin.updateSettings(() => {
+                const previousAutoProperties = this.plugin.settings.AutoProperties.properties;
+                const nextAutoProperties = applyAutoPropertySettingsOperation(previousAutoProperties, operation);
+                if (nextAutoProperties === false) return false;
+
+                this.plugin.settings.AutoProperties.properties = nextAutoProperties;
+
+                // Compare-and-restore: only undo this settings-tab operation if the
+                // failed flush still points at the array this operation assigned.
+                return () => {
+                    if (this.plugin.settings.AutoProperties.properties === nextAutoProperties) {
+                        this.plugin.settings.AutoProperties.properties = previousAutoProperties;
+                    }
+                };
+            });
+        } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            new Notice(`MetaEdit could not save the Auto Properties setting: ${reason}`);
+        }
     }
 
     private addEditMetaMenuSetting(containerEl: HTMLElement) {

--- a/src/autoProperties.test.ts
+++ b/src/autoProperties.test.ts
@@ -193,6 +193,21 @@ describe("applyAutoPropertySettingsOperation", () => {
         expect(next).toEqual([{name: "status", choices: ["external"]}]);
     });
 
+    it("inserts pasted choices without replacing a live choice when the stale row disappeared", () => {
+        const next = applyAutoPropertySettingsOperation(
+            [{name: "status", choices: ["todo", "external"]}],
+            {
+                kind: "replaceChoiceWithChoices",
+                target,
+                index: 1,
+                previousValue: "",
+                values: ["doing", "blocked"],
+            },
+        );
+
+        expect(next).toEqual([{name: "status", choices: ["todo", "doing", "blocked", "external"]}]);
+    });
+
     it("keeps live-added properties when the tab edits another property", () => {
         const next = applyAutoPropertySettingsOperation(
             [

--- a/src/autoProperties.test.ts
+++ b/src/autoProperties.test.ts
@@ -1,6 +1,8 @@
 import {describe, expect, it} from "vitest";
 import {
+    applyAutoPropertySettingsOperation,
     autoPropertyType,
+    cloneAutoProperties,
     findAutoProperty,
     isMultiAutoProperty,
     isNewChoice,
@@ -143,6 +145,84 @@ describe("withChoicesPasted", () => {
 
     it("trims tokens", () => {
         expect(withChoicesPasted([""], 0, [" a ", "b"])).toEqual(["a", "b"]);
+    });
+});
+
+describe("applyAutoPropertySettingsOperation", () => {
+    const target = {name: "status", index: 0};
+
+    it("updates a tab-edited field without dropping a choice added to live settings", () => {
+        const live: AutoProperty[] = [{name: "status", choices: ["todo", "external"], type: "Single"}];
+
+        const next = applyAutoPropertySettingsOperation(live, {
+            kind: "setDescription",
+            target,
+            value: "Shown in the picker",
+        });
+
+        expect(next).toEqual([
+            {name: "status", choices: ["todo", "external"], type: "Single", description: "Shown in the picker"},
+        ]);
+        expect(live[0].choices).toEqual(["todo", "external"]);
+    });
+
+    it("renames the live property while preserving concurrently-added choices", () => {
+        const next = applyAutoPropertySettingsOperation(
+            [{name: "status", choices: ["todo", "external"], type: "Single"}],
+            {kind: "setName", target, value: "state"},
+        );
+
+        expect(next).toEqual([{name: "state", choices: ["todo", "external"], type: "Single"}]);
+    });
+
+    it("edits only the targeted choice and preserves live choices the tab never saw", () => {
+        const next = applyAutoPropertySettingsOperation(
+            [{name: "status", choices: ["todo", "external"]}],
+            {kind: "setChoice", target, index: 0, previousValue: "todo", value: "doing"},
+        );
+
+        expect(next).toEqual([{name: "status", choices: ["doing", "external"]}]);
+    });
+
+    it("removes only the targeted choice and preserves live choices the tab never saw", () => {
+        const next = applyAutoPropertySettingsOperation(
+            [{name: "status", choices: ["todo", "external"]}],
+            {kind: "removeChoice", target, index: 0, value: "todo"},
+        );
+
+        expect(next).toEqual([{name: "status", choices: ["external"]}]);
+    });
+
+    it("keeps live-added properties when the tab edits another property", () => {
+        const next = applyAutoPropertySettingsOperation(
+            [
+                {name: "status", choices: ["todo"]},
+                {name: "priority", choices: ["high"]},
+            ],
+            {kind: "setType", target, value: "Multi"},
+        );
+
+        expect(next).toEqual([
+            {name: "status", choices: ["todo"], type: "Multi"},
+            {name: "priority", choices: ["high"]},
+        ]);
+    });
+
+    it("returns false when the target property no longer exists", () => {
+        expect(applyAutoPropertySettingsOperation(
+            [{name: "priority", choices: ["high"]}],
+            {kind: "setDescription", target, value: "ignored"},
+        )).toBe(false);
+    });
+
+    it("clones Auto Properties without sharing choice arrays", () => {
+        const live: AutoProperty[] = [{name: "status", choices: ["todo"]}];
+        const clone = cloneAutoProperties(live);
+
+        clone[0].choices.push("done");
+
+        expect(live[0].choices).toEqual(["todo"]);
+        expect(clone[0].choices).toEqual(["todo", "done"]);
     });
 });
 

--- a/src/autoProperties.ts
+++ b/src/autoProperties.ts
@@ -201,9 +201,9 @@ export function applyAutoPropertySettingsOperation(
         case "replaceChoiceWithChoices": {
             const property = findAutoPropertyOperationTarget(next, operation.target);
             if (!property) return false;
-            const choiceIndex = findWritableChoiceIndex(property.choices, operation.index, operation.previousValue);
-            if (choiceIndex >= property.choices.length) {
-                property.choices.push(...operation.values);
+            const choiceIndex = findExistingChoiceIndex(property.choices, operation.index, operation.previousValue);
+            if (choiceIndex === -1) {
+                property.choices = withChoicesInserted(property.choices, operation.index, operation.values);
             } else {
                 property.choices = withChoicesPasted(property.choices, choiceIndex, operation.values);
             }
@@ -247,6 +247,22 @@ function findWritableChoiceIndex(choices: string[], index: number, value: string
     const existingIndex = findExistingChoiceIndex(choices, index, value);
     if (existingIndex !== -1) return existingIndex;
     return boundedInsertIndex(index, choices.length);
+}
+
+function withChoicesInserted(choices: string[], index: number, tokens: string[]): string[] {
+    const next = [...choices];
+    const taken = new Set(next.map((c) => (c ?? "").trim()).filter((c) => c !== ""));
+    const inserted: string[] = [];
+
+    for (const raw of tokens) {
+        const choice = (raw ?? "").trim();
+        if (choice === "" || taken.has(choice)) continue;
+        taken.add(choice);
+        inserted.push(choice);
+    }
+
+    next.splice(boundedInsertIndex(index, next.length), 0, ...inserted);
+    return next;
 }
 
 function isValidIndex(index: number, length: number): boolean {

--- a/src/autoProperties.ts
+++ b/src/autoProperties.ts
@@ -12,6 +12,22 @@ export interface EditModeSettings {
     properties: string[];
 }
 
+export interface AutoPropertyOperationTarget {
+    name: string;
+    index: number;
+}
+
+export type AutoPropertySettingsOperation =
+    | {kind: "addProperty"; index: number; property: AutoProperty}
+    | {kind: "removeProperty"; target: AutoPropertyOperationTarget}
+    | {kind: "setName"; target: AutoPropertyOperationTarget; value: string}
+    | {kind: "setDescription"; target: AutoPropertyOperationTarget; value: string}
+    | {kind: "setType"; target: AutoPropertyOperationTarget; value: AutoPropertyType}
+    | {kind: "addChoice"; target: AutoPropertyOperationTarget; index: number; value: string}
+    | {kind: "removeChoice"; target: AutoPropertyOperationTarget; index: number; value: string}
+    | {kind: "setChoice"; target: AutoPropertyOperationTarget; index: number; previousValue: string; value: string}
+    | {kind: "replaceChoiceWithChoices"; target: AutoPropertyOperationTarget; index: number; previousValue: string; values: string[]};
+
 /** Find the auto property whose name matches `propertyName` (first match wins). */
 export function findAutoProperty(
     properties: AutoProperty[] | undefined,
@@ -106,6 +122,135 @@ export function withChoicesPasted(choices: string[], index: number, tokens: stri
         inserted.push(choice);
     }
     return [...before, ...inserted, ...after];
+}
+
+export function cloneAutoProperty(property: AutoProperty): AutoProperty {
+    const clone: AutoProperty = {
+        name: property.name,
+        choices: Array.isArray(property.choices) ? [...property.choices] : [],
+    };
+
+    if (property.description !== undefined) clone.description = property.description;
+    if (property.type !== undefined) clone.type = property.type;
+    return clone;
+}
+
+export function cloneAutoProperties(properties: AutoProperty[] | undefined): AutoProperty[] {
+    if (!Array.isArray(properties)) return [];
+    return properties.map(cloneAutoProperty);
+}
+
+export function applyAutoPropertySettingsOperation(
+    properties: AutoProperty[],
+    operation: AutoPropertySettingsOperation,
+): AutoProperty[] | false {
+    const next = cloneAutoProperties(properties);
+
+    switch (operation.kind) {
+        case "addProperty": {
+            const index = boundedInsertIndex(operation.index, next.length);
+            next.splice(index, 0, cloneAutoProperty(operation.property));
+            return next;
+        }
+        case "removeProperty": {
+            const index = findAutoPropertyOperationTargetIndex(next, operation.target);
+            if (index === -1) return false;
+            next.splice(index, 1);
+            return next;
+        }
+        case "setName":
+        case "setDescription":
+        case "setType": {
+            const index = findAutoPropertyOperationTargetIndex(next, operation.target);
+            if (index === -1) return false;
+            const current = next[index];
+            if (operation.kind === "setName") {
+                if (current.name === operation.value) return false;
+                current.name = operation.value;
+            } else if (operation.kind === "setDescription") {
+                if ((current.description ?? "") === operation.value) return false;
+                current.description = operation.value;
+            } else {
+                if ((current.type ?? "Single") === operation.value) return false;
+                current.type = operation.value;
+            }
+            return next;
+        }
+        case "addChoice": {
+            const property = findAutoPropertyOperationTarget(next, operation.target);
+            if (!property) return false;
+            property.choices.splice(boundedInsertIndex(operation.index, property.choices.length), 0, operation.value);
+            return next;
+        }
+        case "removeChoice": {
+            const property = findAutoPropertyOperationTarget(next, operation.target);
+            if (!property) return false;
+            const choiceIndex = findExistingChoiceIndex(property.choices, operation.index, operation.value);
+            if (choiceIndex === -1) return false;
+            property.choices.splice(choiceIndex, 1);
+            return next;
+        }
+        case "setChoice": {
+            const property = findAutoPropertyOperationTarget(next, operation.target);
+            if (!property) return false;
+            if (operation.previousValue === operation.value) return false;
+            const choiceIndex = findWritableChoiceIndex(property.choices, operation.index, operation.previousValue);
+            property.choices.splice(choiceIndex, choiceIndex < property.choices.length ? 1 : 0, operation.value);
+            return next;
+        }
+        case "replaceChoiceWithChoices": {
+            const property = findAutoPropertyOperationTarget(next, operation.target);
+            if (!property) return false;
+            const choiceIndex = findWritableChoiceIndex(property.choices, operation.index, operation.previousValue);
+            if (choiceIndex >= property.choices.length) {
+                property.choices.push(...operation.values);
+            } else {
+                property.choices = withChoicesPasted(property.choices, choiceIndex, operation.values);
+            }
+            return next;
+        }
+    }
+}
+
+function boundedInsertIndex(index: number, length: number): number {
+    if (!Number.isFinite(index)) return length;
+    return Math.max(0, Math.min(index, length));
+}
+
+function findAutoPropertyOperationTarget(properties: AutoProperty[], target: AutoPropertyOperationTarget): AutoProperty | undefined {
+    const index = findAutoPropertyOperationTargetIndex(properties, target);
+    return index === -1 ? undefined : properties[index];
+}
+
+function findAutoPropertyOperationTargetIndex(properties: AutoProperty[], target: AutoPropertyOperationTarget): number {
+    if (isValidIndex(target.index, properties.length) && properties[target.index].name === target.name) {
+        return target.index;
+    }
+
+    if (target.name !== "") {
+        const namedIndex = properties.findIndex(property => property.name === target.name);
+        if (namedIndex !== -1) return namedIndex;
+    }
+
+    if (target.name === "" && isValidIndex(target.index, properties.length)) return target.index;
+
+    return -1;
+}
+
+function findExistingChoiceIndex(choices: string[], index: number, value: string): number {
+    if (isValidIndex(index, choices.length) && choices[index] === value) return index;
+
+    return choices.findIndex(choice => choice === value);
+}
+
+function findWritableChoiceIndex(choices: string[], index: number, value: string): number {
+    const existingIndex = findExistingChoiceIndex(choices, index, value);
+    if (existingIndex !== -1) return existingIndex;
+    return boundedInsertIndex(index, choices.length);
+}
+
+function isValidIndex(index: number, length: number): boolean {
+    return Number.isInteger(index) && index >= 0 && index < length;
 }
 
 // Historical string values are loose comma lists, not parsed YAML/JSON. Keep the

--- a/tests/e2e/audit-settings.test.ts
+++ b/tests/e2e/audit-settings.test.ts
@@ -143,6 +143,60 @@ describe("MetaEdit settings tab", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("AUTO-03: settings tab saves do not clobber choices added elsewhere while open", async () => {
+		const { obsidian } = getContext();
+		const result = await evalJsonAsync<{
+			afterExternal: string[];
+			afterTabSave: { choices: string[]; description?: string };
+			persisted: { choices: string[]; description?: string };
+		}>(
+			obsidian,
+			`
+			(async () => {
+				${HELPERS}
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const snapshot = {
+					auto: JSON.parse(JSON.stringify(plugin.settings.AutoProperties)),
+				};
+
+				plugin.settings.AutoProperties.enabled = true;
+				plugin.settings.AutoProperties.properties = [{ name: "status", choices: ["todo"], type: "Single" }];
+				await plugin.saveSettings();
+
+				const root = await openTab();
+				const item = itemByName(root, "Auto Properties");
+				item.querySelector(".extra-setting-button").click();
+				await sleep(250);
+
+				await plugin.api.setAutoProperties([{ name: "status", choices: ["todo", "external"], type: "Single" }]);
+				const afterExternal = plugin.settings.AutoProperties.properties[0].choices.slice();
+
+				const desc = item.querySelector(".metaedit-ap-description");
+				desc.value = "tab edit";
+				desc.dispatchEvent(new Event("input", { bubbles: true }));
+				desc.dispatchEvent(new Event("change", { bubbles: true }));
+				await sleep(500);
+
+				const afterTabSave = JSON.parse(JSON.stringify(plugin.settings.AutoProperties.properties[0]));
+				const persisted = (await plugin.loadData()).AutoProperties.properties[0];
+
+				app.setting.close();
+				plugin.settings.AutoProperties = snapshot.auto;
+				await plugin.saveSettings();
+
+				return { afterExternal, afterTabSave, persisted };
+			})()
+		`,
+		);
+
+		expect(result.afterExternal).toEqual(["todo", "external"]);
+		expect(result.afterTabSave.choices).toEqual(["todo", "external"]);
+		expect(result.afterTabSave.description).toBe("tab edit");
+		expect(result.persisted.choices).toEqual(["todo", "external"]);
+		expect(result.persisted.description).toBe("tab edit");
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("MENU-04: UIElements toggle registers and unregisters the Edit Meta file menu", async () => {
 		const { obsidian, sandbox } = getContext();
 		const notePath = sandbox.path("menu-toggle.md");


### PR DESCRIPTION
Prevent the Auto Properties settings tab from saving a stale whole-list snapshot over live settings changes.

The tab now emits narrow edit operations for property/choice changes. The settings tab applies each operation through `updateSettings()`, so it reads the current live Auto Properties list at the head of the serialized settings queue and preserves choices or properties added by the API or the in-note save-as-choice flow while the tab is open.

An adversarial design review rejected the initial whole-snapshot three-way merge approach because property names are mutable and the component already knows the exact user operation. This PR keeps that operation-level intent instead of reconstructing it from two stale snapshots.

Validation:
- Reproduced the bug in the isolated vault `metaedit-settings-tab-race`: opened Auto Properties settings, added `external` through `plugin.api.setAutoProperties`, then saved a description edit from the still-open tab; before the fix, persisted choices reverted to `["todo"]`.
- Re-ran the same isolated-vault repro after the fix; persisted choices stayed `["todo", "external"]` and the tab description edit persisted.
- `pnpm exec vitest run src/autoProperties.test.ts`
- `pnpm run lint && pnpm run build && pnpm run test`
- `METAEDIT_E2E_OBSIDIAN_HOME` isolated run: `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/audit-settings.test.ts`
- `pnpm run obsidian:e2e -- dev:errors` returned no captured errors after the live repro.
- `pnpm run stop:e2e-obsidian`

Release impact: patch bug fix for settings persistence; no settings migration or public API change.