### PR TITLE
fix(ui): give the property rows breathing room inside the focus ring

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -89,11 +89,16 @@
     min-width: min(520px, 88vw);
 }
 
+/* Obsidian's .metadata-property:focus-within ring wraps the whole row (pill +
+   value) with no inner padding of its own, so give the composite breathing room
+   - otherwise the pill's rounded background collides with the ring's corner and
+   wrapped chips sit flush against it. Same treatment as the create row. */
 .metaedit-native-property-row {
     display: flex;
     align-items: flex-start;
     gap: 8px;
     margin: 12px 0;
+    padding: 4px;
 }
 
 .metaedit-native-property-host {
@@ -139,6 +144,7 @@
     gap: 8px;
     flex-wrap: nowrap;
     margin: 16px 0 6px;
+    padding: 4px;
 }
 
 /* The type pill shared by the fluid create modal and the native edit prompt. */


### PR DESCRIPTION
Follow-up to #173, from a spacing report: with the value editor focused, Obsidian's `.metadata-property:focus-within` ring wraps the whole composite row (type pill + value) with zero inner padding, so the pill's rounded background collided with the ring's corner and wrapped chips sat flush against the ring.

CSS-only: 4px padding on `.metaedit-native-property-row` and `.metaedit-fluid-create-row` (the create row shared the latent issue).

**Before** (list property with wrapped chips, chip input focused):
the pill's corner overlaps the ring's corner; chips touch the ring.

**After:** pill and chips sit 4px inside the ring; single-line text edit and the create modal verified unaffected (screenshots taken in the live dev vault, light theme; the change is padding-only so themes are unaffected).

Verification: reproduced the reported state live (two-chip list property, focused chip editor), applied the fix, re-verified visually across the wrapped-chip edit modal, single-line text edit modal, and the fluid create modal. `pnpm run lint`, `build`, `test` green (CSS-only change; `styles.css` is a hand-written release asset).