### PR TITLE
feat(editor): always suggest wikilinks in native text/list/aliases editors

### DIFF
--- a/src/Modals/NativePropertyPrompt/NativePropertyPrompt.ts
+++ b/src/Modals/NativePropertyPrompt/NativePropertyPrompt.ts
@@ -129,7 +129,7 @@ export default class NativePropertyPrompt extends Modal {
 				},
 				blur: () => undefined,
 			});
-			this.installAliasesWikilinkFallback();
+			this.installWikilinkSuggester();
 		} catch (error) {
 			const reason = error instanceof Error ? error.message : String(error);
 			this.renderFailed = true;
@@ -143,14 +143,27 @@ export default class NativePropertyPrompt extends Modal {
 		}
 	}
 
-	private installAliasesWikilinkFallback(): void {
-		if (this.type !== "aliases") return;
+	private installWikilinkSuggester(): void {
+		// text, list, and aliases values can hold [[wikilinks]]. Install our own
+		// suggester so typing `[[` always offers vault files - Obsidian's native
+		// autocomplete in these mounted widgets only triggers once the property
+		// is already inferred to contain links, leaving fresh properties without
+		// suggestions. tags/cssclasses are not link-bearing, so they're excluded.
+		if (this.type !== "text" && this.type !== "multitext" && this.type !== "aliases") return;
 
-		const inputEl = this.hostEl.querySelector<HTMLElement>(".multi-select-input[contenteditable='true']");
+		const inputEl = this.wikilinkInputEl();
 		if (!inputEl) return;
 
 		const suggester = new NativeWikilinkSuggester(this.app, inputEl, this.file.path);
 		this.cleanupCallbacks.push(() => suggester.destroy());
+	}
+
+	private wikilinkInputEl(): HTMLElement | null {
+		if (this.type === "multitext" || this.type === "aliases") {
+			return this.hostEl.querySelector<HTMLElement>(".multi-select-input[contenteditable='true']");
+		}
+		// The native text widget renders a contenteditable longtext div.
+		return this.hostEl.querySelector<HTMLElement>("[contenteditable='true']");
 	}
 
 	private mountFallbackInput(reason: string): void {

--- a/src/Modals/NativePropertyPrompt/nativeWikilinkSuggester.test.ts
+++ b/src/Modals/NativePropertyPrompt/nativeWikilinkSuggester.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it} from "vitest";
+import {buildWikilinkInsertion, extractWikilinkQuery} from "./nativeWikilinkSuggester";
+
+describe("extractWikilinkQuery", () => {
+	it("returns the text typed after an open [[", () => {
+		expect(extractWikilinkQuery("[[Foo")).toBe("Foo");
+		expect(extractWikilinkQuery("see [[bar")).toBe("bar");
+		expect(extractWikilinkQuery("[[")).toBe("");
+	});
+
+	it("returns null when there is no open [[", () => {
+		expect(extractWikilinkQuery("")).toBeNull();
+		expect(extractWikilinkQuery("plain text")).toBeNull();
+		// A closed link is not an active query.
+		expect(extractWikilinkQuery("[[Foo]]")).toBeNull();
+	});
+});
+
+describe("buildWikilinkInsertion", () => {
+	it("preserves text typed before the [[", () => {
+		expect(buildWikilinkInsertion("see [[fo", "[[Foo]]")).toBe("see [[Foo]]");
+	});
+
+	it("inserts a comma-containing link verbatim as a single value", () => {
+		expect(buildWikilinkInsertion("[[A, ", "[[A, B]]")).toBe("[[A, B]]");
+		expect(buildWikilinkInsertion("ref [[a", "[[A, B|alias]]")).toBe("ref [[A, B|alias]]");
+	});
+
+	it("replaces the whole value when it is only the query", () => {
+		expect(buildWikilinkInsertion("[[Foo", "[[Foo]]")).toBe("[[Foo]]");
+	});
+
+	it("appends defensively when there is no open [[", () => {
+		expect(buildWikilinkInsertion("done", "[[Foo]]")).toBe("done[[Foo]]");
+	});
+});

--- a/src/Modals/NativePropertyPrompt/nativeWikilinkSuggester.ts
+++ b/src/Modals/NativePropertyPrompt/nativeWikilinkSuggester.ts
@@ -8,6 +8,24 @@ type LinkSuggestion = {
 
 const WIKILINK_QUERY = /\[\[([^\]]*)$/;
 
+// The query the user is typing after the most recent unclosed `[[`, or null if
+// the text does not end with an open `[[`.
+export function extractWikilinkQuery(text: string): string | null {
+	const match = text.match(WIKILINK_QUERY);
+	if (!match) return null;
+	return match[1] ?? "";
+}
+
+// Replace the trailing `[[query` with the generated link, preserving any text
+// typed before the `[[`. The query regex is end-anchored, so the link is
+// appended to that prefix. A link containing a comma (e.g. `[[A, B]]`) is
+// inserted verbatim and is never split into multiple values.
+export function buildWikilinkInsertion(text: string, link: string): string {
+	const match = text.match(WIKILINK_QUERY);
+	const prefix = match && match.index !== undefined ? text.slice(0, match.index) : text;
+	return prefix + link;
+}
+
 export class NativeWikilinkSuggester extends AbstractInputSuggest<LinkSuggestion> {
 	private readonly mirrorEl: HTMLInputElement;
 	private readonly onInput = () => this.refreshFromContent();
@@ -72,10 +90,8 @@ export class NativeWikilinkSuggester extends AbstractInputSuggest<LinkSuggestion
 	}
 
 	private currentQuery(): {query: string} | null {
-		const text = this.inputEl.textContent ?? "";
-		const match = text.match(WIKILINK_QUERY);
-		if (!match) return null;
-		return {query: match[1] ?? ""};
+		const query = extractWikilinkQuery(this.inputEl.textContent ?? "");
+		return query === null ? null : {query};
 	}
 
 	private acceptSuggestion(suggestion: LinkSuggestion): void {
@@ -86,8 +102,9 @@ export class NativeWikilinkSuggester extends AbstractInputSuggest<LinkSuggestion
 			"",
 			suggestion.alias,
 		);
-		this.inputEl.textContent = link;
+		this.inputEl.textContent = buildWikilinkInsertion(this.inputEl.textContent ?? "", link);
 		this.inputEl.focus();
+		placeCaretAtEnd(this.inputEl);
 		this.inputEl.trigger("input");
 		this.close();
 	}
@@ -99,4 +116,14 @@ export class NativeWikilinkSuggester extends AbstractInputSuggest<LinkSuggestion
 		const suggestions = metadataCache.getLinkSuggestions?.() ?? [];
 		return suggestions.filter(suggestion => suggestion.file);
 	}
+}
+
+function placeCaretAtEnd(el: HTMLElement): void {
+	const selection = el.ownerDocument.defaultView?.getSelection();
+	if (!selection) return;
+	const range = el.ownerDocument.createRange();
+	range.selectNodeContents(el);
+	range.collapse(false);
+	selection.removeAllRanges();
+	selection.addRange(range);
 }


