### PR TITLE
feat(editor): native-feeling typed editor for YAML list properties

### DIFF
--- a/src/Modals/TypedListPrompt/TypedListPrompt.ts
+++ b/src/Modals/TypedListPrompt/TypedListPrompt.ts
@@ -1,0 +1,70 @@
+import {type App, Modal} from "obsidian";
+import TypedListPromptContent from "./TypedListPromptContent.svelte";
+import {type MountedSvelteComponent, mountSvelteComponent, unmountSvelteComponent} from "../../svelteMount";
+import {createTypedListItems, type TypedListPromptResult} from "../../typedList";
+
+type TypedListPromptInput = {
+	propertyKey: string;
+	value: readonly unknown[];
+};
+
+export default class TypedListPrompt extends Modal {
+	private modalContent: MountedSvelteComponent | null = null;
+	private resolvePromise!: (result: TypedListPromptResult) => void;
+	private result: TypedListPromptResult = {kind: "cancel"};
+	private didResolve = false;
+	private previousFocus: HTMLElement | null = null;
+	public waitForClose: Promise<TypedListPromptResult>;
+
+	public static open(app: App, input: TypedListPromptInput): Promise<TypedListPromptResult> {
+		const modal = new TypedListPrompt(app, input);
+		return modal.waitForClose;
+	}
+
+	private constructor(app: App, input: TypedListPromptInput) {
+		super(app);
+
+		this.waitForClose = new Promise<TypedListPromptResult>((resolve) => {
+			this.resolvePromise = resolve;
+		});
+
+		this.modalEl.classList.add("metaedit-typed-list-modal");
+		this.previousFocus = activeDocument.activeElement instanceof HTMLElement
+			? activeDocument.activeElement
+			: null;
+
+		this.modalContent = mountSvelteComponent(
+			TypedListPromptContent,
+			this.contentEl,
+			{
+				items: createTypedListItems(input.value),
+				propertyKey: input.propertyKey,
+				onCancel: () => {
+					this.result = {kind: "cancel"};
+					this.close();
+				},
+				onSubmit: (value: unknown[]) => {
+					this.result = {kind: "submit", value};
+					this.close();
+				},
+			},
+		);
+
+		this.open();
+	}
+
+	onClose() {
+		super.onClose();
+		unmountSvelteComponent(this.modalContent);
+		this.modalContent = null;
+
+		if (this.previousFocus && activeDocument.body.contains(this.previousFocus)) {
+			this.previousFocus.focus();
+		}
+
+		if (!this.didResolve) {
+			this.didResolve = true;
+			this.resolvePromise(this.result);
+		}
+	}
+}

