### PR TITLE
fix(controller): make inline-field writes fence-aware

### DIFF
--- a/src/metaController.test.ts
+++ b/src/metaController.test.ts
@@ -31,6 +31,10 @@ const setup = (initial: string) => {
     return {controller, file: new TFile("note.md"), store, app};
 };
 
+const callUpdateMultiple = (controller: MetaController, props: Property[], file: TFile) =>
+    (controller as unknown as {updateMultipleInFile(p: Property[], f: TFile): Promise<void>})
+        .updateMultipleInFile(props, file);
+
 describe("MetaController.appendDataviewField", () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -97,6 +101,95 @@ describe("MetaController.appendDataviewField", () => {
         ]);
 
         expect(store.content).toBe(["body", "watch:: 1", "watch:: 2"].join("\n"));
+    });
+});
+
+describe("MetaController inline Dataview writes", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("updatePropertyInFile rewrites real inline fields but leaves frontmatter and fenced examples untouched", async () => {
+        const {controller, file, store} = setup(
+            [
+                "---",
+                "summary: \"[status:: yaml example]\"",
+                "---",
+                "",
+                "status:: Backlog",
+                "",
+                "```dataview",
+                "status:: fenced example",
+                "```",
+                "",
+                "tail",
+            ].join("\n"),
+        );
+
+        await controller.updatePropertyInFile({key: "status", content: "Backlog", type: MetaType.Dataview}, "Done", file);
+
+        expect(store.content).toBe(
+            [
+                "---",
+                "summary: \"[status:: yaml example]\"",
+                "---",
+                "",
+                "status:: Done",
+                "",
+                "```dataview",
+                "status:: fenced example",
+                "```",
+                "",
+                "tail",
+            ].join("\n"),
+        );
+    });
+
+    it("updateMultipleInFile rewrites multiple real inline fields but leaves fenced examples untouched", async () => {
+        const {controller, file, store} = setup(
+            [
+                "status:: Backlog",
+                "priority:: Low",
+                "",
+                "```",
+                "status:: fenced status",
+                "priority:: fenced priority",
+                "```",
+            ].join("\n"),
+        );
+
+        await callUpdateMultiple(
+            controller,
+            [
+                {key: "status", content: "Done", type: MetaType.Dataview},
+                {key: "priority", content: "High", type: MetaType.Dataview},
+            ],
+            file,
+        );
+
+        expect(store.content).toBe(
+            [
+                "status:: Done",
+                "priority:: High",
+                "",
+                "```",
+                "status:: fenced status",
+                "priority:: fenced priority",
+                "```",
+            ].join("\n"),
+        );
+    });
+
+    it("preserves mixed line endings while updating inline fields outside fences", async () => {
+        const {controller, file, store} = setup(
+            "status:: Backlog\r\nbody\n```dataview\r\nstatus:: fenced example\r\n```\n",
+        );
+
+        await controller.updatePropertyInFile({key: "status", content: "Backlog", type: MetaType.Dataview}, "Done", file);
+
+        expect(store.content).toBe(
+            "status:: Done\r\nbody\n```dataview\r\nstatus:: fenced example\r\n```\n",
+        );
     });
 });
 
@@ -246,10 +339,6 @@ describe("MetaController reserved-key guard", () => {
         const controller = new MetaController(app as never, plugin as never);
         return {controller, file: new TFile("note.md"), fm, processFrontMatter, vaultModify};
     };
-
-    const callUpdateMultiple = (controller: MetaController, props: Property[], file: TFile) =>
-        (controller as unknown as {updateMultipleInFile(p: Property[], f: TFile): Promise<void>})
-            .updateMultipleInFile(props, file);
 
     beforeEach(() => {
         vi.clearAllMocks();

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -513,15 +513,12 @@ export default class MetaController {
                 return;
             }
 
+            if (property.type !== MetaType.Dataview || !property.key) return;
+
             const fileContent = await this.app.vault.read(file);
-
-            const newFileContent = fileContent.split("\n").map(line => {
-                if (this.lineMatch(property, line)) {
-                    return this.updatePropertyLine(property, newValue, line);
-                }
-
-                return line;
-            }).join("\n");
+            const newFileContent = this.parser.replaceInlineFieldValuesInContent(fileContent, [
+                {key: property.key, value: String(newValue)},
+            ]);
 
             await this.app.vault.modify(file, newFileContent);
         });
@@ -573,44 +570,6 @@ export default class MetaController {
         }
     }
 
