### PR TITLE
fix(e2e): call local obsidian-e2e bin directly in Orca archive hook

### DIFF
--- a/orca.yaml
+++ b/orca.yaml
@@ -19,10 +19,13 @@
 #   --profile-root, stop it with the matching
 #   `pnpm run stop:e2e-obsidian -- --vault <name> [--profile-root <path>]` before
 #   removing the worktree.
-# - The hook runs the teardown through `pnpm exec`, so it needs `pnpm` on the
-#   GUI app's PATH (Orca runs it via non-login /bin/bash). It is guarded with
-#   `command -v pnpm` so a missing pnpm degrades to a no-op (the
+# - The hook invokes this worktree's local runner bin directly
+#   (node_modules/.bin/obsidian-e2e) rather than via `pnpm exec`, so it needs
+#   only `node` on the GUI app's PATH - not pnpm, whose corepack/shell-startup
+#   shim is often absent in Orca's non-login /bin/bash. The bin is a POSIX-sh
+#   launcher that resolves its own module paths and execs node. It is guarded
+#   with `command -v node` so a missing node degrades to a no-op (the
 #   reap-on-next-start safety net then handles cleanup) instead of erroring.
 scripts:
   archive: |
-    command -v pnpm >/dev/null 2>&1 && pnpm exec obsidian-e2e stop --worktree "$ORCA_WORKTREE_PATH" || true
+    command -v node >/dev/null 2>&1 && "$ORCA_WORKTREE_PATH/node_modules/.bin/obsidian-e2e" stop --worktree "$ORCA_WORKTREE_PATH" || true


### PR DESCRIPTION
## Summary

Follow-up to #177 (already merged). The Orca `archive` teardown hook guards on `command -v node` but invoked the runner via `pnpm exec obsidian-e2e stop`. In Orca's non-login GUI PATH (`/bin/bash`, no login shell), pnpm's corepack/shell-startup shim is often absent, so the `stop` command fails with `pnpm: command not found` and `|| true` swallows it - leaking the worktree's Obsidian process tree and `/private/tmp` profile.

This calls the worktree's local launcher directly:

```
command -v node >/dev/null 2>&1 && "$ORCA_WORKTREE_PATH/node_modules/.bin/obsidian-e2e" stop --worktree "$ORCA_WORKTREE_PATH" || true
```

`node_modules/.bin/obsidian-e2e` is a POSIX-sh launcher (`#!/bin/sh`) that resolves its own module paths and execs node, so it needs only `node` on PATH - which the existing guard already checks. This matches the fix QuickAdd landed in `ca29a8a7`.

### Why this supersedes #177's approach
#177 changed the guard to `command -v pnpm`. That is still wrong for the real environment: when pnpm is absent (the actual Orca case), the guard fails and teardown degrades to a no-op, so the instance still leaks. Guarding on node and calling the bin directly actually runs the teardown.

## Verification
`env -i` invocation with a node-only PATH (pnpm absent), simulating Orca's non-login GUI shell:

- Old form: `sh: pnpm: command not found`, exit `127` (would leak under `|| true`).
- New form: exit `0`, and it performed real teardown: `Stopped instance /tmp/metaedit-obsidian-e2e/metaedit-metaedit-...: terminated 0, killed 0, removed.`

Local gates: `pnpm run lint` clean, `pnpm run test` 355 passed, `pnpm run build` ok, `pnpm run typecheck` 0 errors. Only `orca.yaml` changed.

## Release/migration impact
None. Dev/CI-adjacent tooling only; no plugin runtime, settings, storage, or API changes.