### PR TITLE
feat(create): fluid, type-aware native YAML property creation

### DIFF
--- a/src/Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt.ts
+++ b/src/Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt.ts
@@ -97,6 +97,7 @@ export default class FluidPropertyCreatePrompt extends Modal {
 			this.resolvePromise = resolve;
 		});
 
+		this.modalEl.addClass("metaedit-fluid-create-modal");
 		this.contentEl.addClass("metaedit-fluid-create");
 		new Setting(this.contentEl).setHeading().setName("New property");
 
@@ -174,7 +175,7 @@ export default class FluidPropertyCreatePrompt extends Modal {
 
 	private registerKeyInput(): void {
 		if (this.opts.suggestValues.length > 0) {
-			this.keySuggester = new GenericTextSuggester(this.app, this.keyInputEl, this.opts.suggestValues);
+			this.keySuggester = new FluidKeyNameSuggester(this.app, this.keyInputEl, this.opts.suggestValues);
 		}
 		this.keyInputEl.addEventListener("input", () => this.updateValidity());
 		this.keyInputEl.addEventListener("blur", () => this.settleKey());
@@ -439,5 +440,18 @@ export default class FluidPropertyCreatePrompt extends Modal {
 
 	private capitalize(text: string): string {
 		return text.length === 0 ? text : text[0].toUpperCase() + text.slice(1);
+	}
+}
+
+/**
+ * The key-name suggester for the create modal. It tags its dropdown so the scoped
+ * CSS cap applies (a fixed max-height + scroll, sized to sit above the action
+ * buttons within the reserved modal height), so the list never spills below the
+ * modal or covers the buttons.
+ */
+class FluidKeyNameSuggester extends GenericTextSuggester {
+	renderSuggestion(value: string, el: HTMLElement): void {
+		super.renderSuggestion(value, el);
+		el.closest(".suggestion-container")?.addClass("metaedit-fluid-create-suggest");
 	}
 }

--- a/src/Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt.ts
+++ b/src/Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt.ts
@@ -106,7 +106,7 @@ export default class FluidPropertyCreatePrompt extends Modal {
 		this.typePillEl.type = "button";
 		this.typePillIconEl = this.typePillEl.createSpan({cls: "metaedit-fluid-create-type-icon"});
 		this.typePillLabelEl = this.typePillEl.createSpan({cls: "metaedit-fluid-create-type-label"});
-		this.typePillEl.addEventListener("click", (evt) => this.openTypeMenu(evt));
+		this.typePillEl.addEventListener("click", () => this.openTypeMenu());
 
 		this.keyInputEl = rowEl.createEl("input", {
 			cls: "metadata-property-key-input metaedit-fluid-create-key",
@@ -282,7 +282,7 @@ export default class FluidPropertyCreatePrompt extends Modal {
 		this.host.focus();
 	}
 
-	private openTypeMenu(evt?: MouseEvent): void {
+	private openTypeMenu(): void {
 		if (this.autoPropertyKey || LOCKED_TYPES.has(this.host.type)) return;
 
 		const menu = new Menu();
@@ -294,12 +294,10 @@ export default class FluidPropertyCreatePrompt extends Modal {
 				item.onClick(() => this.pickType(choice.type));
 			});
 		}
-		if (evt instanceof MouseEvent) {
-			menu.showAtMouseEvent(evt);
-		} else {
-			const rect = this.typePillEl.getBoundingClientRect();
-			menu.showAtPosition({x: rect.left, y: rect.bottom});
-		}
+		// Anchor the menu under the pill like a dropdown (deterministic position,
+		// independent of the pointer), so click and Cmd/Ctrl+Y open it the same way.
+		const rect = this.typePillEl.getBoundingClientRect();
+		menu.showAtPosition({x: rect.left, y: rect.bottom + 4});
 	}
 
 	private updateTypePill(): void {

--- a/src/Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt.ts
+++ b/src/Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt.ts
@@ -243,8 +243,17 @@ export default class FluidPropertyCreatePrompt extends Modal {
 		}
 		if (this.autoPropertyKey) this.exitAutoPropertyState();
 
-		if (this.pinnedType) return;
 		const type = resolveCreationType(this.app, key);
+		// A reserved key (tags/aliases) forces its widget and overrides any pinned
+		// choice - you can never make `tags` a Number - so this check runs BEFORE the
+		// pinned short-circuit and clears the pin.
+		if (LOCKED_TYPES.has(type)) {
+			this.pinnedType = false;
+			if (type !== this.host.type) this.remountAs(type);
+			return;
+		}
+
+		if (this.pinnedType) return;
 		if (type !== this.host.type) this.remountAs(type);
 	}
 
@@ -270,6 +279,9 @@ export default class FluidPropertyCreatePrompt extends Modal {
 	}
 
 	private remountAs(type: StandardNativePropertyType): void {
+		// Close the key dropdown first so the host's portal teardown can't remove a
+		// live sibling suggestion popover during the re-mount.
+		this.keySuggester?.close();
 		const seed = seedFromRawText(this.host.readRawText(), type);
 		this.host.mountNative(type, seed);
 		this.updateTypePill();
@@ -283,6 +295,9 @@ export default class FluidPropertyCreatePrompt extends Modal {
 	}
 
 	private openTypeMenu(): void {
+		// Settle first so a reserved key locks its type before the menu opens (you
+		// can't pick a type for tags/aliases), and so the adopted type is checked.
+		this.settleKey();
 		if (this.autoPropertyKey || LOCKED_TYPES.has(this.host.type)) return;
 
 		const menu = new Menu();
@@ -364,6 +379,13 @@ export default class FluidPropertyCreatePrompt extends Modal {
 
 		if (this.autoPropertyKey) {
 			this.finish({kind: "autoProperty", key});
+			return;
+		}
+
+		// Fail closed if the native editor never rendered (no editor to take a value
+		// from), matching the edit prompt - never write the bare seed in that case.
+		if (this.host.renderFailed) {
+			new Notice(`MetaEdit could not render an editor for '${key}'. Nothing was written.`);
 			return;
 		}
 

--- a/src/Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt.ts
+++ b/src/Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt.ts
@@ -1,0 +1,423 @@
+import {Menu, Modal, Notice, Setting, setIcon, setTooltip, type App, type ButtonComponent} from "obsidian";
+import {
+	CREATION_TYPE_CHOICES,
+	emptyValueForType,
+	getNativeWidgetForType,
+	inferCreationTypeFromText,
+	normalizeWidgetValue,
+	resolveCreationType,
+	seedFromRawText,
+	type NativeValueSource,
+	type StandardNativePropertyType,
+} from "../../typedProperties/nativePropertyTypes";
+import {isReservedFrontmatterKey} from "../../yamlPath";
+import {NativeWidgetHost} from "../NativeWidgetHost";
+import {GenericTextSuggester} from "../GenericPrompt/genericTextSuggester";
+
+export type FluidPropertyCreateResult =
+	| {
+		kind: "submit";
+		key: string;
+		type: StandardNativePropertyType;
+		value: unknown;
+		valueSource: NativeValueSource;
+	}
+	| {kind: "autoProperty"; key: string}
+	| {kind: "cancel"};
+
+export interface FluidPropertyCreateOptions {
+	sourcePath: string;
+	suggestValues: string[];
+	existingKeys: ReadonlySet<string>;
+	hasAutoProperty: (key: string) => boolean;
+}
+
+// Reserved keys with a dedicated Obsidian widget lock the type picker (switching a
+// `tags`/`aliases` property to Number is nonsense). `cssclasses` maps to the List
+// widget and needs no lock.
+const LOCKED_TYPES: ReadonlySet<StandardNativePropertyType> = new Set(["tags", "aliases"]);
+const FALLBACK_ICONS: Record<StandardNativePropertyType, string> = {
+	text: "text",
+	multitext: "list",
+	number: "binary",
+	checkbox: "check-square",
+	date: "calendar",
+	datetime: "clock",
+	tags: "tags",
+	aliases: "text",
+	cssclasses: "list",
+};
+
+/**
+ * A single keyboard-first modal for creating a new YAML frontmatter property,
+ * cloning the FEEL of Obsidian's own add-property row: a type pill, a key input
+ * with known-name suggestions, and an adaptive value host that mounts Obsidian's
+ * native widget for the current type. A key the vault already knows auto-adopts
+ * its type; a brand-new key defaults to text and the user can switch fluidly.
+ *
+ * Resolves a discriminated result (never truthiness): `submit` with the typed
+ * value, `autoProperty` to hand a key back to its Auto Property flow, or `cancel`.
+ */
+export default class FluidPropertyCreatePrompt extends Modal {
+	private readonly opts: FluidPropertyCreateOptions;
+	private resolvePromise: (result: FluidPropertyCreateResult) => void;
+
+	private keyInputEl: HTMLInputElement;
+	private hostEl: HTMLElement;
+	private typePillEl: HTMLButtonElement;
+	private typePillIconEl: HTMLElement;
+	private typePillLabelEl: HTMLElement;
+	private hintEl: HTMLElement;
+	private warningEl: HTMLElement;
+	private autoPropertyNoteEl: HTMLElement;
+	private addButton: ButtonComponent | null = null;
+
+	private host: NativeWidgetHost;
+	private keySuggester: GenericTextSuggester | undefined;
+
+	private pinnedType = false;
+	private autoPropertyKey = false;
+	private lastSettledKey: string | null = null;
+	private inferredType: StandardNativePropertyType | null = null;
+
+	private result: FluidPropertyCreateResult = {kind: "cancel"};
+	private didFinish = false;
+	private didResolve = false;
+
+	public readonly waitForClose: Promise<FluidPropertyCreateResult>;
+
+	public static Open(app: App, options: FluidPropertyCreateOptions): Promise<FluidPropertyCreateResult> {
+		return new FluidPropertyCreatePrompt(app, options).waitForClose;
+	}
+
+	private constructor(app: App, options: FluidPropertyCreateOptions) {
+		super(app);
+		this.opts = options;
+		this.waitForClose = new Promise((resolve) => {
+			this.resolvePromise = resolve;
+		});
+
+		this.contentEl.addClass("metaedit-fluid-create");
+		new Setting(this.contentEl).setHeading().setName("New property");
+
+		const rowEl = this.contentEl.createDiv({cls: "metadata-property metaedit-fluid-create-row"});
+
+		this.typePillEl = rowEl.createEl("button", {cls: "metaedit-fluid-create-type"});
+		this.typePillEl.type = "button";
+		this.typePillIconEl = this.typePillEl.createSpan({cls: "metaedit-fluid-create-type-icon"});
+		this.typePillLabelEl = this.typePillEl.createSpan({cls: "metaedit-fluid-create-type-label"});
+		this.typePillEl.addEventListener("click", (evt) => this.openTypeMenu(evt));
+
+		this.keyInputEl = rowEl.createEl("input", {
+			cls: "metadata-property-key-input metaedit-fluid-create-key",
+			type: "text",
+		});
+		this.keyInputEl.placeholder = "Property name";
+
+		this.hostEl = rowEl.createDiv({cls: "metadata-property-value metaedit-native-property-host metaedit-fluid-create-value"});
+		this.autoPropertyNoteEl = rowEl.createDiv({cls: "metaedit-fluid-create-autoprop"});
+		this.autoPropertyNoteEl.hide();
+
+		this.hintEl = this.contentEl.createDiv({cls: "metaedit-fluid-create-hint"});
+		this.hintEl.hide();
+		this.warningEl = this.contentEl.createDiv({cls: "metaedit-fluid-create-warning"});
+		this.warningEl.hide();
+
+		this.host = new NativeWidgetHost({
+			app,
+			hostEl: this.hostEl,
+			sourcePath: options.sourcePath,
+			key: "",
+		});
+		this.host.mountNative("text", emptyValueForType("text"));
+		this.updateTypePill();
+
+		this.buildFooter();
+		this.registerKeyInput();
+		this.registerKeyboard();
+
+		this.open();
+	}
+
+	onOpen(): void {
+		super.onOpen();
+		this.keyInputEl.focus();
+		this.updateValidity();
+	}
+
+	onClose(): void {
+		super.onClose();
+		this.keySuggester?.close();
+		this.keySuggester = undefined;
+		this.host.destroy();
+		if (!this.didFinish) this.result = {kind: "cancel"};
+		this.resolveOnce();
+	}
+
+	private buildFooter(): void {
+		new Setting(this.contentEl)
+			.addExtraButton(button => button
+				.setIcon("info")
+				.setDisabled(true)
+				.setTooltip("⌘/Ctrl+↵ to add · ⌘/Ctrl+Y to change type"))
+			.addButton(button => {
+				this.addButton = button;
+				button
+					.setButtonText("Add")
+					.setCta()
+					.onClick(() => this.commit());
+			})
+			.addButton(button => button
+				.setButtonText("Cancel")
+				.onClick(() => this.cancel()));
+	}
+
+	private registerKeyInput(): void {
+		if (this.opts.suggestValues.length > 0) {
+			this.keySuggester = new GenericTextSuggester(this.app, this.keyInputEl, this.opts.suggestValues);
+		}
+		this.keyInputEl.addEventListener("input", () => this.updateValidity());
+		this.keyInputEl.addEventListener("blur", () => this.settleKey());
+		this.keyInputEl.addEventListener("keydown", (evt) => {
+			if (evt.isComposing) return;
+			if ((evt.key === "Enter" || evt.key === "Tab") && !evt.shiftKey && !this.isSuggestionOpen()) {
+				evt.preventDefault();
+				this.settleAndAdvance();
+			}
+		});
+	}
+
+	private registerKeyboard(): void {
+		// Universal commit + type-switch accelerators, in the capture phase so they
+		// fire regardless of which native widget owns focus.
+		this.contentEl.addEventListener("keydown", (evt) => {
+			if (evt.isComposing) return;
+			if ((evt.metaKey || evt.ctrlKey) && evt.key === "Enter") {
+				evt.preventDefault();
+				this.commit();
+				return;
+			}
+			if ((evt.metaKey || evt.ctrlKey) && (evt.key === "y" || evt.key === "Y")) {
+				evt.preventDefault();
+				this.openTypeMenu();
+			}
+		}, true);
+
+		// Plain Enter commits only from a genuinely single-line value editor
+		// (number/date/datetime); in the text longtext or a chip editor Enter
+		// belongs to the widget.
+		this.hostEl.addEventListener("keydown", (evt) => {
+			if (evt.isComposing) return;
+			if (evt.key !== "Enter" || evt.metaKey || evt.ctrlKey || evt.shiftKey || evt.altKey) return;
+			if (!this.host.isSingleLineEditor()) return;
+			evt.preventDefault();
+			this.commit();
+		});
+		this.hostEl.addEventListener("input", () => this.updateInferenceHint());
+	}
+
+	private settleAndAdvance(): void {
+		this.settleKey();
+		if (this.autoPropertyKey) return;
+		this.host.focus();
+	}
+
+	private settleKey(): void {
+		const key = this.keyInputEl.value.trim();
+		this.updateValidity();
+
+		if (key === "" || isReservedFrontmatterKey(key) || this.opts.existingKeys.has(key)) {
+			// Not a creatable key: keep the default text host, adopt nothing.
+			if (this.autoPropertyKey) this.exitAutoPropertyState();
+			this.lastSettledKey = key;
+			return;
+		}
+
+		if (key === this.lastSettledKey) return;
+		this.lastSettledKey = key;
+		this.host.setKey(key);
+
+		if (this.opts.hasAutoProperty(key)) {
+			this.enterAutoPropertyState(key);
+			return;
+		}
+		if (this.autoPropertyKey) this.exitAutoPropertyState();
+
+		if (this.pinnedType) return;
+		const type = resolveCreationType(this.app, key);
+		if (type !== this.host.type) this.remountAs(type);
+	}
+
+	private enterAutoPropertyState(key: string): void {
+		this.autoPropertyKey = true;
+		this.host.destroy();
+		this.hostEl.hide();
+		this.typePillEl.hide();
+		this.hideInferenceHint();
+		this.autoPropertyNoteEl.setText(`"${key}" uses an Auto Property – press ⌘/Ctrl+↵ to choose its value.`);
+		this.autoPropertyNoteEl.show();
+		this.updateValidity();
+	}
+
+	private exitAutoPropertyState(): void {
+		this.autoPropertyKey = false;
+		this.autoPropertyNoteEl.hide();
+		this.hostEl.show();
+		this.typePillEl.show();
+		this.host.mountNative("text", emptyValueForType("text"));
+		this.pinnedType = false;
+		this.updateTypePill();
+	}
+
+	private remountAs(type: StandardNativePropertyType): void {
+		const seed = seedFromRawText(this.host.readRawText(), type);
+		this.host.mountNative(type, seed);
+		this.updateTypePill();
+		this.updateInferenceHint();
+	}
+
+	private pickType(type: StandardNativePropertyType): void {
+		this.pinnedType = true;
+		this.remountAs(type);
+		this.host.focus();
+	}
+
+	private openTypeMenu(evt?: MouseEvent): void {
+		if (this.autoPropertyKey || LOCKED_TYPES.has(this.host.type)) return;
+
+		const menu = new Menu();
+		for (const choice of CREATION_TYPE_CHOICES) {
+			menu.addItem(item => {
+				item.setTitle(choice.label);
+				item.setIcon(this.iconIdFor(choice.type));
+				item.setChecked(choice.type === this.host.type);
+				item.onClick(() => this.pickType(choice.type));
+			});
+		}
+		if (evt instanceof MouseEvent) {
+			menu.showAtMouseEvent(evt);
+		} else {
+			const rect = this.typePillEl.getBoundingClientRect();
+			menu.showAtPosition({x: rect.left, y: rect.bottom});
+		}
+	}
+
+	private updateTypePill(): void {
+		const type = this.host.type;
+		const label = CREATION_TYPE_CHOICES.find(choice => choice.type === type)?.label ?? this.capitalize(type);
+		setIcon(this.typePillIconEl, this.iconIdFor(type));
+		this.typePillLabelEl.setText(label);
+		const locked = LOCKED_TYPES.has(type);
+		this.typePillEl.toggleClass("is-locked", locked);
+		this.typePillEl.disabled = locked;
+		setTooltip(this.typePillEl, locked ? `${label} (fixed for this property)` : "Change type (⌘/Ctrl+Y)");
+	}
+
+	private updateInferenceHint(): void {
+		if (this.autoPropertyKey || this.pinnedType) {
+			this.hideInferenceHint();
+			return;
+		}
+		const inferred = inferCreationTypeFromText(this.host.readRawText(), this.host.type);
+		if (!inferred) {
+			this.hideInferenceHint();
+			return;
+		}
+		this.inferredType = inferred;
+		const label = CREATION_TYPE_CHOICES.find(choice => choice.type === inferred)?.label ?? inferred;
+		this.hintEl.empty();
+		this.hintEl.createSpan({text: `Looks like a ${label.toLowerCase()}. `});
+		const acceptEl = this.hintEl.createEl("a", {cls: "metaedit-fluid-create-hint-accept", text: `Change to ${label}`});
+		acceptEl.addEventListener("click", (evt) => {
+			evt.preventDefault();
+			if (this.inferredType) this.pickType(this.inferredType);
+		});
+		this.hintEl.show();
+	}
+
+	private hideInferenceHint(): void {
+		this.inferredType = null;
+		this.hintEl.hide();
+		this.hintEl.empty();
+	}
+
+	private updateValidity(): void {
+		const key = this.keyInputEl.value.trim();
+		let warning = "";
+		if (key !== "" && isReservedFrontmatterKey(key)) {
+			warning = `"${key}" is a reserved property name and can't be used.`;
+		} else if (key !== "" && this.opts.existingKeys.has(key)) {
+			warning = `This note already has a property named "${key}".`;
+		}
+		this.warningEl.setText(warning);
+		this.warningEl.toggle(warning !== "");
+		this.addButton?.setDisabled(key === "" || warning !== "");
+	}
+
+	private commit(): void {
+		this.settleKey();
+
+		const key = this.keyInputEl.value.trim();
+		if (key === "" || isReservedFrontmatterKey(key) || this.opts.existingKeys.has(key)) {
+			this.updateValidity();
+			this.keyInputEl.focus();
+			return;
+		}
+
+		if (this.autoPropertyKey) {
+			this.finish({kind: "autoProperty", key});
+			return;
+		}
+
+		this.host.flushFocus();
+
+		if (this.host.valueSource === "native" && this.host.didEditDom && !this.host.didReceiveChange) {
+			new Notice(`MetaEdit did not receive a value from Obsidian's native editor for '${key}'. Nothing was written.`);
+			return;
+		}
+
+		const normalized = normalizeWidgetValue(this.host.type, this.host.value, this.host.valueSource);
+		if (normalized.ok === false) {
+			new Notice(`MetaEdit could not create '${key}': ${normalized.reason}`);
+			return;
+		}
+
+		this.finish({
+			kind: "submit",
+			key,
+			type: this.host.type,
+			value: normalized.value,
+			valueSource: this.host.valueSource,
+		});
+	}
+
+	private cancel(): void {
+		this.finish({kind: "cancel"});
+	}
+
+	private finish(result: FluidPropertyCreateResult): void {
+		this.result = result;
+		this.didFinish = true;
+		this.close();
+	}
+
+	private resolveOnce(): void {
+		if (this.didResolve) return;
+		this.didResolve = true;
+		this.resolvePromise(this.result);
+	}
+
+	private isSuggestionOpen(): boolean {
+		return activeDocument.querySelector(".suggestion-container") !== null;
+	}
+
+	private iconIdFor(type: StandardNativePropertyType): string {
+		const raw = getNativeWidgetForType(this.app, type)?.icon;
+		const id = typeof raw === "string" ? raw.replace(/^lucide-/, "") : "";
+		return id || FALLBACK_ICONS[type];
+	}
+
+	private capitalize(text: string): string {
+		return text.length === 0 ? text : text[0].toUpperCase() + text.slice(1);
+	}
+}

--- a/src/Modals/NativePropertyPrompt/NativePropertyPrompt.ts
+++ b/src/Modals/NativePropertyPrompt/NativePropertyPrompt.ts
@@ -4,51 +4,18 @@ import {
 	normalizeWidgetValue,
 	resolveNativeProperty,
 	type NativePropertyPromptResult,
-	type NativePropertyWidget,
-	type StandardNativePropertyType,
-	type NativeValueSource,
 } from "../../typedProperties/nativePropertyTypes";
-import {NativeWikilinkSuggester} from "./nativeWikilinkSuggester";
-
-type WidgetLifecycleOwner = {
-	close?: unknown;
-	destroy?: unknown;
-	unload?: unknown;
-	multiselect?: unknown;
-	suggest?: unknown;
-	suggester?: unknown;
-	suggestEl?: unknown;
-	hoverPopover?: unknown;
-	popover?: unknown;
-};
-
-const BODY_PORTAL_SELECTOR = ".suggestion-container, .popover, .hover-popover";
-const EDITING_KEYS = new Set([
-	"Backspace",
-	"Delete",
-	"Enter",
-	"Spacebar",
-	" ",
-]);
+import {NativeWidgetHost} from "../NativeWidgetHost";
 
 export default class NativePropertyPrompt extends Modal {
 	private readonly file: TFile;
 	private readonly property: Property;
 	private resolvePromise: (result: NativePropertyPromptResult) => void;
-	private readonly initialBodyChildren: Set<Element>;
-	private readonly cleanupCallbacks: Array<() => void> = [];
-	private readonly valueSource: NativeValueSource;
-	private readonly type: StandardNativePropertyType;
-	private fallbackInputEl: HTMLInputElement | null = null;
+	private readonly host: NativeWidgetHost;
 	private hostEl: HTMLElement;
-	private widgetInstance: unknown;
-	private lastValue: unknown;
 	private result: NativePropertyPromptResult = {kind: "cancel"};
 	private didFinish = false;
 	private didResolve = false;
-	private didReceiveChange = false;
-	private didEditDom = false;
-	private renderFailed = false;
 	private saveButton: ButtonComponent | null = null;
 
 	public readonly waitForClose: Promise<NativePropertyPromptResult>;
@@ -62,8 +29,6 @@ export default class NativePropertyPrompt extends Modal {
 		super(app);
 		this.file = file;
 		this.property = property;
-		this.lastValue = property.content;
-		this.initialBodyChildren = new Set(Array.from(activeDocument.body.children));
 		this.waitForClose = new Promise<NativePropertyPromptResult>((resolve) => {
 			this.resolvePromise = resolve;
 		});
@@ -76,14 +41,18 @@ export default class NativePropertyPrompt extends Modal {
 		const rowEl = this.contentEl.createDiv({cls: "metadata-property metaedit-native-property-row"});
 		this.hostEl = rowEl.createDiv({cls: "metadata-property-value metaedit-native-property-host"});
 
-		const resolution = resolveNativeProperty(app, property);
-		this.type = resolution.type;
-		this.valueSource = resolution.kind === "native" ? "native" : "fallback";
+		this.host = new NativeWidgetHost({
+			app,
+			hostEl: this.hostEl,
+			sourcePath: file.path,
+			key: property.key,
+		});
 
+		const resolution = resolveNativeProperty(app, property);
 		if (resolution.kind === "native") {
-			this.mountNativeWidget(resolution.widget);
+			this.host.mountNative(resolution.type, property.content);
 		} else {
-			this.mountFallbackInput(resolution.reason);
+			this.host.mountFallback(resolution.reason, property.content);
 		}
 
 		new Setting(this.contentEl)
@@ -92,7 +61,7 @@ export default class NativePropertyPrompt extends Modal {
 				button
 					.setButtonText("Save")
 					.setCta()
-					.setDisabled(this.renderFailed)
+					.setDisabled(this.host.renderFailed)
 					.onClick(() => this.submit());
 			})
 			.addButton(button => {
@@ -106,104 +75,37 @@ export default class NativePropertyPrompt extends Modal {
 
 	onOpen(): void {
 		super.onOpen();
-		this.focusInitialEditor();
+		this.host.focus();
 	}
 
 	onClose(): void {
 		super.onClose();
-		this.cleanup();
+		this.host.destroy();
+		this.hostEl.remove();
 		if (!this.didFinish) this.result = {kind: "cancel"};
 		this.resolveOnce();
 	}
 
-	private mountNativeWidget(widget: NativePropertyWidget): void {
-		this.trackWidgetDomActivity();
-		try {
-			this.widgetInstance = widget.render?.(this.hostEl, this.property.content, {
-				app: this.app,
-				key: this.property.key,
-				sourcePath: this.file.path,
-				onChange: (value: unknown) => {
-					this.lastValue = value;
-					this.didReceiveChange = true;
-				},
-				blur: () => undefined,
-			});
-			this.installAliasesWikilinkFallback();
-		} catch (error) {
-			const reason = error instanceof Error ? error.message : String(error);
-			this.renderFailed = true;
-			this.hostEl.empty();
-			this.hostEl.createDiv({
-				cls: "metaedit-native-property-error",
-				text: `MetaEdit could not render Obsidian's native editor for '${this.property.key}'.`,
-			});
-			this.saveButton?.setDisabled(true);
-			new Notice(`MetaEdit could not render Obsidian's native editor for '${this.property.key}': ${reason}`);
-		}
-	}
-
-	private installAliasesWikilinkFallback(): void {
-		if (this.type !== "aliases") return;
-
-		const inputEl = this.hostEl.querySelector<HTMLElement>(".multi-select-input[contenteditable='true']");
-		if (!inputEl) return;
-
-		const suggester = new NativeWikilinkSuggester(this.app, inputEl, this.file.path);
-		this.cleanupCallbacks.push(() => suggester.destroy());
-	}
-
-	private mountFallbackInput(reason: string): void {
-		this.hostEl.createDiv({
-			cls: "metaedit-native-property-fallback-note",
-			text: reason,
-		});
-		const inputEl = this.hostEl.createEl("input", {
-			cls: "metadata-input metadata-input-text metaedit-native-property-fallback-input",
-			type: "text",
-		});
-		inputEl.value = this.property.content === null || this.property.content === undefined
-			? ""
-			: String(this.property.content);
-		inputEl.addEventListener("input", () => {
-			this.lastValue = inputEl.value;
-			this.didReceiveChange = true;
-		});
-		this.fallbackInputEl = inputEl;
-	}
-
-	private trackWidgetDomActivity(): void {
-		const markEdited = (evt: Event) => {
-			if (evt instanceof KeyboardEvent && !isEditingKey(evt)) return;
-			this.didEditDom = true;
-		};
-		const events: Array<keyof HTMLElementEventMap> = ["input", "change", "paste", "compositionend", "keydown"];
-		for (const eventName of events) {
-			this.hostEl.addEventListener(eventName, markEdited, true);
-			this.cleanupCallbacks.push(() => this.hostEl.removeEventListener(eventName, markEdited, true));
-		}
-	}
-
 	private submit(): void {
-		this.flushFocusedWidget();
+		this.host.flushFocus();
 
-		if (this.valueSource === "native" && this.didEditDom && !this.didReceiveChange) {
+		if (this.host.valueSource === "native" && this.host.didEditDom && !this.host.didReceiveChange) {
 			new Notice(`MetaEdit did not receive a value from Obsidian's native editor for '${this.property.key}'. Nothing was written.`);
 			return;
 		}
 
-		if (!this.didReceiveChange) {
+		if (!this.host.didReceiveChange) {
 			this.finish({
 				kind: "submit",
 				changed: false,
-				type: this.type,
+				type: this.host.type,
 				value: this.property.content,
-				valueSource: this.valueSource,
+				valueSource: this.host.valueSource,
 			});
 			return;
 		}
 
-		const normalized = normalizeWidgetValue(this.type, this.lastValue, this.valueSource);
+		const normalized = normalizeWidgetValue(this.host.type, this.host.value, this.host.valueSource);
 		if (normalized.ok === false) {
 			new Notice(`MetaEdit could not update '${this.property.key}': ${normalized.reason}`);
 			return;
@@ -212,9 +114,9 @@ export default class NativePropertyPrompt extends Modal {
 		this.finish({
 			kind: "submit",
 			changed: true,
-			type: this.type,
+			type: this.host.type,
 			value: normalized.value,
-			valueSource: this.valueSource,
+			valueSource: this.host.valueSource,
 		});
 	}
 
@@ -222,11 +124,10 @@ export default class NativePropertyPrompt extends Modal {
 		this.finish({kind: "cancel"});
 	}
 
-	private finish(result: NativePropertyPromptResult, closeModal: boolean = true): void {
+	private finish(result: NativePropertyPromptResult): void {
 		this.result = result;
 		this.didFinish = true;
-		if (closeModal) this.close();
-		else this.resolveOnce();
+		this.close();
 	}
 
 	private resolveOnce(): void {
@@ -234,77 +135,4 @@ export default class NativePropertyPrompt extends Modal {
 		this.didResolve = true;
 		this.resolvePromise(this.result);
 	}
-
-	private focusInitialEditor(): void {
-		const fallbackInput = this.fallbackInputEl;
-		if (fallbackInput) {
-			fallbackInput.focus();
-			fallbackInput.select();
-			return;
-		}
-
-		const focusable = this.hostEl.querySelector<HTMLElement>(
-			"input, textarea, [contenteditable='true'], button, select",
-		);
-		focusable?.focus();
-	}
-
-	private flushFocusedWidget(): void {
-		const active = activeDocument.activeElement;
-		if (active instanceof HTMLElement && this.hostEl.contains(active)) {
-			active.blur();
-		}
-	}
-
-	private cleanup(): void {
-		for (const callback of this.cleanupCallbacks.splice(0)) {
-			try {
-				callback();
-			} catch {
-				// Best-effort cleanup only.
-			}
-		}
-
-		this.closeWidgetLifecycle(this.widgetInstance);
-		this.removeBodyPortalsCreatedByWidget();
-		this.hostEl.remove();
-	}
-
-	private closeWidgetLifecycle(value: unknown): void {
-		const seen = new Set<unknown>();
-		const visit = (candidate: unknown) => {
-			if (!candidate || seen.has(candidate)) return;
-			seen.add(candidate);
-
-			const owner = candidate as WidgetLifecycleOwner;
-			for (const method of ["close", "destroy", "unload"] as const) {
-				const fn = owner[method];
-				if (typeof fn !== "function") continue;
-				try {
-					fn.call(candidate);
-				} catch {
-					// Private widget cleanup is best-effort.
-				}
-			}
-
-			for (const key of ["multiselect", "suggest", "suggester", "suggestEl", "hoverPopover", "popover"] as const) {
-				visit(owner[key]);
-			}
-		};
-
-		visit(value);
-	}
-
-	private removeBodyPortalsCreatedByWidget(): void {
-		for (const el of Array.from(activeDocument.querySelectorAll(BODY_PORTAL_SELECTOR))) {
-			if (this.initialBodyChildren.has(el)) continue;
-			el.remove();
-		}
-	}
-}
-
-function isEditingKey(evt: KeyboardEvent): boolean {
-	if (evt.metaKey || evt.ctrlKey || evt.altKey) return false;
-	if (evt.key.length === 1) return true;
-	return EDITING_KEYS.has(evt.key);
 }

--- a/src/Modals/NativeWidgetHost.test.ts
+++ b/src/Modals/NativeWidgetHost.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from "vitest";
+import {NativeWidgetHost, carryTextFromEditor, stringifyForCarry} from "./NativeWidgetHost";
+
+// A minimal fake host element whose querySelector answers like the real DOM for
+// the readRawText probes (an input/textarea, a contenteditable, or no editor).
+function makeHost(editor: {kind: "input" | "editable" | "none"; value?: string}) {
+	const hostEl = {
+		querySelector(selector: string): unknown {
+			if (editor.kind === "input" && selector.includes("input")) return {value: editor.value};
+			if (editor.kind === "editable" && selector.includes("contenteditable")) return {textContent: editor.value};
+			return null;
+		},
+	};
+	return new NativeWidgetHost({app: {} as never, hostEl: hostEl as never, sourcePath: "", key: "k"});
+}
+
+describe("carryTextFromEditor (type-switch carry decision)", () => {
+	it("carries the live editor text, and an EMPTY editor stays empty (never resurrects lastValue)", () => {
+		// The bug: clearing a Number seeded with 123 then switching type must carry ""
+		// (the cleared value), not the stale 123.
+		expect(carryTextFromEditor("", "123")).toBe("");
+		expect(carryTextFromEditor("", ["a", "b"])).toBe("");
+		expect(carryTextFromEditor("hello", "123")).toBe("hello");
+	});
+
+	it("falls back to the last reported value ONLY when there is no text editor (e.g. a checkbox)", () => {
+		expect(carryTextFromEditor(null, true)).toBe("true");
+		expect(carryTextFromEditor(null, false)).toBe("");
+		expect(carryTextFromEditor(null, ["a", "b"])).toBe("a, b");
+		expect(carryTextFromEditor(null, 5)).toBe("5");
+		expect(carryTextFromEditor(null, undefined)).toBe("");
+	});
+});
+
+describe("stringifyForCarry", () => {
+	it("stringifies a value for carrying across a switch", () => {
+		expect(stringifyForCarry("plain")).toBe("plain");
+		expect(stringifyForCarry(["x", "y"])).toBe("x, y");
+		expect(stringifyForCarry(42)).toBe("42");
+		expect(stringifyForCarry(true)).toBe("true");
+		expect(stringifyForCarry(false)).toBe("");
+		expect(stringifyForCarry(null)).toBe("");
+	});
+});
+
+describe("NativeWidgetHost.readRawText", () => {
+	it("reads a live input value, including an empty one", () => {
+		expect(makeHost({kind: "input", value: "in-progress"}).readRawText()).toBe("in-progress");
+		expect(makeHost({kind: "input", value: ""}).readRawText()).toBe("");
+	});
+
+	it("reads a live contenteditable value, including an empty one", () => {
+		expect(makeHost({kind: "editable", value: "typed"}).readRawText()).toBe("typed");
+		expect(makeHost({kind: "editable", value: ""}).readRawText()).toBe("");
+	});
+
+	it("returns empty when there is no text editor and no prior value", () => {
+		expect(makeHost({kind: "none"}).readRawText()).toBe("");
+	});
+});

--- a/src/Modals/NativeWidgetHost.ts
+++ b/src/Modals/NativeWidgetHost.ts
@@ -196,13 +196,19 @@ export class NativeWidgetHost {
 		return focusable instanceof HTMLSelectElement;
 	}
 
-	/** The current raw editor text (for carrying across a type switch). */
+	/**
+	 * The current value as raw text, for carrying across a type switch. Prefers a
+	 * live editor's in-progress text; otherwise falls back to the last reported
+	 * value stringified, so switching away from a checkbox/number/list still
+	 * carries its state (a checked box -> "true", a list -> its comma-joined items)
+	 * rather than dropping to empty.
+	 */
 	public readRawText(): string {
 		const input = this.hostEl.querySelector<HTMLInputElement>("input:not([type='checkbox']), textarea");
-		if (input) return input.value ?? "";
+		if (input && input.value) return input.value;
 		const editable = this.hostEl.querySelector<HTMLElement>("[contenteditable='true']");
-		if (editable) return editable.textContent ?? "";
-		return "";
+		if (editable && editable.textContent) return editable.textContent;
+		return stringifyForCarry(this.lastValueInternal);
 	}
 
 	public destroy(): void {
@@ -303,6 +309,14 @@ export class NativeWidgetHost {
 			el.remove();
 		}
 	}
+}
+
+function stringifyForCarry(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (Array.isArray(value)) return value.map(item => String(item ?? "")).filter(Boolean).join(", ");
+	if (typeof value === "number" && Number.isFinite(value)) return String(value);
+	if (value === true) return "true";
+	return "";
 }
 
 function isEditingKey(evt: KeyboardEvent): boolean {

--- a/src/Modals/NativeWidgetHost.ts
+++ b/src/Modals/NativeWidgetHost.ts
@@ -1,0 +1,312 @@
+import {Notice, type App} from "obsidian";
+import {
+	getNativeWidgetForType,
+	type NativePropertyWidget,
+	type NativeValueSource,
+	type StandardNativePropertyType,
+} from "../typedProperties/nativePropertyTypes";
+import {NativeWikilinkSuggester} from "./NativePropertyPrompt/nativeWikilinkSuggester";
+
+type WidgetLifecycleOwner = {
+	close?: unknown;
+	destroy?: unknown;
+	unload?: unknown;
+	multiselect?: unknown;
+	suggest?: unknown;
+	suggester?: unknown;
+	suggestEl?: unknown;
+	hoverPopover?: unknown;
+	popover?: unknown;
+};
+
+const BODY_PORTAL_SELECTOR = ".suggestion-container, .popover, .hover-popover";
+const EDITING_KEYS = new Set([
+	"Backspace",
+	"Delete",
+	"Enter",
+	"Spacebar",
+	" ",
+]);
+
+export interface NativeWidgetHostOptions {
+	app: App;
+	hostEl: HTMLElement;
+	sourcePath: string;
+	key: string;
+	onChange?: (value: unknown) => void;
+}
+
+/**
+ * Owns the lifecycle of a single mounted Obsidian native property widget inside a
+ * host element: mounting (or re-mounting) the widget for a given type + seed
+ * value, tracking whether the user edited it and whether it reported a value,
+ * cleaning up the widget instance and any body-level popovers it opened, and
+ * focusing it. Extracted from NativePropertyPrompt (PR #168) so the edit prompt
+ * and the fluid create modal share one battle-tested widget host instead of
+ * duplicating its subtle teardown/portal logic.
+ *
+ * Re-mount safety: every mount snapshots the body's popover portals FIRST and, on
+ * the next teardown, removes only portals that appeared during that widget's life
+ * - so re-mounting on a type switch never deletes a sibling UI's popover (the key
+ * suggester, the type menu) nor leaks the outgoing widget's own. Both edit-tracking
+ * flags reset on every mount, so the fail-closed guard always reasons about the
+ * CURRENT widget only.
+ */
+export class NativeWidgetHost {
+	private readonly app: App;
+	private readonly hostEl: HTMLElement;
+	private readonly sourcePath: string;
+	private readonly onChangeCallback?: (value: unknown) => void;
+
+	/** The property key the widget is mounted for; update via {@link setKey} before a re-mount. */
+	public key: string;
+
+	private widgetInstance: unknown = null;
+	private preMountBodyChildren: Set<Element> = new Set();
+	private readonly perMountCleanup: Array<() => void> = [];
+
+	private lastValueInternal: unknown;
+	private typeInternal: StandardNativePropertyType = "text";
+	private valueSourceInternal: NativeValueSource = "native";
+	private didReceiveChangeInternal = false;
+	private didEditDomInternal = false;
+	private renderFailedInternal = false;
+
+	constructor(options: NativeWidgetHostOptions) {
+		this.app = options.app;
+		this.hostEl = options.hostEl;
+		this.sourcePath = options.sourcePath;
+		this.key = options.key;
+		this.onChangeCallback = options.onChange;
+	}
+
+	public get value(): unknown {
+		return this.lastValueInternal;
+	}
+
+	public get type(): StandardNativePropertyType {
+		return this.typeInternal;
+	}
+
+	public get valueSource(): NativeValueSource {
+		return this.valueSourceInternal;
+	}
+
+	public get didReceiveChange(): boolean {
+		return this.didReceiveChangeInternal;
+	}
+
+	public get didEditDom(): boolean {
+		return this.didEditDomInternal;
+	}
+
+	public get renderFailed(): boolean {
+		return this.renderFailedInternal;
+	}
+
+	public setKey(key: string): void {
+		this.key = key;
+	}
+
+	/**
+	 * Mount `type`'s native widget seeded with `value`, tearing down any currently
+	 * mounted widget first. Falls back to a plain text input when the native widget
+	 * is unavailable. `lastValue` starts at the seed so an untouched widget commits
+	 * exactly what was mounted.
+	 */
+	public mountNative(type: StandardNativePropertyType, value: unknown): void {
+		const widget = getNativeWidgetForType(this.app, type);
+		if (!widget) {
+			this.mountFallback(`Obsidian's native ${type} property widget is not available.`, value);
+			this.typeInternal = type;
+			return;
+		}
+
+		this.beginMount(type, value, "native");
+		try {
+			this.widgetInstance = widget.render?.(this.hostEl, value, {
+				app: this.app,
+				key: this.key,
+				sourcePath: this.sourcePath,
+				onChange: (changed: unknown) => {
+					this.lastValueInternal = changed;
+					this.didReceiveChangeInternal = true;
+					this.onChangeCallback?.(changed);
+				},
+				blur: () => undefined,
+			});
+			this.installAliasesWikilinkFallback(type);
+		} catch (error) {
+			this.handleRenderFailure(type, error, widget);
+		}
+	}
+
+	/** Mount a plain text input (native widgets unavailable, or a render failure fallback). */
+	public mountFallback(reason: string, value: unknown): void {
+		this.beginMount("text", value, "fallback");
+
+		this.hostEl.createDiv({
+			cls: "metaedit-native-property-fallback-note",
+			text: reason,
+		});
+		const inputEl = this.hostEl.createEl("input", {
+			cls: "metadata-input metadata-input-text metaedit-native-property-fallback-input",
+			type: "text",
+		});
+		inputEl.value = value === null || value === undefined ? "" : String(value);
+		const onInput = () => {
+			this.lastValueInternal = inputEl.value;
+			this.didReceiveChangeInternal = true;
+			this.onChangeCallback?.(inputEl.value);
+		};
+		inputEl.addEventListener("input", onInput);
+		this.perMountCleanup.push(() => inputEl.removeEventListener("input", onInput));
+	}
+
+	public focus(): void {
+		const focusable = this.hostEl.querySelector<HTMLElement>(
+			"input, textarea, [contenteditable='true'], select, button",
+		);
+		if (!focusable) return;
+		focusable.focus();
+		if (focusable instanceof HTMLInputElement && focusable.type === "text") focusable.select();
+	}
+
+	/** Blur the focused editor if it lives in this host, so a pending edit flushes to onChange before submit. */
+	public flushFocus(): void {
+		const active = activeDocument.activeElement;
+		if (active instanceof HTMLElement && this.hostEl.contains(active)) {
+			active.blur();
+		}
+	}
+
+	/**
+	 * Whether the mounted editor is a genuinely single-line control (a real
+	 * `<input>`/`<select>`, e.g. number/date/datetime) rather than a multi-line
+	 * contenteditable (the text longtext editor) or a chip editor. Used to decide
+	 * whether plain Enter should commit: in a single-line control it can, matching
+	 * Obsidian; in a contenteditable/chip editor Enter belongs to the widget.
+	 */
+	public isSingleLineEditor(): boolean {
+		if (this.hostEl.querySelector(".multi-select-container")) return false;
+		if (this.hostEl.querySelector("[contenteditable='true']")) return false;
+		const focusable = this.hostEl.querySelector("input, select, textarea");
+		if (focusable instanceof HTMLTextAreaElement) return false;
+		if (focusable instanceof HTMLInputElement) return focusable.type !== "checkbox";
+		return focusable instanceof HTMLSelectElement;
+	}
+
+	/** The current raw editor text (for carrying across a type switch). */
+	public readRawText(): string {
+		const input = this.hostEl.querySelector<HTMLInputElement>("input:not([type='checkbox']), textarea");
+		if (input) return input.value ?? "";
+		const editable = this.hostEl.querySelector<HTMLElement>("[contenteditable='true']");
+		if (editable) return editable.textContent ?? "";
+		return "";
+	}
+
+	public destroy(): void {
+		this.teardownCurrent();
+	}
+
+	private beginMount(type: StandardNativePropertyType, value: unknown, valueSource: NativeValueSource): void {
+		this.teardownCurrent();
+		this.preMountBodyChildren = new Set(Array.from(activeDocument.body.children));
+		this.typeInternal = type;
+		this.valueSourceInternal = valueSource;
+		this.lastValueInternal = value;
+		this.didReceiveChangeInternal = false;
+		this.didEditDomInternal = false;
+		this.renderFailedInternal = false;
+		this.trackDomActivity();
+	}
+
+	private handleRenderFailure(type: StandardNativePropertyType, error: unknown, widget: NativePropertyWidget): void {
+		const reason = error instanceof Error ? error.message : String(error);
+		this.renderFailedInternal = true;
+		this.hostEl.empty();
+		this.hostEl.createDiv({
+			cls: "metaedit-native-property-error",
+			text: `MetaEdit could not render Obsidian's native editor for '${this.key}'.`,
+		});
+		new Notice(`MetaEdit could not render Obsidian's native editor for '${this.key}': ${reason}`);
+		void widget;
+	}
+
+	private installAliasesWikilinkFallback(type: StandardNativePropertyType): void {
+		// Only aliases needs the manual `[[` suggester; the other list/text widgets
+		// carry Obsidian's own link autocomplete (verified in #168).
+		if (type !== "aliases") return;
+
+		const inputEl = this.hostEl.querySelector<HTMLElement>(".multi-select-input[contenteditable='true']");
+		if (!inputEl) return;
+
+		const suggester = new NativeWikilinkSuggester(this.app, inputEl, this.sourcePath);
+		this.perMountCleanup.push(() => suggester.destroy());
+	}
+
+	private trackDomActivity(): void {
+		const markEdited = (evt: Event) => {
+			if (evt instanceof KeyboardEvent && !isEditingKey(evt)) return;
+			this.didEditDomInternal = true;
+		};
+		const events: Array<keyof HTMLElementEventMap> = ["input", "change", "paste", "compositionend", "keydown"];
+		for (const eventName of events) {
+			this.hostEl.addEventListener(eventName, markEdited, true);
+			this.perMountCleanup.push(() => this.hostEl.removeEventListener(eventName, markEdited, true));
+		}
+	}
+
+	private teardownCurrent(): void {
+		for (const callback of this.perMountCleanup.splice(0)) {
+			try {
+				callback();
+			} catch {
+				// Best-effort cleanup only.
+			}
+		}
+
+		this.closeWidgetLifecycle(this.widgetInstance);
+		this.widgetInstance = null;
+		this.removeBodyPortalsCreatedByWidget();
+		this.hostEl.empty();
+	}
+
+	private closeWidgetLifecycle(value: unknown): void {
+		const seen = new Set<unknown>();
+		const visit = (candidate: unknown) => {
+			if (!candidate || seen.has(candidate)) return;
+			seen.add(candidate);
+
+			const owner = candidate as WidgetLifecycleOwner;
+			for (const method of ["close", "destroy", "unload"] as const) {
+				const fn = owner[method];
+				if (typeof fn !== "function") continue;
+				try {
+					fn.call(candidate);
+				} catch {
+					// Private widget cleanup is best-effort.
+				}
+			}
+
+			for (const key of ["multiselect", "suggest", "suggester", "suggestEl", "hoverPopover", "popover"] as const) {
+				visit(owner[key]);
+			}
+		};
+
+		visit(value);
+	}
+
+	private removeBodyPortalsCreatedByWidget(): void {
+		for (const el of Array.from(activeDocument.querySelectorAll(BODY_PORTAL_SELECTOR))) {
+			if (this.preMountBodyChildren.has(el)) continue;
+			el.remove();
+		}
+	}
+}
+
+function isEditingKey(evt: KeyboardEvent): boolean {
+	if (evt.metaKey || evt.ctrlKey || evt.altKey) return false;
+	if (evt.key.length === 1) return true;
+	return EDITING_KEYS.has(evt.key);
+}

--- a/src/Modals/NativeWidgetHost.ts
+++ b/src/Modals/NativeWidgetHost.ts
@@ -204,11 +204,20 @@ export class NativeWidgetHost {
 	 * rather than dropping to empty.
 	 */
 	public readRawText(): string {
+		return carryTextFromEditor(this.readEditorText(), this.lastValueInternal);
+	}
+
+	/**
+	 * The live text of the mounted editor, or null when there is no text editor at
+	 * all (e.g. a checkbox). An EXISTING but empty editor returns "" (not null), so a
+	 * cleared value is carried as empty rather than resurrecting the stale lastValue.
+	 */
+	private readEditorText(): string | null {
 		const input = this.hostEl.querySelector<HTMLInputElement>("input:not([type='checkbox']), textarea");
-		if (input && input.value) return input.value;
+		if (input) return input.value ?? "";
 		const editable = this.hostEl.querySelector<HTMLElement>("[contenteditable='true']");
-		if (editable && editable.textContent) return editable.textContent;
-		return stringifyForCarry(this.lastValueInternal);
+		if (editable) return editable.textContent ?? "";
+		return null;
 	}
 
 	public destroy(): void {
@@ -311,7 +320,17 @@ export class NativeWidgetHost {
 	}
 }
 
-function stringifyForCarry(value: unknown): string {
+/**
+ * Decide the text to carry across a type switch: the live editor text when a text
+ * editor exists (even when empty, so a cleared value stays cleared), otherwise the
+ * last reported value stringified (so a checkbox/number with no text editor still
+ * carries). `editorText === null` means "no text editor"; "" means "empty editor".
+ */
+export function carryTextFromEditor(editorText: string | null, lastValue: unknown): string {
+	return editorText === null ? stringifyForCarry(lastValue) : editorText;
+}
+
+export function stringifyForCarry(value: unknown): string {
 	if (typeof value === "string") return value;
 	if (Array.isArray(value)) return value.map(item => String(item ?? "")).filter(Boolean).join(", ");
 	if (typeof value === "number" && Number.isFinite(value)) return String(value);

--- a/src/Modals/metaEditSuggester.ts
+++ b/src/Modals/metaEditSuggester.ts
@@ -86,21 +86,11 @@ export default class MetaEditSuggester extends FuzzySuggestModal<Property> {
 
     async onChooseItem(item: Property, _evt: MouseEvent | KeyboardEvent): Promise<void> {
         if (item.content === newYaml) {
-            const newProperty = await this.controller.createNewProperty(this.suggestValues);
-            if (!newProperty) return null;
-
-            const {propName, propValue} = newProperty;
-            // The add fails closed on a reserved object-machinery key
-            // (__proto__/constructor/prototype). Surface it as a Notice here so
-            // a typed reserved name does not become an uncaught rejection. The
-            // inline (Dataview) path below is line-based, not a frontmatter key,
-            // so it is intentionally NOT guarded.
-            try {
-                await this.controller.addYamlProp(propName, propValue, this.file);
-            } catch (error) {
-                const reason = error instanceof Error ? error.message : String(error);
-                new Notice(`MetaEdit could not add '${propName}': ${reason}`);
-            }
+            // Fluid, type-aware native creation: one keyboard-first modal that
+            // mounts Obsidian's own widget for the adopted/chosen type. The
+            // controller owns key/type/value resolution, the reserved-key guard,
+            // and the Auto Property handoff.
+            await this.controller.createNewYamlPropertyFluid(this.file, this.suggestValues, this.fileKeys);
             return;
         }
 

--- a/src/metaController.test.ts
+++ b/src/metaController.test.ts
@@ -8,6 +8,7 @@ vi.mock("./Modals/GenericPrompt/GenericPrompt", () => ({default: {Prompt: vi.fn(
 vi.mock("./Modals/GenericSuggester/GenericSuggester", () => ({default: {Suggest: vi.fn()}}));
 vi.mock("./Modals/AutoPropertyValueModal/AutoPropertyValueModal", () => ({default: {Show: vi.fn()}}));
 vi.mock("./Modals/NativePropertyPrompt/NativePropertyPrompt", () => ({default: {Prompt: vi.fn()}}));
+vi.mock("./Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt", () => ({default: {Open: vi.fn()}}));
 
 import MetaController from "./metaController";
 import AutoPropertyValueModal from "./Modals/AutoPropertyValueModal/AutoPropertyValueModal";
@@ -541,5 +542,65 @@ describe("MetaController reserved-key guard", () => {
 
         await ctx.controller.updateYamlPath(["safe", "ok"], 2, ctx.file);
         expect(ctx.fm).toEqual({safe: {ok: 2}});
+    });
+});
+
+describe("MetaController.createNativeYamlProperty (fluid creation write path)", () => {
+    const setupFm = (initial: Record<string, unknown> = {}, mode: EditMode = EditMode.AllSingle) => {
+        const fm: Record<string, unknown> = {...initial};
+        const processFrontMatter = vi.fn(async (_file: unknown, fn: (f: Record<string, unknown>) => void) => {
+            fn(fm);
+        });
+        const app = {
+            plugins: {plugins: {}},
+            vault: {read: vi.fn(async () => ""), modify: vi.fn(async () => {})},
+            fileManager: {processFrontMatter},
+        };
+        const plugin = {settings: {EditMode: {mode, properties: [] as string[]}, AutoProperties: {enabled: false, properties: []}}};
+        const controller = new MetaController(app as never, plugin as never);
+        return {controller, file: new TFile("note.md"), fm, processFrontMatter};
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("refuses reserved keys before opening the file", async () => {
+        const ctx = setupFm();
+        for (const key of ["__proto__", "constructor", "prototype"]) {
+            await expect(ctx.controller.createNativeYamlProperty(key, "x", ctx.file)).rejects.toThrow(/reserved property name/);
+        }
+        expect(ctx.processFrontMatter).not.toHaveBeenCalled();
+        expect(ctx.fm).toEqual({});
+    });
+
+    it("writes the typed native value directly with NO EditMode multi-wrap, even under AllMulti (chosen type wins)", async () => {
+        const ctx = setupFm({}, EditMode.AllMulti);
+
+        await ctx.controller.createNativeYamlProperty("estimate", 5, ctx.file);
+        await ctx.controller.createNativeYamlProperty("status", "in-progress", ctx.file);
+        await ctx.controller.createNativeYamlProperty("done", false, ctx.file);
+        await ctx.controller.createNativeYamlProperty("blank", null, ctx.file);
+
+        // Falsy typed values commit (never truthiness-filtered), and none are wrapped into a list.
+        expect(ctx.fm).toEqual({estimate: 5, status: "in-progress", done: false, blank: null});
+    });
+
+    it("writes a list value as-is and does NOT canonicalize tags, so create round-trips like native edit", async () => {
+        const ctx = setupFm();
+
+        await ctx.controller.createNativeYamlProperty("related", ["alpha", "beta"], ctx.file);
+        await ctx.controller.createNativeYamlProperty("tags", ["#area/next", "area/test"], ctx.file);
+
+        expect(ctx.fm).toEqual({related: ["alpha", "beta"], tags: ["#area/next", "area/test"]});
+    });
+
+    it("create-guard: refuses to clobber a key that already exists (no overwrite)", async () => {
+        const ctx = setupFm({status: "existing"});
+
+        await ctx.controller.createNativeYamlProperty("status", "new", ctx.file);
+
+        expect(ctx.processFrontMatter).toHaveBeenCalledTimes(1);
+        expect(ctx.fm).toEqual({status: "existing"});
     });
 });

--- a/src/metaController.ts
+++ b/src/metaController.ts
@@ -17,6 +17,7 @@ import {getYamlPath, isReservedFrontmatterKey, isYamlParentContainerValue, parse
 import {computeTagRewrite, isNestedTag, isTagsKey, isValidTagToken, normalizeTagToken, splitFrontmatterTags, spliceTag, stripHash, tagLeaf, tagParent, canonicalizeFrontmatterTag, type TagEditMode} from "./tagEditing";
 import {setPendingValueContext} from "./Modals/GenericPrompt/promptValueContext";
 import NativePropertyPrompt from "./Modals/NativePropertyPrompt/NativePropertyPrompt";
+import FluidPropertyCreatePrompt from "./Modals/FluidPropertyCreatePrompt/FluidPropertyCreatePrompt";
 import {frontmatterValuesEqual, isNativeEditableYamlProperty} from "./typedProperties/nativePropertyTypes";
 
 const fileWriteQueues: Map<string, Promise<unknown>> = new Map();
@@ -254,6 +255,68 @@ export default class MetaController {
         }
 
         return {propName, propValue: typeof propValue === "string" ? propValue.trim() : propValue};
+    }
+
+    /**
+     * Create a new top-level YAML property through the fluid, type-aware native
+     * flow: a single keyboard-first modal that mounts Obsidian's own widget for
+     * the adopted/chosen type. A key with an active Auto Property hands off to the
+     * existing Auto Property value flow (preserving its single/multi behaviour);
+     * everything else writes the widget's typed value directly via
+     * {@link createNativeYamlProperty}. Cancels are silent.
+     */
+    public async createNewYamlPropertyFluid(file: TFile, suggestValues: string[], existingKeys: ReadonlySet<string>): Promise<void> {
+        const result = await FluidPropertyCreatePrompt.Open(this.app, {
+            sourcePath: file.path,
+            suggestValues,
+            existingKeys,
+            hasAutoProperty: (key) => !!this.getActiveAutoProperty(key),
+        });
+
+        if (result.kind === "cancel") return;
+
+        try {
+            if (result.kind === "autoProperty") {
+                const autoValue = await this.handleAutoProperties(result.key);
+                if (autoValue === null) return; // user cancelled the auto property prompt
+                await this.addYamlProp(result.key, autoValue, file);
+                return;
+            }
+
+            await this.createNativeYamlProperty(result.key, result.value, file);
+        } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            new Notice(`MetaEdit could not add '${result.key}': ${reason}`);
+        }
+    }
+
+    /**
+     * Write a NEW top-level YAML property carrying the native widget's already
+     * type-normalized value. The chosen native type is authoritative, so - unlike
+     * {@link addYamlProp} - this does NOT apply the legacy EditMode single/multi
+     * wrap (List is the explicit array path) and does NOT canonicalize tags (the
+     * tags widget already yields canonical strings, so create round-trips exactly
+     * like native edit does). Reuses addYamlProp's guards and serialized queue,
+     * with a create-guard re-read inside processFrontMatter so a key added between
+     * modal-open and write is never clobbered.
+     */
+    public async createNativeYamlProperty(key: string, value: unknown, file: TFile): Promise<void> {
+        this.assertWritableKey(key);
+
+        let propertyExists = false;
+        await this.enqueueFileWrite(file, async () => {
+            await this.processFrontMatter(file, (frontmatter) => {
+                if (Object.prototype.hasOwnProperty.call(frontmatter, key)) {
+                    propertyExists = true;
+                    return;
+                }
+                frontmatter[key] = value;
+            });
+        });
+
+        if (propertyExists) {
+            new Notice(`Frontmatter in file '${file.name}' already has property '${key}'. Will not add.`);
+        }
     }
 
     public async deleteProperty(property: Property, file: TFile): Promise<void> {

--- a/src/typedProperties/nativePropertyTypes.test.ts
+++ b/src/typedProperties/nativePropertyTypes.test.ts
@@ -189,6 +189,18 @@ describe("value-text inference (suggest, promotion-only)", () => {
 		expect(inferCreationTypeFromText("hello", "text")).toBeNull();
 	});
 
+	it("rejects shape-valid but calendar-invalid dates/times (never infers a bogus date)", () => {
+		expect(inferCreationTypeFromText("2026-99-99", "text")).toBeNull();
+		expect(inferCreationTypeFromText("2026-13-01", "text")).toBeNull();
+		expect(inferCreationTypeFromText("2026-02-30", "text")).toBeNull();
+		expect(inferCreationTypeFromText("2026-07-01T25:00", "text")).toBeNull();
+		expect(inferCreationTypeFromText("2026-07-01T12:60", "text")).toBeNull();
+		// Real dates/times still infer.
+		expect(inferCreationTypeFromText("2026-02-28", "text")).toBe("date");
+		expect(inferCreationTypeFromText("2024-02-29", "text")).toBe("date"); // leap year
+		expect(inferCreationTypeFromText("2026-07-01T23:59:59", "text")).toBe("datetime");
+	});
+
 	it("never fires once the user is already on a non-text type (no trap, no flip-flop)", () => {
 		expect(inferCreationTypeFromText("3", "number")).toBeNull();
 		expect(inferCreationTypeFromText("plain text", "date")).toBeNull();
@@ -212,6 +224,10 @@ describe("seedFromRawText across a type switch", () => {
 		expect(seedFromRawText("not-a-date", "date")).toBe("");
 		expect(seedFromRawText("noon", "datetime")).toBe("");
 		expect(seedFromRawText("maybe", "checkbox")).toBe(false);
+		// Calendar-invalid dates are not seeded as dates (would write a bogus value).
+		expect(seedFromRawText("2026-99-99", "date")).toBe("");
+		expect(seedFromRawText("2026-02-30", "date")).toBe("");
+		expect(seedFromRawText("2026-07-01T25:00", "datetime")).toBe("");
 	});
 
 	it("INVARIANT: every seed is a value normalizeWidgetValue accepts for the target type", () => {

--- a/src/typedProperties/nativePropertyTypes.test.ts
+++ b/src/typedProperties/nativePropertyTypes.test.ts
@@ -133,6 +133,14 @@ describe("creation type resolution (no value-shape inference)", () => {
 		expect(resolveCreationType(app as never, "aliases")).toBe("aliases");
 	});
 
+	it("routes the singular 'tag' key to the tags widget too (consistent with isTagsKey)", () => {
+		const app = appWithManager({});
+		// Without this, a new `tag` key would fall through to the text default and be
+		// written as a plain text scalar instead of tag metadata.
+		expect(resolveCreationType(app as never, "tag")).toBe("tags");
+		expect(resolveCreationType(app as never, "Tag")).toBe("tags");
+	});
+
 	it("adopts an assigned, then property-info, then Obsidian-expected type before defaulting", () => {
 		const assigned = appWithManager({getAssignedWidget: () => "number"});
 		expect(resolveCreationType(assigned as never, "rating")).toBe("number");

--- a/src/typedProperties/nativePropertyTypes.test.ts
+++ b/src/typedProperties/nativePropertyTypes.test.ts
@@ -1,10 +1,16 @@
 import {describe, expect, it} from "vitest";
 import {MetaType} from "../Types/metaType";
 import {
+	CREATION_TYPE_CHOICES,
+	emptyValueForType,
 	frontmatterValuesEqual,
+	inferCreationTypeFromText,
 	isNativeEditableYamlProperty,
 	normalizeWidgetValue,
+	resolveCreationType,
 	resolveNativeProperty,
+	seedFromRawText,
+	type StandardNativePropertyType,
 } from "./nativePropertyTypes";
 
 const widget = () => ({
@@ -116,6 +122,108 @@ describe("native widget value normalization", () => {
 	it("keeps the minimal fallback as a text value", () => {
 		expect(normalizeWidgetValue("number", 42, "fallback")).toEqual({ok: true, value: "42"});
 		expect(normalizeWidgetValue("text", null, "fallback")).toEqual({ok: true, value: ""});
+	});
+});
+
+describe("creation type resolution (no value-shape inference)", () => {
+	it("locks reserved key names to their native widget", () => {
+		const app = appWithManager({});
+		expect(resolveCreationType(app as never, "tags")).toBe("tags");
+		expect(resolveCreationType(app as never, "Tags")).toBe("tags");
+		expect(resolveCreationType(app as never, "aliases")).toBe("aliases");
+	});
+
+	it("adopts an assigned, then property-info, then Obsidian-expected type before defaulting", () => {
+		const assigned = appWithManager({getAssignedWidget: () => "number"});
+		expect(resolveCreationType(assigned as never, "rating")).toBe("number");
+
+		const propertyInfo = appWithManager({getAllProperties: () => ({priority: {widget: "number"}})});
+		expect(resolveCreationType(propertyInfo as never, "priority")).toBe("number");
+
+		const expected = appWithManager({getTypeInfo: () => ({expected: {type: "date"}})});
+		expect(resolveCreationType(expected as never, "due")).toBe("date");
+	});
+
+	it("defaults a brand-new key to text, and degrades to text without a type manager", () => {
+		expect(resolveCreationType(appWithManager({}) as never, "totallyNew")).toBe("text");
+		expect(resolveCreationType({} as never, "anything")).toBe("text");
+	});
+});
+
+describe("empty seed per type", () => {
+	it("maps each type to a value normalizeWidgetValue accepts as an empty native value", () => {
+		const cases: Array<[StandardNativePropertyType, unknown]> = [
+			["text", ""],
+			["multitext", []],
+			["tags", []],
+			["aliases", []],
+			["cssclasses", []],
+			["number", null],
+			["checkbox", false],
+			["date", ""],
+			["datetime", ""],
+		];
+		for (const [type, expectedEmpty] of cases) {
+			expect(emptyValueForType(type)).toEqual(expectedEmpty);
+			expect(normalizeWidgetValue(type, emptyValueForType(type), "native").ok).toBe(true);
+		}
+	});
+});
+
+describe("value-text inference (suggest, promotion-only)", () => {
+	it("promotes the text default to a richer scalar type when the text is unambiguous", () => {
+		expect(inferCreationTypeFromText("2026-07-01", "text")).toBe("date");
+		expect(inferCreationTypeFromText("2026-07-01T09:30", "text")).toBe("datetime");
+		expect(inferCreationTypeFromText("true", "text")).toBe("checkbox");
+		expect(inferCreationTypeFromText("false", "text")).toBe("checkbox");
+		expect(inferCreationTypeFromText("3", "text")).toBe("number");
+		expect(inferCreationTypeFromText("-2.5", "text")).toBe("number");
+	});
+
+	it("stays quiet on ambiguous text, partial values, and leading-zero strings", () => {
+		expect(inferCreationTypeFromText("3 apples", "text")).toBeNull();
+		expect(inferCreationTypeFromText("2026-07-0", "text")).toBeNull();
+		expect(inferCreationTypeFromText("007", "text")).toBeNull();
+		expect(inferCreationTypeFromText("", "text")).toBeNull();
+		expect(inferCreationTypeFromText("   ", "text")).toBeNull();
+		expect(inferCreationTypeFromText("hello", "text")).toBeNull();
+	});
+
+	it("never fires once the user is already on a non-text type (no trap, no flip-flop)", () => {
+		expect(inferCreationTypeFromText("3", "number")).toBeNull();
+		expect(inferCreationTypeFromText("plain text", "date")).toBeNull();
+		expect(inferCreationTypeFromText("2026-07-01", "multitext")).toBeNull();
+	});
+});
+
+describe("seedFromRawText across a type switch", () => {
+	it("carries in-progress text across losslessly where the target type can hold it", () => {
+		expect(seedFromRawText("hello", "text")).toBe("hello");
+		expect(seedFromRawText("in-progress", "multitext")).toEqual(["in-progress"]);
+		expect(seedFromRawText("", "multitext")).toEqual([]);
+		expect(seedFromRawText("42", "number")).toBe(42);
+		expect(seedFromRawText("2026-07-01", "date")).toBe("2026-07-01");
+		expect(seedFromRawText("2026-07-01T09:30", "datetime")).toBe("2026-07-01T09:30");
+		expect(seedFromRawText("true", "checkbox")).toBe(true);
+	});
+
+	it("falls back to the empty value when the target type can't represent the text", () => {
+		expect(seedFromRawText("3 apples", "number")).toBeNull();
+		expect(seedFromRawText("not-a-date", "date")).toBe("");
+		expect(seedFromRawText("noon", "datetime")).toBe("");
+		expect(seedFromRawText("maybe", "checkbox")).toBe(false);
+	});
+
+	it("INVARIANT: every seed is a value normalizeWidgetValue accepts for the target type", () => {
+		const rawSamples = ["", "hello", "3", "3.5", "-1", "007", "3 apples", "true", "false", "2026-07-01", "2026-07-01T09:30", "[[A]], [[B]]", "a, b, c"];
+		const types = CREATION_TYPE_CHOICES.map(choice => choice.type);
+		for (const type of types) {
+			for (const raw of rawSamples) {
+				const seed = seedFromRawText(raw, type);
+				const normalized = normalizeWidgetValue(type, seed, "native");
+				expect(normalized.ok, `seed ${JSON.stringify(seed)} for type ${type} from ${JSON.stringify(raw)}`).toBe(true);
+			}
+		}
 	});
 });
 

--- a/src/typedProperties/nativePropertyTypes.ts
+++ b/src/typedProperties/nativePropertyTypes.ts
@@ -18,6 +18,19 @@ export const STANDARD_NATIVE_PROPERTY_TYPES = [
 export type StandardNativePropertyType = typeof STANDARD_NATIVE_PROPERTY_TYPES[number];
 export type NativeValueSource = "native" | "fallback";
 
+// The types a user can pick for a brand-new property, mirroring Obsidian's own
+// Set-type menu (Text, List, Number, Checkbox, Date, Date & time). Reserved keys
+// (tags/aliases/cssclasses) lock to their widget instead of offering this list.
+// Labels are user-facing; the `type` is the internal widget id.
+export const CREATION_TYPE_CHOICES: ReadonlyArray<{type: StandardNativePropertyType; label: string}> = [
+	{type: "text", label: "Text"},
+	{type: "multitext", label: "List"},
+	{type: "number", label: "Number"},
+	{type: "checkbox", label: "Checkbox"},
+	{type: "date", label: "Date"},
+	{type: "datetime", label: "Date & time"},
+];
+
 export type NativePropertyPromptResult =
 	| {
 		kind: "submit";
@@ -148,6 +161,114 @@ export function normalizeWidgetValue(
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Property creation (fluid, type-aware). Pure logic behind the create modal, so
+// the type/inference/seed behavior is unit-tested without a DOM. See
+// src/Modals/NativePropertyCreatePrompt.
+// ---------------------------------------------------------------------------
+
+/**
+ * The type to adopt for a brand-new property key, using Obsidian's vault-wide
+ * type memory - with ZERO value-shape inference, because at key-entry time there
+ * is no value yet. This is the {@link resolveNativeProperty} ladder minus the
+ * final `inferTypeFromValue` step: reserved key name -> assigned widget ->
+ * property-info widget -> `getTypeInfo(key).expected` (Obsidian's own vault
+ * inference, which returns `text` for an unknown key) -> `text`.
+ *
+ * So a key the vault already knows (e.g. `due` used as dates elsewhere) adopts
+ * that type with zero friction, while a brand-new key defaults to `text`.
+ */
+export function resolveCreationType(app: App, key: string): StandardNativePropertyType {
+	const manager = getMetadataTypeManager(app);
+	const widgets = manager?.registeredTypeWidgets;
+	if (!manager || !widgets) return "text";
+
+	const normalizedKey = key.toLowerCase();
+	if (normalizedKey === "tags") return "tags";
+	if (normalizedKey === "aliases") return "aliases";
+	if (normalizedKey === "cssclasses" && widgets.cssclasses) return "cssclasses";
+
+	const assigned = toStandardType(manager.getAssignedWidget?.(key), widgets);
+	if (assigned) return assigned;
+
+	const propertyInfoType = toStandardType(readPropertyInfoWidget(manager, key), widgets);
+	if (propertyInfoType) return propertyInfoType;
+
+	const expectedType = toStandardType(readTypeInfoExpected(manager, key, undefined), widgets);
+	if (expectedType) return expectedType;
+
+	return "text";
+}
+
+/**
+ * The empty seed value to mount a freshly-created widget against, per type. Every
+ * value here is one {@link normalizeWidgetValue} accepts for that type as a native
+ * source, so an untouched create-mode widget always commits a valid empty value
+ * (text `""`, number `null`, checkbox `false`, date/datetime `""`, list `[]`).
+ */
+export function emptyValueForType(type: StandardNativePropertyType): unknown {
+	switch (type) {
+		case "number":
+			return null;
+		case "checkbox":
+			return false;
+		case "multitext":
+		case "tags":
+		case "aliases":
+		case "cssclasses":
+			return [];
+		case "text":
+		case "date":
+		case "datetime":
+			return "";
+	}
+}
+
+/**
+ * A SUGGESTED richer type for the value the user is typing into the default text
+ * widget, or null. Promotion-only: it only ever suggests upgrading FROM `text` to
+ * a more specific scalar type, and never fires once the user is already on a
+ * non-text type (adopted or chosen). This means inference can never trap a value
+ * in the wrong type and there is no flip-flop - it is a hint the user opts into,
+ * never a silent morph. Lists are intentionally never inferred (a text value can
+ * legitimately contain commas); the user picks List explicitly.
+ */
+export function inferCreationTypeFromText(rawText: string, currentType: StandardNativePropertyType): StandardNativePropertyType | null {
+	if (currentType !== "text") return null;
+	const inferred = inferTypeFromText(rawText.trim());
+	return inferred && inferred !== currentType ? inferred : null;
+}
+
+/**
+ * The seed value to mount `nextType`'s widget against when the user switches type
+ * mid-creation, carrying the in-progress text across losslessly where the target
+ * type can represent it, and falling back to that type's empty value otherwise.
+ * This is deliberately NOT an invented coercion table: every branch returns a
+ * value {@link normalizeWidgetValue} accepts for `nextType` (proven by test), so
+ * the seed can never desync from validation, and switching never writes garbage.
+ * `text` keeps the raw input verbatim, so a richer->text switch is always lossless.
+ */
+export function seedFromRawText(rawText: string, nextType: StandardNativePropertyType): unknown {
+	const trimmed = rawText.trim();
+	switch (nextType) {
+		case "text":
+			return rawText;
+		case "multitext":
+		case "tags":
+		case "aliases":
+		case "cssclasses":
+			return trimmed === "" ? [] : [trimmed];
+		case "number":
+			return isFiniteNumericString(trimmed) ? Number(trimmed) : null;
+		case "checkbox":
+			return trimmed === "true" ? true : false;
+		case "date":
+			return DATE_RE.test(trimmed) ? trimmed : "";
+		case "datetime":
+			return DATETIME_RE.test(trimmed) ? trimmed : "";
+	}
+}
+
 export function frontmatterValuesEqual(left: unknown, right: unknown): boolean {
 	if (left instanceof Date && right instanceof Date) return left.getTime() === right.getTime();
 	if (left instanceof Date || right instanceof Date) return compareDateWithPrimitive(left, right);
@@ -227,6 +348,28 @@ function hasDateTime(value: Date): boolean {
 		value.getUTCMinutes() !== 0 ||
 		value.getUTCSeconds() !== 0 ||
 		value.getUTCMilliseconds() !== 0;
+}
+
+// A strict decimal literal: optional sign, digits with an optional fractional
+// part, or a bare fractional. Deliberately rejects scientific notation, hex, and
+// trailing text ("3 apples"), so value-text inference stays conservative.
+const NUMERIC_RE = /^-?(?:\d+\.?\d*|\.\d+)$/;
+
+function isFiniteNumericString(text: string): boolean {
+	if (!NUMERIC_RE.test(text)) return false;
+	return Number.isFinite(Number(text));
+}
+
+function inferTypeFromText(text: string): StandardNativePropertyType | null {
+	if (text === "") return null;
+	if (DATETIME_RE.test(text)) return "datetime";
+	if (DATE_RE.test(text)) return "date";
+	if (text === "true" || text === "false") return "checkbox";
+	// A leading-zero run (007, 0042) is almost always a meaningful string; never
+	// suggest number and silently strip the zeros. "0" and "0.5" still infer.
+	if (/^0\d/.test(text)) return null;
+	if (isFiniteNumericString(text)) return "number";
+	return null;
 }
 
 function invalidType(type: StandardNativePropertyType, expected: string): NormalizedWidgetValue {

--- a/src/typedProperties/nativePropertyTypes.ts
+++ b/src/typedProperties/nativePropertyTypes.ts
@@ -60,6 +60,7 @@ export type NativePropertyResolution =
 export interface NativePropertyWidget {
 	name?: unknown;
 	type?: unknown;
+	icon?: unknown;
 	validate?: (value: unknown) => boolean;
 	render?: (container: HTMLElement, value: unknown, ctx: NativePropertyWidgetContext) => unknown;
 	reservedKeys?: unknown;

--- a/src/typedProperties/nativePropertyTypes.ts
+++ b/src/typedProperties/nativePropertyTypes.ts
@@ -1,6 +1,7 @@
 import type {App} from "obsidian";
 import type {Property} from "../parser";
 import {MetaType} from "../Types/metaType";
+import {isTagsKey} from "../tagEditing";
 import {isPlainYamlObject, isYamlParentContainerValue} from "../yamlPath";
 
 export const STANDARD_NATIVE_PROPERTY_TYPES = [
@@ -195,7 +196,10 @@ export function resolveCreationType(app: App, key: string): StandardNativeProper
 	if (!manager || !widgets) return "text";
 
 	const normalizedKey = key.toLowerCase();
-	if (normalizedKey === "tags") return "tags";
+	// Both `tags` and the singular `tag` are Obsidian tag frontmatter (matching
+	// isTagsKey and the legacy addYamlProp path), so a new `tag` key adopts the
+	// tags widget and is written as tag metadata, not a plain text scalar.
+	if (isTagsKey(normalizedKey)) return "tags";
 	if (normalizedKey === "aliases") return "aliases";
 	if (normalizedKey === "cssclasses" && widgets.cssclasses) return "cssclasses";
 

--- a/src/typedProperties/nativePropertyTypes.ts
+++ b/src/typedProperties/nativePropertyTypes.ts
@@ -116,6 +116,16 @@ export function resolveNativeProperty(app: App, property: Property): NativePrope
 	return {kind: "native", type, widget};
 }
 
+/**
+ * Obsidian's registered native widget for an explicit type, or null when the
+ * registry or that widget is unavailable. Centralizes the internal-API access so
+ * both the edit prompt and the create modal resolve widgets one way.
+ */
+export function getNativeWidgetForType(app: App, type: StandardNativePropertyType): NativePropertyWidget | null {
+	const widget = getMetadataTypeManager(app)?.registeredTypeWidgets?.[type];
+	return widget && typeof widget.render === "function" ? widget : null;
+}
+
 export function normalizeWidgetValue(
 	type: StandardNativePropertyType,
 	value: unknown,

--- a/src/typedProperties/nativePropertyTypes.ts
+++ b/src/typedProperties/nativePropertyTypes.ts
@@ -274,9 +274,9 @@ export function seedFromRawText(rawText: string, nextType: StandardNativePropert
 		case "checkbox":
 			return trimmed === "true" ? true : false;
 		case "date":
-			return DATE_RE.test(trimmed) ? trimmed : "";
+			return isValidIsoDate(trimmed) ? trimmed : "";
 		case "datetime":
-			return DATETIME_RE.test(trimmed) ? trimmed : "";
+			return isValidIsoDatetime(trimmed) ? trimmed : "";
 	}
 }
 
@@ -371,10 +371,31 @@ function isFiniteNumericString(text: string): boolean {
 	return Number.isFinite(Number(text));
 }
 
+// Shape AND calendar validity: `2026-99-99` / `...T99:99` match the regex but are
+// not real dates, so inference and seeding must reject them (they would otherwise
+// be written as a bogus "date" value).
+function isValidIsoDate(value: string): boolean {
+	if (!DATE_RE.test(value)) return false;
+	const year = Number(value.slice(0, 4));
+	const month = Number(value.slice(5, 7));
+	const day = Number(value.slice(8, 10));
+	const date = new Date(Date.UTC(year, month - 1, day));
+	return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}
+
+function isValidIsoDatetime(value: string): boolean {
+	if (!DATETIME_RE.test(value)) return false;
+	if (!isValidIsoDate(value.slice(0, 10))) return false;
+	const hour = Number(value.slice(11, 13));
+	const minute = Number(value.slice(14, 16));
+	const second = value.length > 16 ? Number(value.slice(17, 19)) : 0;
+	return hour <= 23 && minute <= 59 && second <= 59;
+}
+
 function inferTypeFromText(text: string): StandardNativePropertyType | null {
 	if (text === "") return null;
-	if (DATETIME_RE.test(text)) return "datetime";
-	if (DATE_RE.test(text)) return "date";
+	if (isValidIsoDatetime(text)) return "datetime";
+	if (isValidIsoDate(text)) return "date";
 	if (text === "true" || text === "false") return "checkbox";
 	// A leading-zero run (007, 0042) is almost always a meaningful string; never
 	// suggest number and silently strip the zeros. "0" and "0.5" still infer.

--- a/styles.css
+++ b/styles.css
@@ -120,3 +120,81 @@
     position: absolute;
     width: 1px;
 }
+
+.metaedit-fluid-create {
+    min-width: min(560px, 90vw);
+}
+
+.metaedit-fluid-create-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin: 16px 0 6px;
+}
+
+.metaedit-fluid-create-type {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex: 0 0 auto;
+    height: var(--input-height);
+    padding: 0 10px;
+    border-radius: var(--radius-s);
+    background: var(--interactive-normal);
+    box-shadow: var(--input-shadow);
+    color: var(--text-normal);
+    font-size: var(--font-ui-small);
+    cursor: pointer;
+}
+
+.metaedit-fluid-create-type:hover {
+    background: var(--interactive-hover);
+}
+
+.metaedit-fluid-create-type.is-locked {
+    cursor: default;
+    opacity: 0.75;
+}
+
+.metaedit-fluid-create-type-icon {
+    display: inline-flex;
+    align-items: center;
+}
+
+.metaedit-fluid-create-type-icon .svg-icon {
+    width: var(--icon-s);
+    height: var(--icon-s);
+}
+
+.metaedit-fluid-create-key {
+    flex: 0 0 34%;
+    min-width: 0;
+}
+
+.metaedit-fluid-create-value {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.metaedit-fluid-create-autoprop {
+    flex: 1 1 auto;
+    align-self: center;
+    color: var(--text-muted);
+    font-size: var(--font-ui-small);
+}
+
+.metaedit-fluid-create-hint {
+    color: var(--text-muted);
+    font-size: var(--font-ui-small);
+    margin: 0 0 6px;
+}
+
+.metaedit-fluid-create-hint-accept {
+    cursor: pointer;
+}
+
+.metaedit-fluid-create-warning {
+    color: var(--text-error);
+    font-size: var(--font-ui-small);
+    margin: 0 0 6px;
+}

--- a/styles.css
+++ b/styles.css
@@ -121,14 +121,31 @@
     width: 1px;
 }
 
+/* Widen the modal BOX itself (not the content past the box padding, which caused
+   the horizontal scrollbar) and give it vertical room so the key-name dropdown
+   has space above the action buttons. */
+.metaedit-fluid-create-modal {
+    width: min(620px, 92vw);
+    max-width: 92vw;
+}
+
 .metaedit-fluid-create {
-    min-width: min(560px, 90vw);
+    display: flex;
+    flex-direction: column;
+    min-height: 320px;
+}
+
+/* Pin the action-button row to the bottom so the dropdown opens in the space
+   above it rather than over it. */
+.metaedit-fluid-create > .setting-item:last-child {
+    margin-top: auto;
 }
 
 .metaedit-fluid-create-row {
     display: flex;
     align-items: flex-start;
     gap: 8px;
+    flex-wrap: nowrap;
     margin: 16px 0 6px;
 }
 
@@ -167,13 +184,21 @@
 }
 
 .metaedit-fluid-create-key {
-    flex: 0 0 34%;
+    flex: 2 1 0;
     min-width: 0;
 }
 
 .metaedit-fluid-create-value {
-    flex: 1 1 auto;
+    flex: 3 1 0;
     min-width: 0;
+}
+
+/* Cap the key-name suggestion dropdown (~6-7 rows + internal scroll). Sized to fit
+   above the action buttons within the reserved modal height, so it never spills
+   below the modal or covers the buttons. */
+.metaedit-fluid-create-suggest {
+    max-height: 190px;
+    overflow-y: auto;
 }
 
 .metaedit-fluid-create-autoprop {

--- a/styles.css
+++ b/styles.css
@@ -122,23 +122,11 @@
 }
 
 /* Widen the modal BOX itself (not the content past the box padding, which caused
-   the horizontal scrollbar) and give it vertical room so the key-name dropdown
-   has space above the action buttons. */
+   the horizontal scrollbar). Height hugs the content - no reserved space; the
+   key-name dropdown floats as a capped overlay (see below). */
 .metaedit-fluid-create-modal {
     width: min(620px, 92vw);
     max-width: 92vw;
-}
-
-.metaedit-fluid-create {
-    display: flex;
-    flex-direction: column;
-    min-height: 320px;
-}
-
-/* Pin the action-button row to the bottom so the dropdown opens in the space
-   above it rather than over it. */
-.metaedit-fluid-create > .setting-item:last-child {
-    margin-top: auto;
 }
 
 .metaedit-fluid-create-row {
@@ -193,9 +181,9 @@
     min-width: 0;
 }
 
-/* Cap the key-name suggestion dropdown (~6-7 rows + internal scroll). Sized to fit
-   above the action buttons within the reserved modal height, so it never spills
-   below the modal or covers the buttons. */
+/* The key-name suggestion dropdown floats as a capped overlay (~6-7 rows +
+   internal scroll) so the modal stays compact when it's closed, instead of
+   reserving permanent vertical space. */
 .metaedit-fluid-create-suggest {
     max-height: 190px;
     overflow-y: auto;

--- a/tests/e2e/audit-settings.test.ts
+++ b/tests/e2e/audit-settings.test.ts
@@ -269,11 +269,12 @@ describe("MetaEdit settings tab", () => {
 				const prevIgnored = JSON.parse(JSON.stringify(plugin.settings.IgnoredProperties));
 				plugin.settings.IgnoredProperties.enabled = true;
 				plugin.settings.IgnoredProperties.properties = ["secretKey"];
-				// Spy on createNewProperty to capture the suggestValues the suggester
-				// computed, then cancel (return null) so nothing is written.
-				const orig = plugin.controller.createNewProperty.bind(plugin.controller);
+				// Spy on the fluid YAML-creation entry point to capture the suggestValues
+				// the suggester computed (its 2nd arg), then return without opening the
+				// modal so nothing is written.
+				const orig = plugin.controller.createNewYamlPropertyFluid.bind(plugin.controller);
 				let captured = null;
-				plugin.controller.createNewProperty = async (sv) => { captured = sv ? [...sv] : []; return null; };
+				plugin.controller.createNewYamlPropertyFluid = async (_file, sv) => { captured = sv ? [...sv] : []; };
 				try {
 					await plugin.runMetaEditForFile(f);
 					const waitForItem = async () => {
@@ -294,7 +295,7 @@ describe("MetaEdit settings tab", () => {
 					for (const el of Array.from(document.querySelectorAll(".suggestion-container, .suggestion-item, .prompt"))) el.remove();
 					return { suggestValues: captured ?? [], captured: captured !== null };
 				} finally {
-					plugin.controller.createNewProperty = orig;
+					plugin.controller.createNewYamlPropertyFluid = orig;
 					plugin.settings.IgnoredProperties = prevIgnored;
 				}
 			})()

--- a/tests/e2e/audit-suggester.test.ts
+++ b/tests/e2e/audit-suggester.test.ts
@@ -56,8 +56,21 @@ describe("MetaEdit Edit Meta suggester flows", () => {
 				await plugin.runMetaEditForFile(f);
 				const option = await waitFor(".suggestion-item", (i) => itemText(i) === "New YAML property");
 				clickItem(option);
-				await typePrompt("freshKey");   // property name prompt
-				await typePrompt("freshValue"); // property value prompt
+				// The fluid create modal opens. A brand-new key defaults to the text
+				// widget, so drive it wedge-safe (no synthetic keyboard/popover): set the
+				// key via an input event, type the value into the contenteditable, and
+				// click Add.
+				const modal = await waitFor(".metaedit-fluid-create");
+				const keyEl = modal.querySelector(".metaedit-fluid-create-key");
+				keyEl.value = "freshKey";
+				keyEl.dispatchEvent(new Event("input", { bubbles: true }));
+				const valueEl = modal.querySelector(".metaedit-fluid-create-value [contenteditable='true']");
+				valueEl.focus();
+				document.execCommand("insertText", false, "freshValue");
+				valueEl.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: "freshValue" }));
+				valueEl.dispatchEvent(new Event("blur", { bubbles: true }));
+				await sleep(150);
+				Array.from(modal.querySelectorAll("button")).find((b) => b.textContent.trim() === "Add").click();
 				await waitFor("body", () => (app.metadataCache.getFileCache(f)?.frontmatter ?? {}).freshKey === "freshValue");
 				closeModals();
 				await sleep(100);

--- a/tests/e2e/fluid-create.test.ts
+++ b/tests/e2e/fluid-create.test.ts
@@ -1,0 +1,209 @@
+import {describe, expect, test} from "vitest";
+import {createMetaEditE2EHarness, evalJsonAsync, PLUGIN_ID} from "./harness";
+
+const getContext = createMetaEditE2EHarness("fluid-create");
+
+// CI E2E is deliberately WEDGE-SAFE and light. Driving the modal with synthetic
+// KEYBOARD events (Enter to settle the key) or driving a native suggest/value
+// POPOVER deadlocks the obsidian-e2e package transport (it works via the CLI, but
+// not here). So the CI test drives the modal only with `input` events + button
+// clicks: it asserts the modal renders the default native widget, the type pill,
+// and the validity/reserved-key guards, then the write path directly (no modal).
+// The keyboard-driven behaviors - vault-known type auto-adopt, value round-trips
+// through each widget, the inference hint + accept, and the type-menu pick - are
+// proven by live CLI DOM-state verification recorded in the PR, and their pure
+// logic (resolveCreationType/inferCreationTypeFromText/seedFromRawText/
+// emptyValueForType) is exhaustively unit-tested.
+describe("MetaEdit fluid property creation", () => {
+	test("the create modal renders the default native widget and enforces the key guards", async () => {
+		const {obsidian, sandbox} = getContext();
+		const notePath = sandbox.path("fluid-create-modal.md");
+		await writeLiveFile(obsidian, notePath, "---\ntaken: 1\n---\nbody\n");
+
+		const result = await evalJsonAsync<{
+			defaultWidget: string;
+			defaultPill: string | null;
+			addDisabledEmpty: boolean;
+			reservedAddDisabled: boolean;
+			reservedWarned: boolean;
+			duplicateAddDisabled: boolean;
+			validAddEnabled: boolean;
+			modalCount: number;
+			cacheKeys: string[];
+		}>(
+			obsidian,
+			`
+			(async () => {
+				${FLUID_HELPERS}
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				const out = {};
+
+				const {promise, modal} = await openCreate(file, ["taken"]);
+				const host = valueHost(modal);
+				out.defaultWidget = host.querySelector("[contenteditable='true']") ? "contenteditable" : host.innerHTML.slice(0, 40);
+				out.defaultPill = pillLabel(modal);
+				out.addDisabledEmpty = addButton(modal).disabled;
+
+				setKeyText(modal, "__proto__");
+				await sleep(90);
+				out.reservedAddDisabled = addButton(modal).disabled;
+				const warn = modal.querySelector(".metaedit-fluid-create-warning");
+				out.reservedWarned = warn && warn.style.display !== "none" && warn.textContent.length > 0;
+
+				setKeyText(modal, "taken");
+				await sleep(90);
+				out.duplicateAddDisabled = addButton(modal).disabled;
+
+				setKeyText(modal, "brandnew");
+				await sleep(90);
+				out.validAddEnabled = !addButton(modal).disabled;
+
+				cancel(modal);
+				await promise;
+
+				out.modalCount = document.querySelectorAll(".modal-container").length;
+				out.cacheKeys = Object.keys(app.metadataCache.getFileCache(file)?.frontmatter ?? {});
+				return out;
+			})()
+			`,
+		);
+
+		expect(result.defaultWidget).toBe("contenteditable");
+		expect(result.defaultPill).toBe("Text");
+		expect(result.addDisabledEmpty).toBe(true);
+		expect(result.reservedAddDisabled).toBe(true);
+		expect(result.reservedWarned).toBe(true);
+		expect(result.duplicateAddDisabled).toBe(true);
+		expect(result.validAddEnabled).toBe(true);
+		expect(result.modalCount).toBe(0);
+		expect(result.cacheKeys).toEqual(["taken"]); // cancelled: nothing written
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("the write path: chosen native type wins over EditMode, tags stay as-is, create-guard holds", async () => {
+		const {obsidian, sandbox} = getContext();
+		const notePath = sandbox.path("fluid-create-writepath.md");
+		await writeLiveFile(obsidian, notePath, "---\nexisting: 1\n---\nbody\n");
+
+		const result = await evalJsonAsync<{cache: Record<string, unknown>; content: string}>(
+			obsidian,
+			`
+			(async () => {
+				${FLUID_HELPERS}
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+
+				// A chosen native SCALAR type must NOT be list-wrapped, even under AllMulti.
+				const prevMode = plugin.settings.EditMode.mode;
+				plugin.settings.EditMode.mode = "All Multi";
+				await plugin.controller.createNativeYamlProperty("estimate", 5, file);
+				await plugin.controller.createNativeYamlProperty("done", false, file);
+				plugin.settings.EditMode.mode = prevMode;
+
+				// A list value writes as-is; tags are NOT canonicalized (matches native edit).
+				await plugin.controller.createNativeYamlProperty("related", ["alpha", "beta"], file);
+				await plugin.controller.createNativeYamlProperty("tags", ["#area/next", "area/test"], file);
+
+				// Create-guard: never clobber a key that already exists.
+				await plugin.controller.createNativeYamlProperty("existing", 999, file);
+
+				await waitCache(file, "tags");
+				return {
+					cache: {...app.metadataCache.getFileCache(file)?.frontmatter},
+					content: await app.vault.read(file),
+				};
+			})()
+			`,
+		);
+
+		expect(result.cache.estimate).toBe(5);
+		expect(result.cache.done).toBe(false);
+		expect(result.content).toContain("estimate: 5");
+		expect(result.cache.related).toEqual(["alpha", "beta"]);
+		expect(result.cache.tags).toEqual(["#area/next", "area/test"]);
+		expect(result.cache.existing).toBe(1); // create-guard preserved the original
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+});
+
+const FLUID_HELPERS = String.raw`
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitFor = async (selector, timeout = 5000) => {
+	const start = Date.now();
+	while (Date.now() - start < timeout) {
+		const el = document.querySelector(selector);
+		if (el) return el;
+		await sleep(70);
+	}
+	throw new Error("Timed out waiting for " + selector);
+};
+
+const waitCache = async (file, key) => {
+	const start = Date.now();
+	while (Date.now() - start < 5000) {
+		const fm = app.metadataCache.getFileCache(file)?.frontmatter;
+		if (fm && Object.prototype.hasOwnProperty.call(fm, key)) return fm[key];
+		await sleep(70);
+	}
+	throw new Error("Timed out waiting for cache key " + key);
+};
+
+async function openCreate(file, existingKeys = []) {
+	const plugin = app.plugins.plugins.${PLUGIN_ID};
+	// No key suggestions: keeps the key-name suggester popover out of the transport.
+	// existingKeys mirrors what the suggester passes (the note's current keys).
+	const promise = plugin.controller.createNewYamlPropertyFluid(file, [], new Set(existingKeys));
+	const modal = await waitFor(".metaedit-fluid-create");
+	return {promise, modal};
+}
+
+function valueHost(modal) {
+	return modal.querySelector(".metaedit-fluid-create-value");
+}
+
+function pillLabel(modal) {
+	return modal.querySelector(".metaedit-fluid-create-type-label")?.textContent ?? null;
+}
+
+function addButton(modal) {
+	return Array.from(modal.querySelectorAll("button")).find((b) => b.textContent.trim() === "Add");
+}
+
+// Set the key via an input event only (no keyboard events, which would wedge the
+// transport). This exercises the validity/guard logic without settling the type.
+function setKeyText(modal, key) {
+	const input = modal.querySelector(".metaedit-fluid-create-key");
+	input.value = key;
+	input.dispatchEvent(new Event("input", {bubbles: true}));
+}
+
+function cancel(modal) {
+	Array.from(modal.querySelectorAll("button")).find((b) => b.textContent.trim() === "Cancel").click();
+}
+`;
+
+async function writeLiveFile(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	path: string,
+	content: string,
+): Promise<void> {
+	await evalJsonAsync<void>(
+		obsidian,
+		`
+		(async () => {
+			const path = ${JSON.stringify(path)};
+			const content = ${JSON.stringify(content)};
+			const existing = app.vault.getAbstractFileByPath(path);
+			if (existing) await app.vault.delete(existing);
+			await app.vault.create(path, content);
+			for (let i = 0; i < 40; i++) {
+				const cache = app.metadataCache.getFileCache(app.vault.getAbstractFileByPath(path));
+				if (cache) break;
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+		})()
+		`,
+	);
+}

--- a/tests/e2e/fluid-create.test.ts
+++ b/tests/e2e/fluid-create.test.ts
@@ -81,7 +81,7 @@ describe("MetaEdit fluid property creation", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
-	test("layout: the row never overflows horizontally and the key dropdown stays above the buttons", async () => {
+	test("layout: no horizontal overflow, compact height, and the floating dropdown never covers the buttons", async () => {
 		const {obsidian, sandbox} = getContext();
 		const notePath = sandbox.path("fluid-create-layout.md");
 		await writeLiveFile(obsidian, notePath, "---\n---\nbody\n");
@@ -90,10 +90,11 @@ describe("MetaEdit fluid property creation", () => {
 			modalOverflowX: boolean;
 			rowOverflowX: boolean;
 			hostRightWithinModal: boolean;
+			gapRowToButtons: number;
 			dropdownItems: number;
-			dropdownBottom: number;
-			addBtnTop: number;
-			modalBottom: number;
+			dropdownHeight: number;
+			coversAdd: boolean;
+			coversCancel: boolean;
 		}>(
 			obsidian,
 			`
@@ -107,11 +108,15 @@ describe("MetaEdit fluid property creation", () => {
 				const row = modal.querySelector(".metaedit-fluid-create-row");
 				const host = modal.querySelector(".metaedit-fluid-create-value");
 				const modalBox = modal.closest(".modal");
+				const add = Array.from(modal.querySelectorAll("button")).find(b => b.textContent.trim() === "Add");
+				const cancelBtn = Array.from(modal.querySelectorAll("button")).find(b => b.textContent.trim() === "Cancel");
+				const intersects = (a, c) => a.left < c.right && a.right > c.left && a.top < c.bottom && a.bottom > c.top;
 				const out = {
 					modalOverflowX: modal.scrollWidth > modal.clientWidth,
 					rowOverflowX: row.scrollWidth > row.clientWidth,
 					hostRightWithinModal: Math.round(host.getBoundingClientRect().right) <= Math.round(modalBox.getBoundingClientRect().right),
-					modalBottom: Math.round(modalBox.getBoundingClientRect().bottom),
+					// Compact: only a little breathing room between the row and the buttons (no reserved dead space).
+					gapRowToButtons: Math.round(add.getBoundingClientRect().top - row.getBoundingClientRect().bottom),
 				};
 				// Open the key dropdown with an input event only (no keyboard-to-selection).
 				const key = modal.querySelector(".metaedit-fluid-create-key");
@@ -120,10 +125,11 @@ describe("MetaEdit fluid property creation", () => {
 				key.dispatchEvent(new Event("input", {bubbles: true}));
 				await sleep(350);
 				const dd = document.querySelector(".suggestion-container.metaedit-fluid-create-suggest");
-				const add = Array.from(modal.querySelectorAll("button")).find(b => b.textContent.trim() === "Add");
 				out.dropdownItems = dd ? dd.querySelectorAll(".suggestion-item").length : 0;
-				out.dropdownBottom = dd ? Math.round(dd.getBoundingClientRect().bottom) : 0;
-				out.addBtnTop = Math.round(add.getBoundingClientRect().top);
+				out.dropdownHeight = dd ? Math.round(dd.getBoundingClientRect().height) : 0;
+				// 2D intersection: the floating dropdown must not visually cover either button.
+				out.coversAdd = dd ? intersects(dd.getBoundingClientRect(), add.getBoundingClientRect()) : true;
+				out.coversCancel = dd ? intersects(dd.getBoundingClientRect(), cancelBtn.getBoundingClientRect()) : true;
 				cancel(modal);
 				await promise;
 				document.querySelectorAll(".suggestion-container").forEach(e => e.remove());
@@ -135,9 +141,11 @@ describe("MetaEdit fluid property creation", () => {
 		expect(result.modalOverflowX).toBe(false);
 		expect(result.rowOverflowX).toBe(false);
 		expect(result.hostRightWithinModal).toBe(true);
+		expect(result.gapRowToButtons).toBeLessThan(80); // compact: no big reserved gap
 		expect(result.dropdownItems).toBeGreaterThan(0); // dropdown actually opened
-		expect(result.dropdownBottom).toBeLessThanOrEqual(result.addBtnTop); // never covers the buttons
-		expect(result.dropdownBottom).toBeLessThanOrEqual(result.modalBottom); // never spills below the modal
+		expect(result.dropdownHeight).toBeLessThanOrEqual(200); // capped (~6-7 rows + scroll)
+		expect(result.coversAdd).toBe(false); // floating dropdown never covers the buttons
+		expect(result.coversCancel).toBe(false);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 

--- a/tests/e2e/fluid-create.test.ts
+++ b/tests/e2e/fluid-create.test.ts
@@ -81,6 +81,66 @@ describe("MetaEdit fluid property creation", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("layout: the row never overflows horizontally and the key dropdown stays above the buttons", async () => {
+		const {obsidian, sandbox} = getContext();
+		const notePath = sandbox.path("fluid-create-layout.md");
+		await writeLiveFile(obsidian, notePath, "---\n---\nbody\n");
+
+		const result = await evalJsonAsync<{
+			modalOverflowX: boolean;
+			rowOverflowX: boolean;
+			hostRightWithinModal: boolean;
+			dropdownItems: number;
+			dropdownBottom: number;
+			addBtnTop: number;
+			modalBottom: number;
+		}>(
+			obsidian,
+			`
+			(async () => {
+				${FLUID_HELPERS}
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				const names = Array.from({length: 30}, (_, i) => "layoutProbeKey" + i);
+				const promise = plugin.controller.createNewYamlPropertyFluid(file, names, new Set());
+				const modal = await waitFor(".metaedit-fluid-create");
+				const row = modal.querySelector(".metaedit-fluid-create-row");
+				const host = modal.querySelector(".metaedit-fluid-create-value");
+				const modalBox = modal.closest(".modal");
+				const out = {
+					modalOverflowX: modal.scrollWidth > modal.clientWidth,
+					rowOverflowX: row.scrollWidth > row.clientWidth,
+					hostRightWithinModal: Math.round(host.getBoundingClientRect().right) <= Math.round(modalBox.getBoundingClientRect().right),
+					modalBottom: Math.round(modalBox.getBoundingClientRect().bottom),
+				};
+				// Open the key dropdown with an input event only (no keyboard-to-selection).
+				const key = modal.querySelector(".metaedit-fluid-create-key");
+				key.focus();
+				key.value = "layoutProbeKey";
+				key.dispatchEvent(new Event("input", {bubbles: true}));
+				await sleep(350);
+				const dd = document.querySelector(".suggestion-container.metaedit-fluid-create-suggest");
+				const add = Array.from(modal.querySelectorAll("button")).find(b => b.textContent.trim() === "Add");
+				out.dropdownItems = dd ? dd.querySelectorAll(".suggestion-item").length : 0;
+				out.dropdownBottom = dd ? Math.round(dd.getBoundingClientRect().bottom) : 0;
+				out.addBtnTop = Math.round(add.getBoundingClientRect().top);
+				cancel(modal);
+				await promise;
+				document.querySelectorAll(".suggestion-container").forEach(e => e.remove());
+				return out;
+			})()
+			`,
+		);
+
+		expect(result.modalOverflowX).toBe(false);
+		expect(result.rowOverflowX).toBe(false);
+		expect(result.hostRightWithinModal).toBe(true);
+		expect(result.dropdownItems).toBeGreaterThan(0); // dropdown actually opened
+		expect(result.dropdownBottom).toBeLessThanOrEqual(result.addBtnTop); // never covers the buttons
+		expect(result.dropdownBottom).toBeLessThanOrEqual(result.modalBottom); // never spills below the modal
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("the write path: chosen native type wins over EditMode, tags stay as-is, create-guard holds", async () => {
 		const {obsidian, sandbox} = getContext();
 		const notePath = sandbox.path("fluid-create-writepath.md");


### PR DESCRIPTION
## Fluid, type-aware YAML property creation

Creating a new YAML frontmatter property in MetaEdit was two bare, typeless text prompts (name, then value) - no type, no native widget, no `[[` suggestions. This PR makes creation feel fully Obsidian-native and **type-fluid**: you express a key (and optionally a type / value) and MetaEdit mounts Obsidian's real native widget for the right type, adapting smoothly.

Builds on #168's native-widget host and reuses the same write path + invariants (discriminated submit/cancel, fail-closed on no-onChange, stale/create-guard, serialized writes, reserved-key guard, per-type normalization, clean widget/portal teardown).

### Converged design: "Native creation row"
One keyboard-first modal cloning the *feel* of Obsidian's own add-property row:
- **Type pill** (left) → a MetaEdit-owned menu of Text / List / Number / Checkbox / Date / Date & time (`⌘/Ctrl+Y`).
- **Key input** (middle) with fuzzy known-name suggestions.
- **Adaptive value host** (right) mounting Obsidian's own native widget (real date picker, checkbox, number input, chip editor, `[[` link suggest).

**Fluid behaviors (verified live against `metadataTypeManager`):**
- A key the vault already knows auto-adopts its type with zero friction (`resolveCreationType` → `getTypeInfo(key).expected.type`, e.g. `due`→date, `priority`→number). A brand-new key defaults to `text`.
- Typing a value that unambiguously looks like a date/number/boolean offers a one-click **“Change to <Type>”** hint (promotion-only; never morphs under your caret).
- Switch type anytime; the widget re-mounts carrying your text across losslessly-or-empty (`seedFromRawText` - proven by test to only ever yield values `normalizeWidgetValue` accepts).
- `⌘/Ctrl+Enter` commits anywhere; plain Enter also commits in single-line inputs (number/date/datetime).

### Product decisions (steered by @chhoumann)
- **Value inference:** suggest-to-accept, shipped.
- **Type picker:** pill + dropdown menu.
- **EditMode:** the chosen native type owns list-vs-scalar - a typed scalar writes bare even under AllMulti/SomeMulti (functionality over legacy).
- **Type memory:** does **not** persist via `setType` - writes the value and lets Obsidian infer (no vault-wide side effect from single-note creation).

### Engineering
- Extract a shared `NativeWidgetHost` from #168's `NativePropertyPrompt` (used by both edit + create). Hardened for re-mounts: per-mount body-portal snapshot (a re-mount only cleans up *its* widget's popovers), and both edit-tracking flags reset per mount so the fail-closed guard always reasons about the current widget.
- New `FluidPropertyCreatePrompt` (the row UI) + controller `createNativeYamlProperty` (create-guard re-read; no EditMode wrap; no `setType`; tags written as-is so create == native edit).
- Auto Property keys hand off to the existing value flow; Dataview/inline creation keeps the legacy text path (inline fields are untyped/uncached).

### Design + review process
Converged via a design workflow (4 diverse candidates → 4 adversarial critiques → synthesis) plus an opposing-model (Codex) adversarial review of both the design and the implementation; all findings reconciled.

### Verification
- **Unit:** 376 pass, incl. exhaustive coverage of `resolveCreationType` / `inferCreationTypeFromText` / `seedFromRawText` / `emptyValueForType` (with the invariant that every seed is accepted by `normalizeWidgetValue`) and the `createNativeYamlProperty` write path (chosen-type-wins under AllMulti, falsy values, tags-as-is, create-guard).
- **E2E (isolated live Obsidian):** the create modal renders the default native widget + guards; the write path holds. The refactored **edit** path E2E still passes (behavior-preserving).
- **Live CLI DOM-state verification** (recorded, no popover driving): auto-adopt mounts the right widget for a vault-known key (`due`→date pill), values round-trip through the cache (`due: 2026-07-01`, `status: in-progress`, `related: [alpha]`), inference hint appears + accept carries the value, untouched checkbox commits `false`, `estimate: 5` stays a bare scalar under AllMulti, auto-property handoff + reserved guard fire, zero leaked modals/popovers/body-nodes, no runtime errors.
- `pnpm lint` / `build` / `test` all green.

> Note on E2E scope: driving the modal via synthetic keyboard events or a native popover deadlocks the obsidian-e2e package transport (the same class of issue that `test.skip`s the wikilink test), so the CI E2E is intentionally light + button/`input`-driven; the keyboard-driven paths are covered by unit tests + the live CLI verification above.

---

**Status: ready for review, PAUSED for @chhoumann's review + manual verification.** Please don't expect me to self-merge; no release triggered; no community issues touched.

### Progress
- [x] Pure-logic seams + unit tests
- [x] Extract `NativeWidgetHost`; refactor `NativePropertyPrompt` (behavior-preserving, verified)
- [x] `FluidPropertyCreatePrompt` + controller write path + suggester wiring + CSS
- [x] Unit + live DOM-state E2E verification; lint/build/test green
