### PR TITLE
fix(suggester): use native icons + tooltips for row actions

### DIFF
--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -1,4 +1,4 @@
-import {type App, type FuzzyMatch, FuzzySuggestModal, Notice, type TFile} from "obsidian";
+import {type App, type FuzzyMatch, FuzzySuggestModal, Notice, setIcon, setTooltip, type TFile} from "obsidian";
 import type MetaEdit from "../main";
 import type MetaController from "../metaController";
 import type {Property} from "../parser";
@@ -9,6 +9,11 @@ import {getKnownPropertyNames} from "./GenericPrompt/valueSuggest";
 import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
 import {canStructureEditProperty, filterMenuItems} from "./menuFilter";
 import {isReservedFrontmatterKey, isYamlParentContainerValue} from "../yamlPath";
+
+const DELETE_PROPERTY_ICON = "trash-2";
+const TRANSFORM_PROPERTY_ICON = "replace";
+const DELETE_PROPERTY_TOOLTIP = "Delete property";
+const TRANSFORM_PROPERTY_TOOLTIP = "Transform to YAML ⇄ Dataview";
 
 export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
     public app: App;
@@ -41,9 +46,7 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
         this.setSuggestValues();
 
         this.setInstructions([
-            {command: "❌", purpose: "Delete property"},
-            {command: "🔃", purpose: "Transform to YAML/Dataview"},
-            {command: "#tag", purpose: "Select to rename here · vault-wide rename: Obsidian Tag pane"},
+            {command: "#tag", purpose: "rename in this note · vault-wide: Tag pane"},
         ])
     }
 
@@ -54,8 +57,8 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
             el.classList.add("metaedit-suggester-command");
         } else {
             if (MetaEditSuggester.canStructureEdit(item.item)) {
-                this.createButton(el,"❌", this.deleteItem(item));
-                this.createButton(el, "🔃", this.transformProperty(item))
+                this.createButton(el, DELETE_PROPERTY_ICON, DELETE_PROPERTY_TOOLTIP, this.deleteItem(item));
+                this.createButton(el, TRANSFORM_PROPERTY_ICON, TRANSFORM_PROPERTY_TOOLTIP, this.transformProperty(item))
             }
         }
     }
@@ -182,10 +185,13 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
         await this.controller.appendDataviewField(property.key, property.content, this.file);
     }
 