### PR DESCRIPTION
Follow-up to #168. Makes `[[` wikilink suggestions **universal** in the native property editors.

## Problem
The native text/multitext/aliases widgets only surface Obsidian's own `[[` autocomplete once a property is already inferred to contain links - so a fresh/plain property (e.g. a new text value or an empty list) gets **no** suggestions when you type `[[`. Only the aliases path had our own suggester. (Confirmed manually: "`[[` only triggered when editing a property that already has `[[]]` links.")

## Change
- Install our `AbstractInputSuggest`-based `NativeWikilinkSuggester` on **all three** text-bearing native widgets - text, list (multitext), and aliases - so typing `[[` always offers vault files regardless of the property's current content. (tags/cssclasses are excluded - not link-bearing.)
- Fix the insert to **preserve text typed before the `[[`** (it previously replaced the whole value) and place the caret at the end after inserting.
- A link containing a comma (`[[A, B]]`) is inserted verbatim and stays a single value (never split).

## Tests
- `pnpm run lint` + `pnpm run build` + `pnpm run test` (368 unit tests) green.
- New `nativeWikilinkSuggester.test.ts` covers the extracted pure helpers: `[[` query extraction (incl. closed-link = no query) and prefix-preserving insertion (incl. comma-in-link stays one value).
- Live popover behavior is intentionally **not** auto-tested: driving Obsidian's native suggest popover via synthetic events wedges the obsidian-e2e transport (see the skipped test in #168). 

## ⚠️ Needs your manual check before merge
In the dev vault, type `[[` in a **fresh** text/list/aliases property (one with no existing links) and confirm the suggestion popover appears and inserts a correct link that round-trips. Also worth a glance: a property that *already* has links (to confirm there's no double popup with the native one).

Paused for review - not self-merged.