-    private lineMatch(property: Partial<Property>, line: string): boolean {
-        if (!property.key) return false;
-
-        const tagRegex = new RegExp(`^\\s*${this.escapeSpecialCharacters(property.key)}`);
-
-        if (property.key.contains('#')) {
-            return tagRegex.test(line);
-        }
-
-        if (property.type === MetaType.Dataview) {
-            return this.dataviewPropertyRegex(property.key).test(line);
-        }
-
-        const propertyRegex = new RegExp(`^\\s*${this.escapeSpecialCharacters(property.key)}\\s*:`);
-        return propertyRegex.test(line);
-    }
-
-    private updatePropertyLine(property: Partial<Property>, newValue: unknown, line: string) {
-        if (!property.key) return line;
-
-        let newLine: string;
-        switch (property.type) {
-            case MetaType.Dataview:
-                newLine = this.parser.replaceInlineFieldValue(line, property.key, String(newValue));
-                break;
-            case MetaType.YAML:
-                newLine = `${property.key}: ${newValue}`;
-                break;
-            // Body tags are rewritten by span in writeTagOccurrence, never here.
-            default:
-                // Never collapse a matched line to just the key - leave it untouched.
-                newLine = line;
-                break;
-        }
-
-        return newLine;
-    }
-
     private async updateMultipleInFile(properties: Property[], file: TFile): Promise<void> {
         // Refuse a batch with ANY reserved YAML key BEFORE the write starts. This
         // method splices body tags before writing frontmatter, so validating up
@@ -634,7 +593,7 @@ export default class MetaController {
             const yamlProperties = properties.filter(prop => prop.type === MetaType.YAML && !prop.path);
             const yamlPathProperties = properties.filter(prop => prop.type === MetaType.YAML && prop.path);
             const tagProperties = properties.filter(prop => prop.type === MetaType.Tag);
-            const textProperties = properties.filter(prop => prop.type !== MetaType.YAML && prop.type !== MetaType.Tag);
+            const textProperties = properties.filter(prop => prop.type === MetaType.Dataview && prop.key);
 
             // Splice body tags FIRST, while their parsed offsets still match the
             // file. A later processFrontMatter write only touches the frontmatter,
@@ -672,17 +631,11 @@ export default class MetaController {
             }
 
             if (textProperties.length > 0) {
-                let lines = (await this.app.vault.read(file)).split("\n");
-                for (const prop of textProperties) {
-                    lines = lines.map(line => this.lineMatch(prop, line) ? this.updatePropertyLine(prop, prop.content, line) : line);
-                }
-                await this.app.vault.modify(file, lines.join("\n"));
+                const content = await this.app.vault.read(file);
+                const replacements = textProperties.map(prop => ({key: prop.key, value: String(prop.content)}));
+                await this.app.vault.modify(file, this.parser.replaceInlineFieldValuesInContent(content, replacements));
             }
         });