--- a/src/Modals/TypedListPrompt/TypedListPromptContent.svelte
+++ b/src/Modals/TypedListPrompt/TypedListPromptContent.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import {tick, untrack} from "svelte";
+	import {setIcon, setTooltip} from "obsidian";
+	import {
+		createAddedTypedListItem,
+		displayTypedListValue,
+		reconstructTypedList,
+		type TypedListItem,
+	} from "../../typedList";
+
+	let {
+		items: initialItems,
+		propertyKey,
+		onCancel,
+		onSubmit,
+	}: {
+		items: TypedListItem[];
+		propertyKey: string;
+		onCancel: () => void;
+		onSubmit: (value: unknown[]) => void;
+	} = $props();
+
+	const stableInitialItems = untrack(() => initialItems);
+	const stablePropertyKey = untrack(() => propertyKey);
+
+	let items = $state(stableInitialItems.map(item => ({...item})));
+	let addValue = $state("");
+	let addInputEl = $state<HTMLInputElement>();
+	let nextId = stableInitialItems.length;
+	const addInputId = `metaedit-typed-list-add-${stablePropertyKey.replace(/[^A-Za-z0-9_-]/g, "-")}`;
+
+	function removeIcon(node: HTMLElement, label: string) {
+		setIcon(node, "x");
+		setTooltip(node, label);
+
+		return {
+			update(nextLabel: string) {
+				setTooltip(node, nextLabel);
+			},
+		};
+	}
+
+	function updateItemText(id: string, text: string) {
+		items = items.map(item => item.id === id ? {...item, text} : item);
+	}
+
+	function removeItem(id: string) {
+		items = items.filter(item => item.id !== id);
+	}
+
+	async function focusAddInput() {
+		await tick();
+		addInputEl?.focus();
+	}
+
+	function addItem() {
+		if (addValue.length === 0) return;
+		items = [...items, createAddedTypedListItem(`item-${nextId++}`, addValue)];
+		addValue = "";
+		void focusAddInput();
+	}
+
+	function removeLastItem() {
+		if (items.length === 0) return;
+		items = items.slice(0, -1);
+	}
+
+	function resetItem(item: TypedListItem) {
+		if (item.kind === "added") {
+			removeItem(item.id);
+			return;
+		}
+		updateItemText(item.id, displayTypedListValue(item.originalValue));
+	}
+
+	function submit() {
+		const submittedItems = addValue.length > 0
+			? [...items, createAddedTypedListItem(`item-${nextId}`, addValue)]
+			: items;
+		onSubmit(reconstructTypedList(submittedItems));
+	}
+
+	function handleAddKeydown(event: KeyboardEvent) {
+		if (event.key === "Enter") {
+			event.preventDefault();
+			if (addValue.length > 0) addItem();
+			else submit();
+			return;
+		}
+
+		if (event.key === "Backspace" && addValue === "") {
+			event.preventDefault();
+			removeLastItem();
+			return;
+		}
+
+		if (event.key === "Escape") {
+			event.preventDefault();
+			event.stopPropagation();
+			onCancel();
+		}
+	}
+
+	function handleItemKeydown(event: KeyboardEvent, item: TypedListItem) {
+		if (event.key === "Enter") {
+			event.preventDefault();
+			void focusAddInput();
+			return;
+		}
+
+		if (event.key === "Escape") {
+			event.preventDefault();
+			event.stopPropagation();
+			if (item.kind === "original" && item.text !== displayTypedListValue(item.originalValue)) {
+				resetItem(item);
+				void focusAddInput();
+				return;
+			}
+			onCancel();
+		}
+	}
+</script>
+
+<div class="metaedit-typed-list-content">
+	<h1 class="metaedit-typed-list-heading">Edit {stablePropertyKey}</h1>
+
+	<label class="metaedit-typed-list-label" for={addInputId}>Values</label>
+	<div class="multi-select-container metaedit-typed-list-editor" aria-label={`${stablePropertyKey} values`}>
+		{#each items as item, index (item.id)}
+			<span class="multi-select-pill metaedit-typed-list-pill">
+				<input
+					aria-label={`Edit item ${index + 1}`}
+					class="metadata-input metadata-input-text metaedit-typed-list-pill-input"
+					oninput={(event) => updateItemText(item.id, event.currentTarget.value)}
+					onkeydown={(event) => handleItemKeydown(event, item)}
+					type="text"
+					value={item.text}>
+				<button
+					aria-label={`Remove item ${index + 1}`}
+					class="clickable-icon metaedit-typed-list-remove"
+					onclick={() => removeItem(item.id)}
+					type="button"
+					use:removeIcon={`Remove item ${index + 1}`}></button>
+			</span>
+		{/each}
+		<input
+			bind:this={addInputEl}
+			bind:value={addValue}
+			class="multi-select-input metadata-input metadata-input-text metaedit-typed-list-add-input"
+			id={addInputId}
+			onkeydown={handleAddKeydown}
+			placeholder="Add value"
+			type="text">
+	</div>
+
+	<div class="metaedit-typed-list-actions">
+		<button onclick={addItem} type="button">Add item</button>
+		<button onclick={onCancel} type="button">Cancel</button>
+		<button class="mod-cta metaedit-typed-list-save" onclick={submit} type="button">Save</button>
+	</div>
+</div>

--- a/src/Modals/TypedListPrompt/TypedListPromptContent.svelte
+++ b/src/Modals/TypedListPrompt/TypedListPromptContent.svelte
@@ -2,8 +2,11 @@
 	import {tick, untrack} from "svelte";
 	import {setIcon, setTooltip} from "obsidian";
 	import {
+		appendTypedListItem,
 		createAddedTypedListItem,
 		displayTypedListValue,
+		moveTypedListItem,
+		prependTypedListItem,
 		reconstructTypedList,
 		type TypedListItem,
 	} from "../../typedList";
@@ -29,13 +32,14 @@
 	let nextId = stableInitialItems.length;
 	const addInputId = `metaedit-typed-list-add-${stablePropertyKey.replace(/[^A-Za-z0-9_-]/g, "-")}`;
 
-	function removeIcon(node: HTMLElement, label: string) {
-		setIcon(node, "x");
-		setTooltip(node, label);
+	function iconButton(node: HTMLElement, params: {icon: string; label: string}) {
+		setIcon(node, params.icon);
+		setTooltip(node, params.label);
 
 		return {
-			update(nextLabel: string) {
-				setTooltip(node, nextLabel);
+			update(nextParams: {icon: string; label: string}) {
+				setIcon(node, nextParams.icon);
+				setTooltip(node, nextParams.label);
 			},
 		};
 	}
@@ -53,10 +57,24 @@
 		addInputEl?.focus();
 	}
 
-	function addItem() {
-		if (addValue.length === 0) return;
-		items = [...items, createAddedTypedListItem(`item-${nextId++}`, addValue)];
+	function consumeAddedItem(): TypedListItem | null {
+		if (addValue.length === 0) return null;
+		const item = createAddedTypedListItem(`item-${nextId++}`, addValue);
 		addValue = "";
+		return item;
+	}
+
+	function addItemToEnd() {
+		const item = consumeAddedItem();
+		if (!item) return;
+		items = appendTypedListItem(items, item);
+		void focusAddInput();
+	}
+
+	function addItemToBeginning() {
+		const item = consumeAddedItem();
+		if (!item) return;
+		items = prependTypedListItem(items, item);
 		void focusAddInput();
 	}
 
@@ -73,9 +91,13 @@
 		updateItemText(item.id, displayTypedListValue(item.originalValue));
 	}
 
+	function moveItem(index: number, direction: "down" | "up") {
+		items = moveTypedListItem(items, index, direction);
+	}
+
 	function submit() {
 		const submittedItems = addValue.length > 0
-			? [...items, createAddedTypedListItem(`item-${nextId}`, addValue)]
+			? appendTypedListItem(items, createAddedTypedListItem(`item-${nextId}`, addValue))
 			: items;
 		onSubmit(reconstructTypedList(submittedItems));
 	}
@@ -83,7 +105,7 @@
 	function handleAddKeydown(event: KeyboardEvent) {
 		if (event.key === "Enter") {
 			event.preventDefault();
-			if (addValue.length > 0) addItem();
+			if (addValue.length > 0) addItemToEnd();
 			else submit();
 			return;
 		}
@@ -128,6 +150,20 @@
 	<div class="multi-select-container metaedit-typed-list-editor" aria-label={`${stablePropertyKey} values`}>
 		{#each items as item, index (item.id)}
 			<span class="multi-select-pill metaedit-typed-list-pill">
+				<button
+					aria-label={`Move item ${index + 1} up`}
+					class="clickable-icon metaedit-typed-list-move metaedit-typed-list-move-up"
+					disabled={index === 0}
+					onclick={() => moveItem(index, "up")}
+					type="button"
+					use:iconButton={{icon: "arrow-up", label: `Move item ${index + 1} up`}}></button>
+				<button
+					aria-label={`Move item ${index + 1} down`}
+					class="clickable-icon metaedit-typed-list-move metaedit-typed-list-move-down"
+					disabled={index === items.length - 1}
+					onclick={() => moveItem(index, "down")}
+					type="button"
+					use:iconButton={{icon: "arrow-down", label: `Move item ${index + 1} down`}}></button>
 				<input
 					aria-label={`Edit item ${index + 1}`}
 					class="metadata-input metadata-input-text metaedit-typed-list-pill-input"
@@ -140,7 +176,7 @@
 					class="clickable-icon metaedit-typed-list-remove"
 					onclick={() => removeItem(item.id)}
 					type="button"
-					use:removeIcon={`Remove item ${index + 1}`}></button>
+					use:iconButton={{icon: "x", label: `Remove item ${index + 1}`}}></button>
 			</span>
 		{/each}
 		<input
@@ -154,7 +190,8 @@
 	</div>
 
 	<div class="metaedit-typed-list-actions">
-		<button onclick={addItem} type="button">Add item</button>
+		<button class="metaedit-typed-list-add-beginning" onclick={addItemToBeginning} type="button">Add to beginning</button>
+		<button class="metaedit-typed-list-add-end" onclick={addItemToEnd} type="button">Add to end</button>
 		<button onclick={onCancel} type="button">Cancel</button>
 		<button class="mod-cta metaedit-typed-list-save" onclick={submit} type="button">Save</button>
 	</div>

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -9,6 +9,7 @@ import {getKnownPropertyNames} from "./GenericPrompt/valueSuggest";
 import {setPendingValueContext} from "./GenericPrompt/promptValueContext";
 import {canStructureEditProperty, filterMenuItems} from "./menuFilter";
 import {isReservedFrontmatterKey, isYamlParentContainerValue} from "../yamlPath";
+import {shouldUseTypedListEditor} from "../typedList";
 
 const DELETE_PROPERTY_ICON = "trash-2";
 const TRANSFORM_PROPERTY_ICON = "replace";
@@ -115,11 +116,11 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
 
         if (MetaEditSuggester.isYamlParentContainer(item)) return;
 
-        // Hand the prompt the property it is editing so it can offer value
-        // autocomplete and a native date picker, without routing UI concerns
-        // through the controller's write/parse core. Cleared in finally so it
-        // never outlives this edit.
-        setPendingValueContext({app: this.app, key: item.key, type: item.type});
+        // Hand legacy GenericPrompt the property it is editing so it can offer
+        // value autocomplete and a native date picker. The typed list modal owns
+        // its inputs and does not consume this singleton context.
+        if (shouldUseTypedListEditor(item)) setPendingValueContext(null);
+        else setPendingValueContext({app: this.app, key: item.key, type: item.type});
         try {
             await this.controller.editMetaElement(item, this.data, this.file);
         } finally {

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -13,15 +13,21 @@ import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoProperty
 import type {AutoProperty} from "./Types/autoProperty";
 import {findAutoProperty, isMultiAutoProperty, toValueArray, withChoiceAdded} from "./autoProperties";
 import {applyMultiValueEdit, isMultiValueYamlProperty, shouldUseMultiValueEditor, type MultiValueEdit} from "./multiValue";
-import {getYamlPath, isReservedFrontmatterKey, isYamlParentContainerValue, parseYamlPath, setYamlPath, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
+import {getYamlPath, isReservedFrontmatterKey, isYamlParentContainerValue, parseYamlPath, setYamlPath, yamlValuesEqual, YamlPathError, type SetYamlPathOptions, type YamlPathSegment} from "./yamlPath";
 import {computeTagRewrite, isNestedTag, isTagsKey, isValidTagToken, normalizeTagToken, splitFrontmatterTags, spliceTag, stripHash, tagLeaf, tagParent, canonicalizeFrontmatterTag, type TagEditMode} from "./tagEditing";
 import {setPendingValueContext} from "./Modals/GenericPrompt/promptValueContext";
+import {shouldUseTypedListEditor} from "./typedList";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
 const ADD_FIRST_SELECTION = "metaedit:multi-value:add-first";
 const ADD_TO_BEGINNING_SELECTION = "metaedit:multi-value:add-beginning";
 const ADD_TO_END_SELECTION = "metaedit:multi-value:add-end";
 const VALUE_SELECTION_PREFIX = "metaedit:multi-value:value:";
+
+type UiWriteOptions = {
+	expectedValue?: unknown;
+	validateExpectedValue?: boolean;
+};
 
 export default class MetaController {
     private parser: MetaEditParser;
@@ -136,10 +142,14 @@ export default class MetaController {
             return;
         }
 
-        // A real YAML list is inherently multi-value, so it always uses the
-        // element-aware list editor - editing it as a single text line (the
-        // `standardMode` path) would flatten the list and shred elements that
-        // contain commas or `[[wikilinks]]`.
+        if (shouldUseTypedListEditor(property)) {
+            await this.typedListMode(property, file);
+            return;
+        }
+
+        // Tags, aliases, and inline/string multi-value fields keep the legacy
+        // element-aware flow. Ordinary top-level YAML lists are handled by the
+        // typed list modal above.
         if (shouldUseMultiValueEditor(property, this.plugin.settings.EditMode))
             await this.multiValueMode(property, file);
         else
@@ -403,6 +413,24 @@ export default class MetaController {
         return await this.updatePropertyFromUi(property, newValue, file);
     }
 
+    private async typedListMode(property: Property, file: TFile): Promise<boolean> {
+        if (!Array.isArray(property.content)) return false;
+
+        // Unit tests import the controller in a node/Vitest environment without
+        // Svelte transforms. Load the Svelte-backed modal only on this UI path.
+        const {default: TypedListPrompt} = await import("./Modals/TypedListPrompt/TypedListPrompt");
+        const result = await TypedListPrompt.open(this.app, {
+            propertyKey: property.key,
+            value: property.content,
+        });
+        if (result.kind === "cancel") return false;
+
+        return await this.updatePropertyFromUi(property, result.value, file, {
+            expectedValue: property.content,
+            validateExpectedValue: true,
+        });
+    }
+
     private getActiveAutoProperty(propertyName: string): AutoProperty | undefined {
         if (!this.plugin.settings.AutoProperties.enabled) return undefined;
         return findAutoProperty(this.plugin.settings.AutoProperties.properties, propertyName);
@@ -474,7 +502,7 @@ export default class MetaController {
         }
     }
 
-    public async updatePropertyInFile(property: Partial<Property>, newValue: unknown, file: TFile): Promise<void> {
+    public async updatePropertyInFile(property: Partial<Property>, newValue: unknown, file: TFile, options: UiWriteOptions = {}): Promise<void> {
         if (!property.key) return;
 
         // Guard the direct frontmatter key before opening the file. Deeper path
@@ -502,6 +530,10 @@ export default class MetaController {
                         if (tags.length === 0) delete frontmatter[property.key!];
                         else frontmatter[property.key!] = tags;
                     } else {
+                        if (options.validateExpectedValue &&
+                            !yamlValuesEqual(frontmatter[property.key!], options.expectedValue)) {
+                            throw new Error(`current value changed before update.`);
+                        }
                         frontmatter[property.key!] = newValue;
                     }
                 });
@@ -642,9 +674,9 @@ export default class MetaController {
         return toValueArray(property.content);
     }
 
-    private async updatePropertyFromUi(property: Property, newValue: unknown, file: TFile): Promise<boolean> {
+    private async updatePropertyFromUi(property: Property, newValue: unknown, file: TFile, options: UiWriteOptions = {}): Promise<boolean> {
         try {
-            await this.updatePropertyInFile(property, newValue, file);
+            await this.updatePropertyInFile(property, newValue, file, options);
             return true;
         } catch (error) {
             const reason = error instanceof Error ? error.message : String(error);

--- a/src/typedList.test.ts
+++ b/src/typedList.test.ts
@@ -1,8 +1,11 @@
 import {describe, expect, it} from "vitest";
 import {
+	appendTypedListItem,
 	createAddedTypedListItem,
 	createTypedListItems,
 	displayTypedListValue,
+	moveTypedListItem,
+	prependTypedListItem,
 	reconstructTypedList,
 	shouldUseTypedListEditor,
 } from "./typedList";
@@ -44,9 +47,20 @@ describe("reconstructTypedList", () => {
 
 	it("preserves order and duplicates", () => {
 		const items = createTypedListItems(["dup", "dup", "tail"]);
-		items.splice(2, 0, createAddedTypedListItem("item-3", "dup"));
+		const nextItems = appendTypedListItem(items, createAddedTypedListItem("item-3", "dup"));
 
-		expect(reconstructTypedList(items)).toEqual(["dup", "dup", "dup", "tail"]);
+		expect(reconstructTypedList(nextItems)).toEqual(["dup", "dup", "tail", "dup"]);
+	});
+
+	it("prepends and reorders whole mixed-list items without stringifying typed values", () => {
+		let items = createTypedListItems([1, true, null, "x"]);
+
+		items = prependTypedListItem(items, createAddedTypedListItem("item-4", "first"));
+		items = moveTypedListItem(items, 4, "up");
+		items = moveTypedListItem(items, 3, "up");
+		items = moveTypedListItem(items, 2, "up");
+
+		expect(reconstructTypedList(items)).toEqual(["first", "x", 1, true, null]);
 	});
 
 	it("preserves wikilinks with commas as one item", () => {

--- a/src/typedList.test.ts
+++ b/src/typedList.test.ts
@@ -1,0 +1,74 @@
+import {describe, expect, it} from "vitest";
+import {
+	createAddedTypedListItem,
+	createTypedListItems,
+	displayTypedListValue,
+	reconstructTypedList,
+	shouldUseTypedListEditor,
+} from "./typedList";
+import {MetaType} from "./Types/metaType";
+
+describe("shouldUseTypedListEditor", () => {
+	it("routes only ordinary top-level YAML arrays", () => {
+		expect(shouldUseTypedListEditor({key: "topics", type: MetaType.YAML, content: ["a"]})).toBe(true);
+		expect(shouldUseTypedListEditor({key: "topics", type: MetaType.Dataview, content: ["a"]})).toBe(false);
+		expect(shouldUseTypedListEditor({key: "topics", type: MetaType.YAML, content: "a"})).toBe(false);
+		expect(shouldUseTypedListEditor({key: "topics", type: MetaType.YAML, content: ["a"], isNested: true})).toBe(false);
+		expect(shouldUseTypedListEditor({key: "topics", type: MetaType.YAML, content: ["a"], isVirtual: true})).toBe(false);
+	});
+
+	it("leaves tags and aliases on their existing routes", () => {
+		expect(shouldUseTypedListEditor({key: "tags", type: MetaType.YAML, content: ["a"]})).toBe(false);
+		expect(shouldUseTypedListEditor({key: "tag", type: MetaType.YAML, content: ["a"]})).toBe(false);
+		expect(shouldUseTypedListEditor({key: "aliases", type: MetaType.YAML, content: ["Alias"]})).toBe(false);
+	});
+});
+
+describe("reconstructTypedList", () => {
+	it("preserves untouched mixed values by their original type", () => {
+		// The current controller refuses arrays containing object elements as YAML
+		// parent containers. The pure reconstruction helper still preserves an
+		// object if a future typed editor safely routes one through it.
+		const objectValue = {nested: "value"};
+		const items = createTypedListItems([1, true, null, objectValue, "[[A, B]]"]);
+
+		expect(reconstructTypedList(items)).toEqual([1, true, null, objectValue, "[[A, B]]"]);
+	});
+
+	it("changes only the edited element", () => {
+		const items = createTypedListItems([1, true, null, "old"]);
+		items[3] = {...items[3], text: "new"};
+
+		expect(reconstructTypedList(items)).toEqual([1, true, null, "new"]);
+	});
+
+	it("preserves order and duplicates", () => {
+		const items = createTypedListItems(["dup", "dup", "tail"]);
+		items.splice(2, 0, createAddedTypedListItem("item-3", "dup"));
+
+		expect(reconstructTypedList(items)).toEqual(["dup", "dup", "dup", "tail"]);
+	});
+
+	it("preserves wikilinks with commas as one item", () => {
+		const items = createTypedListItems(["[[A, B]]", "next"]);
+
+		expect(reconstructTypedList(items)).toEqual(["[[A, B]]", "next"]);
+	});
+
+	it("does not stringify a typed value after a no-op edit", () => {
+		const items = createTypedListItems([1, false, null]);
+		items[0] = {...items[0], text: "1"};
+		items[1] = {...items[1], text: "false"};
+		items[2] = {...items[2], text: ""};
+
+		expect(reconstructTypedList(items)).toEqual([1, false, null]);
+	});
+
+	it("formats dates predictably for display while preserving them if untouched", () => {
+		const date = new Date("2026-01-02T00:00:00.000Z");
+		const items = createTypedListItems([date]);
+
+		expect(displayTypedListValue(date)).toBe("2026-01-02");
+		expect(reconstructTypedList(items)).toEqual([date]);
+	});
+});

--- a/src/typedList.ts
+++ b/src/typedList.ts
@@ -1,0 +1,62 @@
+import type {Property} from "./parser";
+import {MetaType} from "./Types/metaType";
+import {isTagsKey} from "./tagEditing";
+
+export type TypedListPromptResult =
+	| {kind: "submit"; value: unknown[]}
+	| {kind: "cancel"};
+
+export type TypedListItem =
+	| {
+		id: string;
+		kind: "original";
+		originalValue: unknown;
+		text: string;
+	}
+	| {
+		id: string;
+		kind: "added";
+		text: string;
+	};
+
+type PropertyLike = Pick<Property, "content" | "isNested" | "isVirtual" | "key" | "type">;
+
+export function shouldUseTypedListEditor(property: PropertyLike): boolean {
+	return property.type === MetaType.YAML &&
+		!property.isVirtual &&
+		!property.isNested &&
+		Array.isArray(property.content) &&
+		!isTagsKey(property.key) &&
+		property.key.toLowerCase() !== "aliases";
+}
+
+export function createTypedListItems(values: readonly unknown[]): TypedListItem[] {
+	return values.map((value, index) => ({
+		id: `item-${index}`,
+		kind: "original",
+		originalValue: value,
+		text: displayTypedListValue(value),
+	}));
+}
+
+export function createAddedTypedListItem(id: string, text: string): TypedListItem {
+	return {id, kind: "added", text};
+}
+
+export function displayTypedListValue(value: unknown): string {
+	if (value instanceof Date) {
+		if (Number.isNaN(value.getTime())) return "";
+		const iso = value.toISOString();
+		return iso.endsWith("T00:00:00.000Z") ? iso.slice(0, 10) : iso;
+	}
+	return value == null ? "" : String(value);
+}
+
+export function reconstructTypedList(items: readonly TypedListItem[]): unknown[] {
+	return items.map(item => {
+		if (item.kind === "added") return item.text;
+		return item.text === displayTypedListValue(item.originalValue)
+			? item.originalValue
+			: item.text;
+	});
+}

--- a/src/typedList.ts
+++ b/src/typedList.ts
@@ -43,6 +43,29 @@ export function createAddedTypedListItem(id: string, text: string): TypedListIte
 	return {id, kind: "added", text};
 }
 
+export function appendTypedListItem(items: readonly TypedListItem[], item: TypedListItem): TypedListItem[] {
+	return [...items, item];
+}
+
+export function prependTypedListItem(items: readonly TypedListItem[], item: TypedListItem): TypedListItem[] {
+	return [item, ...items];
+}
+
+export function moveTypedListItem(
+	items: readonly TypedListItem[],
+	index: number,
+	direction: "down" | "up",
+): TypedListItem[] {
+	const targetIndex = direction === "up" ? index - 1 : index + 1;
+	if (index < 0 || index >= items.length || targetIndex < 0 || targetIndex >= items.length) {
+		return [...items];
+	}
+
+	const next = [...items];
+	[next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+	return next;
+}
+
 export function displayTypedListValue(value: unknown): string {
 	if (value instanceof Date) {
 		if (Number.isNaN(value.getTime())) return "";

--- a/src/yamlPath.test.ts
+++ b/src/yamlPath.test.ts
@@ -5,6 +5,7 @@ import {
 	isReservedFrontmatterKey,
 	parseYamlPath,
 	setYamlPath,
+	yamlValuesEqual,
 	YamlPathError,
 } from "./yamlPath";
 
@@ -179,5 +180,20 @@ describe("setYamlPath reserved-key guard", () => {
 		setYamlPath(root, ["meta", "__proto__x"], "ok", {createLeaf: true});
 
 		expect(root).toEqual({meta: {__proto__x: "ok"}});
+	});
+});
+
+describe("yamlValuesEqual", () => {
+	it("compares arrays structurally", () => {
+		expect(yamlValuesEqual([1, true, null, "[[A, B]]"], [1, true, null, "[[A, B]]"])).toBe(true);
+		expect(yamlValuesEqual([1, true], [1, false])).toBe(false);
+	});
+
+	it("compares nested plain objects and dates structurally", () => {
+		const leftDate = new Date("2026-01-02T00:00:00.000Z");
+		const rightDate = new Date("2026-01-02T00:00:00.000Z");
+
+		expect(yamlValuesEqual([{date: leftDate, tags: ["a", "b"]}], [{date: rightDate, tags: ["a", "b"]}])).toBe(true);
+		expect(yamlValuesEqual([{date: leftDate, tags: ["a", "b"]}], [{date: rightDate, tags: ["b", "a"]}])).toBe(false);
 	});
 });

--- a/src/yamlPath.ts
+++ b/src/yamlPath.ts
@@ -235,7 +235,20 @@ function validateLeafWrite(
 	}
 }
 
-function yamlValuesEqual(left: unknown, right: unknown): boolean {
+export function yamlValuesEqual(left: unknown, right: unknown): boolean {
 	if (left instanceof Date && right instanceof Date) return left.getTime() === right.getTime();
+	if (Array.isArray(left) && Array.isArray(right)) {
+		if (left.length !== right.length) return false;
+		return left.every((value, index) => yamlValuesEqual(value, right[index]));
+	}
+	if (isPlainYamlObject(left) && isPlainYamlObject(right)) {
+		const leftKeys = Object.keys(left);
+		const rightKeys = Object.keys(right);
+		if (leftKeys.length !== rightKeys.length) return false;
+		return leftKeys.every(key =>
+			Object.prototype.hasOwnProperty.call(right, key) &&
+			yamlValuesEqual(left[key], right[key])
+		);
+	}
 	return Object.is(left, right);
 }

--- a/styles.css
+++ b/styles.css
@@ -126,6 +126,10 @@
     flex: 0 0 auto;
 }
 
+.metaedit-typed-list-move {
+    flex: 0 0 auto;
+}
+
 .metaedit-typed-list-add-input {
     flex: 1 1 160px;
     min-width: 120px;

--- a/styles.css
+++ b/styles.css
@@ -84,3 +84,55 @@
     color: var(--text-muted);
     font-size: var(--font-ui-smaller);
 }
+
+.metaedit-typed-list-content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.metaedit-typed-list-heading {
+    margin: 0;
+    text-align: center;
+}
+
+.metaedit-typed-list-label {
+    font-weight: var(--font-semibold);
+}
+
+.metaedit-typed-list-editor {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-height: 42px;
+    padding: 6px;
+}
+
+.metaedit-typed-list-pill {
+    align-items: center;
+    display: inline-flex;
+    gap: 4px;
+    max-width: 100%;
+}
+
+.metaedit-typed-list-pill-input {
+    border: 0;
+    min-width: 72px;
+    width: min(26ch, 42vw);
+}
+
+.metaedit-typed-list-remove {
+    flex: 0 0 auto;
+}
+
+.metaedit-typed-list-add-input {
+    flex: 1 1 160px;
+    min-width: 120px;
+}
+
+.metaedit-typed-list-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -192,7 +192,7 @@ export async function evalJsonAsync<T>(
 	obsidian: ObsidianClient,
 	code: string,
 ): Promise<T> {
-	const envelope = await obsidian.dev.eval<AsyncEvalEnvelope<T>>(`
+	let envelope = await obsidian.dev.eval<AsyncEvalEnvelope<T> | string>(`
 		(async () => {
 			const code = ${JSON.stringify(code)};
 			try {
@@ -209,6 +209,23 @@ export async function evalJsonAsync<T>(
 			}
 		})()
 	`);
+
+	if (typeof envelope === "string") {
+		// Obsidian CLI eval can prefix console output before the JSON payload
+		// (`MetaEdit: ...\n=> {...}`) when a behavior intentionally logs, such as
+		// the stale-write refusal path. Recover the final payload without hiding
+		// malformed envelopes below.
+		const marker = "\n=> ";
+		const payloadStart = envelope.lastIndexOf(marker);
+		const payload = payloadStart === -1
+			? envelope.trim()
+			: envelope.slice(payloadStart + marker.length).trim();
+		envelope = JSON.parse(payload) as AsyncEvalEnvelope<T>;
+	}
+
+	if (typeof envelope !== "object" || envelope === null || !("ok" in envelope)) {
+		throw new Error(`Failed to evaluate async Obsidian code: Unexpected eval envelope: ${JSON.stringify(envelope)}`);
+	}
 
 	if (!envelope.ok) {
 		throw new Error(

--- a/tests/e2e/multi-value.test.ts
+++ b/tests/e2e/multi-value.test.ts
@@ -285,6 +285,29 @@ describe("MetaEdit multi-value editing", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("prepends and reorders mixed typed-list items without stringifying untouched values", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("typed-list-reorder-mixed.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nmixed:\n  - 1\n  - true\n  - null\n  - x\n---\nbody\n",
+		);
+
+		const result = await driveTypedListEdit(obsidian, notePath, {
+			key: "mixed",
+			actions: [
+				{ kind: "prepend", value: "first" },
+				{ direction: "up", index: 4, kind: "move" },
+				{ direction: "up", index: 3, kind: "move" },
+				{ direction: "up", index: 2, kind: "move" },
+			],
+		});
+
+		expect(result.readBack).toEqual(["first", "x", 1, true, null]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("saves a typed list containing an untouched YAML date", async () => {
 		const { obsidian, sandbox } = getContext();
 		const notePath = sandbox.path("typed-list-date.md");
@@ -382,7 +405,9 @@ type TypedListAction =
 	| { kind: "add"; value: string }
 	| { kind: "remove"; index: number }
 	| { kind: "set"; index: number; value: string }
-	| { kind: "typeAdd"; value: string };
+	| { kind: "typeAdd"; value: string }
+	| { kind: "prepend"; value: string }
+	| { direction: "down" | "up"; index: number; kind: "move" };
 
 async function driveTypedListEdit(
 	obsidian: Parameters<typeof evalJsonAsync>[0],
@@ -438,9 +463,25 @@ async function driveTypedListEdit(
 					input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
 					await sleep(100);
 				}
+				if (action.kind === "prepend") {
+					const input = await waitFor(".metaedit-typed-list-add-input");
+					setInputValue(input, action.value);
+					const button = await waitFor(".metaedit-typed-list-add-beginning");
+					button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+					await sleep(100);
+				}
 				if (action.kind === "typeAdd") {
 					const input = await waitFor(".metaedit-typed-list-add-input");
 					setInputValue(input, action.value);
+					await sleep(100);
+				}
+				if (action.kind === "move") {
+					const selector = action.direction === "up"
+						? ".metaedit-typed-list-move-up"
+						: ".metaedit-typed-list-move-down";
+					const button = document.querySelectorAll(selector)[action.index];
+					if (!button) throw new Error("Missing move button at " + action.index);
+					button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 					await sleep(100);
 				}
 				if (action.kind === "remove") {

--- a/tests/e2e/multi-value.test.ts
+++ b/tests/e2e/multi-value.test.ts
@@ -70,14 +70,14 @@ describe("MetaEdit multi-value editing", () => {
 			"---\nauthors:\n  - Smith, John\n  - Doe, Jane\n---\nbody\n",
 		);
 
-		const result = await driveListEdit(obsidian, notePath, {
-			mode: "All Single",
+		const result = await driveTypedListEdit(obsidian, notePath, {
 			key: "authors",
-			selectText: "Doe, Jane",
-			enterValue: "Roe, Jane",
+			actions: [{ kind: "set", index: 1, value: "Roe, Jane" }],
 		});
 
 		expect(result.readBack).toEqual(["Smith, John", "Roe, Jane"]);
+		expect(result.dom.hasPillEditor).toBe(true);
+		expect(result.dom.hasGenericPromptInput).toBe(false);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
@@ -92,11 +92,9 @@ describe("MetaEdit multi-value editing", () => {
 			"---\nscripts:\n  - cmd:build\n  - test\n---\nbody\n",
 		);
 
-		const result = await driveListEdit(obsidian, notePath, {
-			mode: "All Single",
+		const result = await driveTypedListEdit(obsidian, notePath, {
 			key: "scripts",
-			selectText: "cmd:build",
-			enterValue: "cmd:rebuild",
+			actions: [{ kind: "set", index: 0, value: "cmd:rebuild" }],
 		});
 
 		expect(result.readBack).toEqual(["cmd:rebuild", "test"]);
@@ -211,18 +209,262 @@ describe("MetaEdit multi-value editing", () => {
 			"---\nscripts:\n  - cmd:addfirst\n  - keep\n---\nbody\n",
 		);
 
-		const result = await driveListEdit(obsidian, notePath, {
-			mode: "All Single",
+		const result = await driveTypedListEdit(obsidian, notePath, {
 			key: "scripts",
-			selectText: "cmd:addfirst",
-			enterValue: "changed",
+			actions: [{ kind: "set", index: 0, value: "changed" }],
 		});
 
 		expect(result.content).toBe("---\nscripts:\n  - changed\n  - keep\n---\nbody\n");
 		expect(result.readBack).toEqual(["changed", "keep"]);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
+
+	test("keeps aliases on the legacy array editor and preserves commas", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("aliases-list.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\naliases:\n  - Alias, One\n  - Alias Two\n---\nbody\n",
+		);
+
+		const result = await driveListEdit(obsidian, notePath, {
+			mode: "All Single",
+			key: "aliases",
+			selectText: "Alias, One",
+			enterValue: "Alias, Changed",
+		});
+
+		expect(result.readBack).toEqual(["Alias, Changed", "Alias Two"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("adds a wikilink-with-comma as one typed-list item", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("typed-list-add-wikilink.md");
+		await writeLiveFile(obsidian, notePath, "---\ntopics:\n  - alpha\n---\nbody\n");
+
+		const result = await driveTypedListEdit(obsidian, notePath, {
+			key: "topics",
+			actions: [{ kind: "typeAdd", value: "[[A, B]]" }],
+		});
+
+		expect(result.readBack).toEqual(["alpha", "[[A, B]]"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("preserves duplicate typed-list values and order", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("typed-list-duplicates.md");
+		await writeLiveFile(obsidian, notePath, "---\nitems:\n  - dup\n  - dup\n---\nbody\n");
+
+		const result = await driveTypedListEdit(obsidian, notePath, {
+			key: "items",
+			actions: [{ kind: "add", value: "dup" }],
+		});
+
+		expect(result.readBack).toEqual(["dup", "dup", "dup"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("preserves untouched mixed typed-list values", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("typed-list-mixed.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\nmixed:\n  - 1\n  - true\n  - null\n  - old\n---\nbody\n",
+		);
+
+		const result = await driveTypedListEdit(obsidian, notePath, {
+			key: "mixed",
+			actions: [{ kind: "set", index: 3, value: "new" }],
+		});
+
+		expect(result.readBack).toEqual([1, true, null, "new"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("saves a typed list containing an untouched YAML date", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("typed-list-date.md");
+		await writeLiveFile(
+			obsidian,
+			notePath,
+			"---\ndates:\n  - 2026-01-02\n  - old\n---\nbody\n",
+		);
+
+		const result = await driveTypedListEdit(obsidian, notePath, {
+			key: "dates",
+			actions: [{ kind: "set", index: 1, value: "new" }],
+		});
+
+		expect(result.content).toContain("new");
+		expect(result.readBack).toEqual(["2026-01-02", "new"]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("writes an empty ordinary typed list as an empty YAML array", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("typed-list-empty.md");
+		await writeLiveFile(obsidian, notePath, "---\nitems:\n  - alpha\n  - beta\n---\nbody\n");
+
+		const result = await driveTypedListEdit(obsidian, notePath, {
+			key: "items",
+			actions: [
+				{ kind: "remove", index: 1 },
+				{ kind: "remove", index: 0 },
+			],
+		});
+
+		expect(result.content).toBe("---\nitems: []\n---\nbody\n");
+		expect(result.readBack).toEqual([]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("refuses a stale typed-list write when frontmatter changes while the modal is open", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("typed-list-stale.md");
+		await writeLiveFile(obsidian, notePath, "---\nitems:\n  - base\n---\nbody\n");
+
+		const result = await evalJsonAsync<{ content: string; readBack: unknown; notices: string[] }>(
+			obsidian,
+			`
+			(async () => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+				const waitFor = async (selector, predicate = () => true) => {
+					const start = Date.now();
+					while (Date.now() - start < 5000) {
+						const el = Array.from(document.querySelectorAll(selector)).find(predicate);
+						if (el) return el;
+						await sleep(80);
+					}
+					throw new Error("Timed out waiting for " + selector);
+				};
+
+				const props = await plugin.controller.getPropertiesInFile(file);
+				const property = props.find((p) => p.key === "items");
+				const editPromise = plugin.controller.editMetaElement(property, props, file);
+				const addInput = await waitFor(".metaedit-typed-list-add-input");
+				addInput.value = "local";
+				addInput.dispatchEvent(new Event("input", { bubbles: true }));
+				addInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+				await app.fileManager.processFrontMatter(file, (frontmatter) => {
+					frontmatter.items = ["external"];
+				});
+				await sleep(300);
+
+				const save = await waitFor(".metaedit-typed-list-save");
+				save.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+				await editPromise;
+				await sleep(300);
+
+				return {
+					content: await app.vault.read(file),
+					readBack: await plugin.api.getPropertyValue("items", file),
+					notices: Array.from(document.querySelectorAll(".notice")).map((notice) => notice.textContent?.trim() ?? ""),
+				};
+			})()
+		`,
+		);
+
+		expect(result.content).toBe("---\nitems:\n  - external\n---\nbody\n");
+		expect(result.readBack).toEqual(["external"]);
+		expect(result.notices.some(text => text.includes("current value changed before update"))).toBe(true);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
 });
+
+type TypedListAction =
+	| { kind: "add"; value: string }
+	| { kind: "remove"; index: number }
+	| { kind: "set"; index: number; value: string }
+	| { kind: "typeAdd"; value: string };
+
+async function driveTypedListEdit(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	notePath: string,
+	opts: { key: string; actions: TypedListAction[] },
+): Promise<{
+	content: string;
+	dom: { hasGenericPromptInput: boolean; hasPillEditor: boolean; pillValues: string[] };
+	readBack: unknown;
+}> {
+	return await evalJsonAsync(
+		obsidian,
+		`
+		(async () => {
+			const plugin = app.plugins.plugins.${PLUGIN_ID};
+			const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+			const actions = ${JSON.stringify(opts.actions)};
+			const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+			const waitFor = async (selector, predicate = () => true) => {
+				const start = Date.now();
+				while (Date.now() - start < 5000) {
+					const el = Array.from(document.querySelectorAll(selector)).find(predicate);
+					if (el) return el;
+					await sleep(80);
+				}
+				throw new Error("Timed out waiting for " + selector);
+			};
+			const setInputValue = (input, value) => {
+				input.value = value;
+				input.dispatchEvent(new Event("input", { bubbles: true }));
+			};
+
+			const props = await plugin.controller.getPropertiesInFile(file);
+			const property = props.find((p) => p.key === ${JSON.stringify(opts.key)});
+			if (!property) throw new Error("Property not parsed: " + ${JSON.stringify(opts.key)});
+			const editPromise = plugin.controller.editMetaElement(property, props, file);
+			await waitFor(".metaedit-typed-list-modal .multi-select-container");
+			const dom = {
+				hasGenericPromptInput: Boolean(document.querySelector(".metaEditPromptInput")),
+				hasPillEditor: Boolean(document.querySelector(".metaedit-typed-list-modal .multi-select-container")),
+				pillValues: Array.from(document.querySelectorAll(".metaedit-typed-list-pill-input")).map((input) => input.value),
+			};
+
+			for (const action of actions) {
+				if (action.kind === "set") {
+					const input = document.querySelectorAll(".metaedit-typed-list-pill-input")[action.index];
+					if (!input) throw new Error("Missing pill input at " + action.index);
+					setInputValue(input, action.value);
+				}
+				if (action.kind === "add") {
+					const input = await waitFor(".metaedit-typed-list-add-input");
+					setInputValue(input, action.value);
+					input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+					await sleep(100);
+				}
+				if (action.kind === "typeAdd") {
+					const input = await waitFor(".metaedit-typed-list-add-input");
+					setInputValue(input, action.value);
+					await sleep(100);
+				}
+				if (action.kind === "remove") {
+					const button = document.querySelectorAll(".metaedit-typed-list-remove")[action.index];
+					if (!button) throw new Error("Missing remove button at " + action.index);
+					button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+					await sleep(100);
+				}
+			}
+
+			const save = await waitFor(".metaedit-typed-list-save");
+			save.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			await editPromise;
+			await sleep(300);
+
+			return {
+				content: await app.vault.read(file),
+				dom,
+				readBack: await plugin.api.getPropertyValue(${JSON.stringify(opts.key)}, file),
+			};
+		})()
+	`,
+	);
+}
 
 // Drive the command edit flow for a list property: open editMetaElement, click a
 // suggestion by its text, then type a value into the prompt and submit.


### PR DESCRIPTION
Add a MetaEdit-owned typed list editor for ordinary top-level YAML array properties. This replaces the old two-step suggester + single text field path for non-tag, non-alias YAML arrays with a stateful pill editor styled with Obsidian multi-select/metadata classes.

This follows the approved build-first direction from:
- Design: `/Users/christian/orca/workspaces/MetaEdit/typed-props-design/TYPED_PROPERTIES_DESIGN.md`
- Native spike verdict: `/tmp/NATIVE_WIDGET_SPIKE_VERDICT.md` / `origin/chhoumann/typed-props-native-spike` (`VERDICT: PARTIAL`)

What changed:
- Routes only top-level `MetaType.YAML` arrays that are not virtual/nested, not `tags`/`tag`, and not `aliases` into the new editor.
- Keeps tags, aliases, scalar YAML, inline Dataview fields, Auto Properties, body tags, and parent containers on their existing paths.
- Reconstructs list values so untouched mixed elements keep their original types, order, duplicates, and wikilink/comma boundaries.
- Adds an atomic stale-write guard for the typed-list path inside the existing `processFrontMatter` write path.
- Leaves parser semantics, public API, storage shape, release metadata, and `minAppVersion` unchanged.

Validation:
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- Focused isolated Obsidian E2E: `pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/multi-value.test.ts` (15/15)
- Direct isolated Obsidian DOM proof: typed modal rendered `.multi-select-container`, no `.metaEditPromptInput`, and `[[C, D]]` round-tripped as one YAML list item.
- `pnpm run obsidian:e2e -- dev:errors`: no errors captured after focused proof.

I also attempted the full isolated E2E suite after touching the shared eval helper. Two full-suite runs hit existing Obsidian lifecycle timeouts during plugin disable/reload; the failing `metaedit-runtime.test.ts` file passed 23/23 when rerun alone from a fresh instance.

Follow-up plan after this foundational PR is reviewed:
- Slice 2: owned tags/aliases editors.
- Slice 3: owned number/checkbox editors.
- Slice 4: owned date/datetime editors.

No community issue is referenced or closed by this PR.