### PR TITLE
fix(suggester): center row action icons flush-right

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,9 +30,21 @@
     font-weight: var(--font-semibold);
 }
 
+/* Lay the row out as flex so the action icons sit flush-right and stay
+   vertically centered against the property label (float:right aligned to the
+   line box, not the row center, which left them looking off). */
+.suggestion-item:has(.metaedit-suggester-action-button) {
+    display: flex;
+    align-items: center;
+}
+
 .metaedit-suggester-action-button {
-    float: right;
     margin-left: 4px;
+}
+
+/* First action button pushes the whole icon group to the right edge. */
+.metaedit-suggester-action-button:first-of-type {
+    margin-left: auto;
 }
 
 .metaedit-dataview-empty-header {


### PR DESCRIPTION
Centers the per-row action icons (delete / transform) in the MetaEdit "Run / Edit Meta" suggester so they sit vertically centered against the property label and flush against the right edge of the row.

The icons were positioned with `float: right`, which aligns to the line box rather than the row's center, leaving them visibly off-center and unevenly spaced - an eyesore against the native-icon polish from #165. This lays each property row out as flex (`align-items: center`) and pushes the icon group flush-right via `margin-left: auto` on the first action button, so the icons stay centered and evenly spaced.

Scoped with `:has(.metaedit-suggester-action-button)` so only MetaEdit property rows are affected; the plain command rows (New YAML/Dataview property) are untouched.

CSS-only follow-up to #165. Verified live in the dev vault across the suggester rows.