-    }
-
-    private dataviewPropertyRegex(propertyKey: string): RegExp {
-        return new RegExp(`(^|[\\s\\[\\(])(${this.escapeSpecialCharacters(propertyKey)})::[ ]*([^\\)\\]\\n\\r]*)(\\]\\]|[\\]\\)]?)`, "g");
     }
 
     private splitMultiValue(property: Partial<Property>): string[] {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -26,7 +26,14 @@ export type InlineFieldInsertLocation = "afterLastMatch" | "end";
 // for a bracketed field, or end-of-line for a full-line field). The latter two
 // let the value be rewritten in place without disturbing the key or wrapper.
 type InlineField = {key: string, value: string, start: number, end: number, sepEnd: number, valueEnd: number};
+type InlineFieldReplacement = {key: string, value: string};
 type ContentLine = {text: string, start: number, end: number, nextStart: number};
+type InlineContentLine = ContentLine & {
+    index: number,
+    inFrontmatter: boolean,
+    fenceBoundary: "open" | "close" | null,
+    readable: boolean,
+};
 type LegacyFrontmatterPosition = {
     start: {line: number, col: number, offset: number},
     end: {line: number, col: number, offset: number},
@@ -218,26 +225,12 @@ export default class MetaEditParser {
      */
     public parseInlineContent(content: string): Property[] {
         const properties: Property[] = [];
-        const lines = this.splitContentLines(content);
-        const frontmatterInfo = this.getFrontmatterInfo(content);
-        let openFence: OpenFence | null = null;
 
-        for (const {text: line, start} of lines) {
+        for (const line of this.walkInlineContentLines(content)) {
+            if (!line.readable) continue;
+            if (!line.text.includes("::")) continue;
 
-            // Skip a leading YAML frontmatter block - it is handled by parseFrontmatter.
-            if (frontmatterInfo?.exists && start < frontmatterInfo.contentStart) {
-                continue;
-            }
-
-            // Skip fenced code blocks so example fields are not treated as metadata.
-            const {open, boundary} = nextFenceState(openFence, line);
-            openFence = open;
-            if (boundary) continue;       // an opening or closing fence marker line
-            if (openFence !== null) continue; // inside a fenced code block
-
-            if (!line.includes("::")) continue;
-
-            for (const field of this.parseLineFields(line)) {
+            for (const field of this.parseLineFields(line.text)) {
                 properties.push({key: field.key, content: field.value, type: MetaType.Dataview});
             }
         }
@@ -312,6 +305,33 @@ export default class MetaEditParser {
         }
 
         return lines;
+    }
+
+    private *walkInlineContentLines(content: string): IterableIterator<InlineContentLine> {
+        const lines = this.splitContentLines(content);
+        const frontmatterInfo = this.getFrontmatterInfo(content);
+        let openFence: OpenFence | null = null;
+
+        for (let index = 0; index < lines.length; index++) {
+            const line = lines[index];
+            const inFrontmatter = frontmatterInfo?.exists === true && line.start < frontmatterInfo.contentStart;
+
+            if (inFrontmatter) {
+                yield {...line, index, inFrontmatter, fenceBoundary: null, readable: false};
+                continue;
+            }
+
+            const {open, boundary} = nextFenceState(openFence, line.text);
+            openFence = open;
+
+            yield {
+                ...line,
+                index,
+                inFrontmatter: false,
+                fenceBoundary: boundary,
+                readable: boundary === null && openFence === null,
+            };
+        }
     }
 
     private parseLineFields(line: string): InlineField[] {
@@ -436,6 +456,39 @@ export default class MetaEditParser {
     }
 
     /**
+     * Rewrite inline field values in raw note content using the same readable-line
+     * boundary as {@link parseInlineContent}. Only the changed line spans are
+     * replaced; all untouched bytes, including mixed CRLF/LF line endings, are
+     * preserved exactly.
+     */
+    public replaceInlineFieldValuesInContent(content: string, replacements: ReadonlyArray<InlineFieldReplacement>): string {
+        const activeReplacements = replacements.filter(({key}) => key.length > 0);
+        if (activeReplacements.length === 0) return content;
+
+        let result = "";
+        let cursor = 0;
+
+        for (const line of this.walkInlineContentLines(content)) {
+            if (!line.readable) continue;
+            if (!line.text.includes("::")) continue;
+
+            let updatedLine = line.text;
+            for (const {key, value} of activeReplacements) {
+                updatedLine = this.replaceInlineFieldValue(updatedLine, key, value);
+            }
+
+            if (updatedLine === line.text) continue;
+
+            result += content.slice(cursor, line.start) + updatedLine;
+            cursor = line.end;
+        }
+
+        if (cursor === 0) return content;
+
+        return result + content.slice(cursor);
+    }
+
+    /**
      * Compute the line index at which to splice a new `name:: value` inline field.
      *
      * This is the write-placement counterpart to {@link parseInlineContent}: it walks
@@ -452,41 +505,36 @@ export default class MetaEditParser {
      * at the start of the body, or at the very end when the whole file is frontmatter.
      */
     public computeInlineInsertIndex(content: string, name: string, location: InlineFieldInsertLocation = "afterLastMatch"): number {
-        const lines = this.splitContentLines(content);
-        const frontmatterInfo = this.getFrontmatterInfo(content);
-
-        let openFence: OpenFence | null = null;
         let lastMatchIdx = -1;   // last body line that declares `name`
         let lastAnchorIdx = -1;  // last line we may insert AFTER (body content or a closing fence)
         let firstBodyIdx = -1;   // first line at/after the frontmatter block
+        let lineCount = 0;
 
-        for (let i = 0; i < lines.length; i++) {
-            const {text: line, start} = lines[i];
+        for (const line of this.walkInlineContentLines(content)) {
+            lineCount = line.index + 1;
 
             // Inside the YAML frontmatter block - never a valid target (mirrors parseInlineContent).
-            if (frontmatterInfo?.exists && start < frontmatterInfo.contentStart) continue;
-            if (firstBodyIdx === -1) firstBodyIdx = i;
+            if (line.inFrontmatter) continue;
+            if (firstBodyIdx === -1) firstBodyIdx = line.index;
 
-            const {open, boundary} = nextFenceState(openFence, line);
-            openFence = open;
             // An opening marker is not a valid anchor (inserting after it lands inside the fence);
             // a closing marker is (inserting after it is outside the fence).
-            if (boundary === "open") continue;
-            if (boundary === "close") {
-                lastAnchorIdx = i;
+            if (line.fenceBoundary === "open") continue;
+            if (line.fenceBoundary === "close") {
+                lastAnchorIdx = line.index;
                 continue;
             }
-            if (openFence !== null) continue; // fence interior - never a target
+            if (!line.readable) continue; // fence interior - never a target
 
-            if (line.trim() !== "") lastAnchorIdx = i;
-            if (line.includes("::") && this.parseLineFields(line).some(field => field.key === name)) {
-                lastMatchIdx = i;
+            if (line.text.trim() !== "") lastAnchorIdx = line.index;
+            if (line.text.includes("::") && this.parseLineFields(line.text).some(field => field.key === name)) {
+                lastMatchIdx = line.index;
             }
         }
 
         if (location === "afterLastMatch" && lastMatchIdx !== -1) return lastMatchIdx + 1;
         if (lastAnchorIdx !== -1) return lastAnchorIdx + 1;
-        return firstBodyIdx !== -1 ? firstBodyIdx : lines.length;
+        return firstBodyIdx !== -1 ? firstBodyIdx : lineCount;
     }
 
 }


### PR DESCRIPTION
Make Dataview inline-field writes use the parser's frontmatter and fenced-code boundary instead of rematching every raw line. This fixes the deepsec `other-data-corruption` fenced-code variant where automated Kanban sync could rewrite `key::` examples inside fenced code blocks.

The parser now exposes an offset-preserving content transform that shares the same readable-line walk used by inline parsing and insert-index calculation. `updatePropertyInFile` and `updateMultipleInFile` route Dataview writes through that transform, preserving untouched bytes including mixed CRLF/LF line endings. YAML and tag write paths are unchanged.

Adversarial design review notes folded in:
- avoid split/rejoin newline normalization by splicing changed line spans back into the original content
- share the parser's frontmatter/fence walk instead of copying controller-side fence logic
- gate the batch text path to `MetaType.Dataview` so option sentinels remain no-op

Validation:
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` (20 files, 344 tests)
- isolated Obsidian vault `metaedit-deepsec-fence-write`: enabled Kanban Helper, moved linked card from Backlog to In Progress, and read back linked note statuses as `["In Progress", "fenced example"]`
- `pnpm run obsidian:e2e -- dev:errors` -> no errors captured
- `pnpm run stop:e2e-obsidian` stopped the isolated instance

Release impact: patch bug fix; no settings or API migration.