-    private createButton(el: HTMLElement, content: string, callback: (evt: MouseEvent) => void) {
+    private createButton(el: HTMLElement, iconName: string, tooltip: string, callback: (evt: MouseEvent) => void) {
         const itemButton = el.createEl("button");
-        itemButton.textContent = content;
-        itemButton.classList.add("not-a-button", "metaedit-suggester-action-button");
+        itemButton.type = "button";
+        itemButton.classList.add("clickable-icon", "metaedit-suggester-action-button");
+        itemButton.setAttribute("aria-label", tooltip);
+        setIcon(itemButton, iconName);
+        setTooltip(itemButton, tooltip);
         itemButton.addEventListener("click", callback);
     }
 

--- a/styles.css
+++ b/styles.css
@@ -32,7 +32,7 @@
 
 .metaedit-suggester-action-button {
     float: right;
-    margin-right: 4px;
+    margin-left: 4px;
 }
 
 .metaedit-dataview-empty-header {

--- a/tests/e2e/audit-suggester.test.ts
+++ b/tests/e2e/audit-suggester.test.ts
@@ -114,11 +114,13 @@ describe("MetaEdit Edit Meta suggester flows", () => {
 				await sleep(300);
 
 				await plugin.runMetaEditForFile(f);
-				// Data rows carry the action buttons, so textContent is "deleteMe❌🔃";
-				// match the key as a prefix.
+				// Data rows carry native icon buttons, so match the key as a prefix.
 				const row = await waitFor(".suggestion-item", (i) => itemText(i).startsWith("deleteMe"));
-				const delBtn = Array.from(row.querySelectorAll("button")).find((b) => b.textContent === "❌");
+				const delBtn = row.querySelector('button.metaedit-suggester-action-button[aria-label="Delete property"]');
 				if (!delBtn) throw new Error("delete button not found");
+				if (!delBtn.classList.contains("clickable-icon")) throw new Error("delete button missing clickable-icon");
+				if (!delBtn.querySelector("svg")) throw new Error("delete button did not render an icon");
+				if ((delBtn.textContent || "").trim() !== "") throw new Error("delete button still has text content");
 				delBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 				await waitFor("body", () => !("deleteMe" in (app.metadataCache.getFileCache(f)?.frontmatter ?? {})));
 				await sleep(200);
@@ -153,8 +155,11 @@ describe("MetaEdit Edit Meta suggester flows", () => {
 
 				await plugin.runMetaEditForFile(f);
 				const row = await waitFor(".suggestion-item", (i) => itemText(i).startsWith("mover"));
-				const xform = Array.from(row.querySelectorAll("button")).find((b) => b.textContent === "🔃");
+				const xform = row.querySelector('button.metaedit-suggester-action-button[aria-label="Transform to YAML ⇄ Dataview"]');
 				if (!xform) throw new Error("transform button not found");
+				if (!xform.classList.contains("clickable-icon")) throw new Error("transform button missing clickable-icon");
+				if (!xform.querySelector("svg")) throw new Error("transform button did not render an icon");
+				if ((xform.textContent || "").trim() !== "") throw new Error("transform button still has text content");
 				xform.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 				// Transform deletes the YAML key, then appends the inline field.
 				await waitFor("body", () => !("mover" in (app.metadataCache.getFileCache(f)?.frontmatter ?? {})));

--- a/tests/e2e/menu-filter.test.ts
+++ b/tests/e2e/menu-filter.test.ts
@@ -50,7 +50,7 @@ async function captureMenuKeys(
 				await sleep(120);
 				const keys = Array.from(document.querySelectorAll(".suggestion-item")).map((el) => {
 					const t = el.querySelector(".suggestion-item-text") || el;
-					return (t.textContent || "").replace(/[❌🔃]/g, "").trim();
+					return (t.textContent || "").trim();
 				});
 				// Close the suggester and wait until it is gone, so the next capture
 				// reads a fresh menu rather than a stacked one.

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -65,6 +65,17 @@ export function getLinkpath(linktext: string): string {
   return cutIndex === -1 ? linktext : linktext.slice(0, cutIndex);
 }
 
+export function setIcon(parent: HTMLElement, iconId: string): void {
+  parent.textContent = "";
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("data-icon", iconId);
+  parent.appendChild(svg);
+}
+
+export function setTooltip(el: HTMLElement, tooltip: string): void {
+  el.setAttribute("aria-label", tooltip);
+}
+
 export function parseYaml(yaml: string): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   const lines = yaml.split(/\r?\n/);


### PR DESCRIPTION
Replace the emoji row actions in the Run / Edit Meta suggester with native Obsidian icon buttons.

The delete and transform actions now use `setIcon`/`setTooltip`, `clickable-icon`, explicit aria labels, and monochrome Lucide icons that inherit Obsidian theme styling. The instruction footer drops the emoji legend and keeps only a terse `#tag` hint for the note-local rename flow and vault-wide Tag pane.

`trash-2` and `replace` were verified in the isolated Obsidian runtime by opening the real suggester in both `theme-light` and `theme-dark`; the rendered buttons contained `svg.svg-icon.lucide-trash-2` and `svg.svg-icon.lucide-replace`, with no emoji text.

Validation:
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- Focused E2E: `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/audit-suggester.test.ts tests/e2e/menu-filter.test.ts` with `HOME` pointed at the isolated Obsidian profile
- Live isolated-vault DOM eval on Obsidian 1.12.7: confirmed both action buttons have SVGs, `clickable-icon`, expected aria labels/tooltips, no emoji text, and delete/transform still mutate the file correctly
- `pnpm run obsidian:e2e -- dev:errors` returned no captured errors after the modal exercise
- `pnpm run stop:e2e-obsidian`

Release impact: UI polish only; no settings, storage, or API migration.