### PR TITLE
chore(e2e): adopt shared createPluginHarness

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-svelte": "^3.20.0",
     "globals": "^17.7.0",
     "obsidian": "1.13.1",
-    "obsidian-e2e": "file:/Users/christian/Developer/obsidian-e2e",
+    "obsidian-e2e": "^0.8.1",
     "semantic-release": "^25.0.5",
     "svelte": "^5.56.4",
     "svelte-check": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-svelte": "^3.20.0",
     "globals": "^17.7.0",
     "obsidian": "1.13.1",
-    "obsidian-e2e": "^0.7.0",
+    "obsidian-e2e": "file:/Users/christian/Developer/obsidian-e2e",
     "semantic-release": "^25.0.5",
     "svelte": "^5.56.4",
     "svelte-check": "^4.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 1.13.1
         version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       obsidian-e2e:
-        specifier: file:/Users/christian/Developer/obsidian-e2e
-        version: file:../obsidian-e2e(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.9)
+        specifier: ^0.8.1
+        version: 0.8.1(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.9)
       semantic-release:
         specifier: ^25.0.5
         version: 25.0.5(typescript@6.0.3)
@@ -3131,8 +3131,8 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  obsidian-e2e@file:../obsidian-e2e:
-    resolution: {directory: ../obsidian-e2e, type: directory}
+  obsidian-e2e@0.8.1:
+    resolution: {integrity: sha512-tcIjZtGxeI5wkOMGAlSWRyEfxIG/nN9834gWgb3l92R41h0fTre8wG05KUamFkk0Lj2I1ibfN+njOIjo2WCftQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -7316,7 +7316,7 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
-  obsidian-e2e@file:../obsidian-e2e(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.9):
+  obsidian-e2e@0.8.1(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.9):
     dependencies:
       vite-plus: 0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0)
       yaml: 2.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 1.13.1
         version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       obsidian-e2e:
-        specifier: ^0.7.0
-        version: 0.7.0(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0))
+        specifier: file:/Users/christian/Developer/obsidian-e2e
+        version: file:../obsidian-e2e(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.9)
       semantic-release:
         specifier: ^25.0.5
         version: 25.0.5(typescript@6.0.3)
@@ -3131,12 +3131,16 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  obsidian-e2e@0.7.0:
-    resolution: {integrity: sha512-qbYMFRU9UgbOhH8OPwnX+gCR55IvLTmrWxyUlTFH52wfTknCtaj28/t2s3aHux10byvh61ElBH04cKqfvbReyA==}
+  obsidian-e2e@file:../obsidian-e2e:
+    resolution: {directory: ../obsidian-e2e, type: directory}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       vite-plus: ^0.1.11
+      vitest: '>=3'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
 
   obsidian@1.13.1:
     resolution: {integrity: sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==}
@@ -7312,10 +7316,12 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
-  obsidian-e2e@0.7.0(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0)):
+  obsidian-e2e@file:../obsidian-e2e(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.9):
     dependencies:
       vite-plus: 0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))(yaml@2.9.0)
       yaml: 2.9.0
+    optionalDependencies:
+      vitest: 4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.2)(yaml@2.9.0))
 
   obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
     dependencies:

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -1,282 +1,53 @@
-import { readlink } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import {
-	acquireVaultRunLock,
-	captureFailureArtifacts,
-	clearVaultRunLockMarker,
-	createObsidianClient,
-	createSandboxApi,
-	type ObsidianClient,
-	type PluginHandle,
-	type PluginReloadOptions,
-	type SandboxApi,
-	type VaultRunLock,
-} from "obsidian-e2e";
-import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+import { type ObsidianClient, resolveObsidianEnvOptions } from "obsidian-e2e";
+import { createPluginHarness } from "obsidian-e2e/vitest";
 
 export const PLUGIN_ID = "metaedit";
-// Canonical OBSIDIAN_E2E_* names are emitted by the shared obsidian-e2e runner;
-// the legacy METAEDIT_E2E_* aliases remain a fallback during the migration.
-export const E2E_VAULT =
-	process.env.OBSIDIAN_E2E_VAULT ?? process.env.METAEDIT_E2E_VAULT ?? "dev";
-export const E2E_BIN = process.env.OBSIDIAN_BIN ?? "obsidian";
-// styles.css is a hand-written release asset shipped alongside main.js, so the
-// provisioned vault symlinks all three artifacts.
-export const PLUGIN_ARTIFACTS = ["main.js", "manifest.json", "styles.css"];
+// Reused by tests for sandbox content polling; also the harness reload interval.
 export const WAIT_OPTS = { timeoutMs: 15_000, intervalMs: 200 };
-export const RELOAD_OPTIONS: PluginReloadOptions = {
-	waitUntilReady: true,
-	timeoutMs: 30_000,
-	readyOptions: {
+
+/**
+ * Suite-scoped MetaEdit E2E harness built on obsidian-e2e's shared
+ * `createPluginHarness`: one vault lock + sandbox + reload per file, per-test
+ * diagnostics reset and data restore, failure-artifact capture, and the dev
+ * vault symlink preflight. Returns the `(testName) => () => context` getter the
+ * test bodies already consume.
+ *
+ * Canonical `OBSIDIAN_E2E_*` env is emitted by the shared runner; the legacy
+ * `METAEDIT_E2E_*` aliases remain a fallback during the migration.
+ */
+export const createMetaEditE2EHarness = createPluginHarness({
+	...resolveObsidianEnvOptions({ legacyPrefix: "METAEDIT" }),
+	pluginId: PLUGIN_ID,
+	reload: {
 		// Plugin-ready sentinel: a command MetaEdit always registers in onload()
 		// (`metaEditRun`). The dev-only `reloadMetaEdit` command is stripped from
 		// production bundles (START.DEVCMD/END.DEVCMD), so it must not be used here.
-		commandId: `${PLUGIN_ID}:metaEditRun`,
-		...WAIT_OPTS,
+		readyCommandId: `${PLUGIN_ID}:metaEditRun`,
+		timeoutMs: 30_000,
+		intervalMs: WAIT_OPTS.intervalMs,
 	},
-};
+	// MetaEdit exposes its public API on the plugin instance in onload()
+	// (`this.api = new MetaEditApi(this).make()`), the most precise signal that
+	// the plugin finished loading.
+	waitUntilReady: (obsidian) =>
+		obsidian.dev.evalJson<boolean>(
+			`Boolean(app.plugins.plugins.${PLUGIN_ID}?.api)`,
+		),
+	// styles.css is a hand-written release asset shipped alongside main.js, so the
+	// provisioned dev vault symlinks all three artifacts.
+	symlinkArtifacts: ["main.js", "manifest.json", "styles.css"],
+	captureOnFailure: true,
+});
 
-type HarnessState = {
-	lock?: VaultRunLock;
-	obsidian?: ObsidianClient;
-	plugin?: PluginHandle;
-	sandbox?: SandboxApi;
-};
-
-export type MetaEditE2EContext = {
-	obsidian: ObsidianClient;
-	plugin: PluginHandle;
-	sandbox: SandboxApi;
-};
-
-const repoRoot = path.resolve(
-	path.dirname(fileURLToPath(import.meta.url)),
-	"..",
-	"..",
-);
-
-export function createMetaEditE2EHarness(testName: string) {
-	const state: HarnessState = {};
-
-	beforeAll(async () => {
-		state.obsidian = createObsidianClient({
-			vault: E2E_VAULT,
-			bin: E2E_BIN,
-			timeoutMs: 20_000,
-			intervalMs: 200,
-		});
-		await state.obsidian.verify();
-
-		state.lock = await acquireVaultRunLock({
-			vaultName: E2E_VAULT,
-			vaultPath: await state.obsidian.vaultPath(),
-			onBusy: "wait",
-			timeoutMs: 60_000,
-		});
-		await state.lock.publishMarker(state.obsidian);
-
-		await assertDevVaultSymlinks(await state.obsidian.vaultPath());
-
-		state.plugin = state.obsidian.plugin(PLUGIN_ID);
-		state.sandbox = await createSandboxApi({
-			obsidian: state.obsidian,
-			sandboxRoot: "__obsidian_e2e__",
-			testName,
-		});
-
-		await state.obsidian.dev.resetDiagnostics().catch(() => undefined);
-		await reloadMetaEdit(state.plugin, state.obsidian);
-	}, 90_000);
-
-	beforeEach((ctx) => {
-		ctx.onTestFailed(async () => {
-			if (!state.obsidian) return;
-
-			await captureFailureArtifacts(
-				{ id: ctx.task.id, name: ctx.task.name },
-				state.obsidian,
-				{
-					captureOnFailure: true,
-					plugin: state.plugin,
-				},
-			).catch((error) => {
-				console.warn("MetaEdit E2E artifact capture failed", error);
-			});
-		});
-	});
-
-	beforeEach(async () => {
-		await state.obsidian?.dev.resetDiagnostics().catch(() => undefined);
-	});
-
-	afterEach(async () => {
-		if (!state.plugin || !state.obsidian) return;
-
-		await restoreMetaEditData(state.plugin, state.obsidian);
-	});
-
-	afterAll(async () => {
-		const errors: unknown[] = [];
-
-		await runTeardown("restore plugin data", errors, () => {
-			if (!state.plugin || !state.obsidian) return undefined;
-			return restoreMetaEditData(state.plugin, state.obsidian);
-		});
-		await runTeardown("clean sandbox", errors, () => state.sandbox?.cleanup());
-		await runTeardown("clear vault lock marker", errors, () => {
-			if (!state.obsidian) return undefined;
-			return clearVaultRunLockMarker(state.obsidian);
-		});
-		await runTeardown("release vault lock", errors, () =>
-			state.lock?.release(),
-		);
-
-		if (errors.length > 0) {
-			throw errors[0];
-		}
-	}, 30_000);
-
-	return (): MetaEditE2EContext => {
-		if (!state.obsidian || !state.plugin || !state.sandbox) {
-			throw new Error("MetaEdit E2E harness is not initialized.");
-		}
-
-		return {
-			obsidian: state.obsidian,
-			plugin: state.plugin,
-			sandbox: state.sandbox,
-		};
-	};
-}
-
-export async function reloadMetaEdit(
-	plugin: PluginHandle,
-	obsidian: ObsidianClient,
-): Promise<void> {
-	await plugin.reload(RELOAD_OPTIONS);
-	await waitForMetaEditReady(obsidian);
-}
-
-export async function restoreMetaEditData(
-	plugin: PluginHandle,
-	obsidian: ObsidianClient,
-): Promise<void> {
-	await plugin.disable();
-	await plugin.restoreData();
-	await plugin.enable();
-	await waitForMetaEditReady(obsidian);
-}
-
-export async function waitForMetaEditReady(
-	obsidian: ObsidianClient,
-): Promise<void> {
-	await obsidian.waitFor(
-		async () => {
-			// MetaEdit exposes its public API on the plugin instance in onload()
-			// (`this.api = new MetaEditApi(this).make()`), which is the most precise
-			// signal that the plugin finished loading.
-			return await obsidian.dev.evalJson<boolean>(
-				`Boolean(app.plugins.plugins.${PLUGIN_ID}?.api)`,
-			);
-		},
-		{
-			...WAIT_OPTS,
-			message: "MetaEdit plugin did not become ready.",
-		},
-	);
-}
-
-type AsyncEvalEnvelope<T> =
-	| { ok: true; value: T }
-	| { error: { message: string; stack?: string }; ok: false };
-
-export async function evalJsonAsync<T>(
+/**
+ * Evaluate an async body in the Obsidian runtime and decode the JSON result,
+ * rethrowing remote failures (as `DevEvalError`) with their message and stack.
+ * Thin adapter over the package's `obsidian.dev.evalJsonAsync` that keeps the
+ * `(obsidian, code)` call shape the test bodies use.
+ */
+export function evalJsonAsync<T>(
 	obsidian: ObsidianClient,
 	code: string,
 ): Promise<T> {
-	const envelope = await obsidian.dev.eval<AsyncEvalEnvelope<T>>(`
-		(async () => {
-			const code = ${JSON.stringify(code)};
-			try {
-				const value = await (0, eval)(code);
-				return JSON.stringify({ ok: true, value });
-			} catch (error) {
-				return JSON.stringify({
-					ok: false,
-					error: {
-						message: error instanceof Error ? error.message : String(error),
-						stack: error instanceof Error ? error.stack : undefined,
-					},
-				});
-			}
-		})()
-	`);
-
-	if (!envelope.ok) {
-		throw new Error(
-			[
-				`Failed to evaluate async Obsidian code: ${envelope.error.message}`,
-				envelope.error.stack ?? "",
-			]
-				.filter(Boolean)
-				.join("\n"),
-		);
-	}
-
-	return envelope.value;
-}
-
-async function assertDevVaultSymlinks(vaultPath: string): Promise<void> {
-	const pluginDir = path.join(vaultPath, ".obsidian", "plugins", PLUGIN_ID);
-
-	for (const fileName of PLUGIN_ARTIFACTS) {
-		await assertSymlinkTarget(pluginDir, fileName);
-	}
-}
-
-async function assertSymlinkTarget(
-	pluginDir: string,
-	fileName: string,
-): Promise<void> {
-	const linkPath = path.join(pluginDir, fileName);
-	const expected = path.join(repoRoot, fileName);
-	let target: string;
-
-	try {
-		target = await readlink(linkPath);
-	} catch (error) {
-		throw new Error(
-			[
-				"MetaEdit E2E preflight failed.",
-				`Expected ${linkPath} to be a symlink to ${expected}.`,
-				`Could not read symlink: ${error instanceof Error ? error.message : String(error)}`,
-			].join(" "),
-		);
-	}
-
-	const resolvedTarget = path.resolve(path.dirname(linkPath), target);
-	if (resolvedTarget !== expected) {
-		throw new Error(
-			[
-				"MetaEdit E2E preflight failed.",
-				`Expected ${linkPath} to point at ${expected}.`,
-				`It currently points at ${resolvedTarget}.`,
-				"Repoint the vault plugin symlink intentionally before running pnpm run test:e2e.",
-			].join(" "),
-		);
-	}
-}
-
-async function runTeardown(
-	label: string,
-	errors: unknown[],
-	step: () => Promise<unknown> | unknown,
-): Promise<void> {
-	try {
-		await step();
-	} catch (error) {
-		errors.push(error);
-		console.warn(`MetaEdit E2E teardown failed during ${label}`, error);
-	}
+	return obsidian.dev.evalJsonAsync<T>(code);
 }


### PR DESCRIPTION
## What

Replaces the hand-rolled `tests/e2e/harness.ts` (~279 lines) with obsidian-e2e's shared `createPluginHarness`. The file drops to ~55 lines:

```ts
export const createMetaEditE2EHarness = createPluginHarness({
  ...resolveObsidianEnvOptions({ legacyPrefix: "METAEDIT" }),
  pluginId: "metaedit",
  reload: { readyCommandId: "metaedit:metaEditRun", timeoutMs: 30_000, intervalMs: 200 },
  waitUntilReady: (obsidian) => obsidian.dev.evalJson<boolean>(`Boolean(app.plugins.plugins.metaedit?.api)`),
  symlinkArtifacts: ["main.js", "manifest.json", "styles.css"],
  captureOnFailure: true,
});
```

All the suite lifecycle the harness used to hand-roll - worker vault lock + marker, per-test sandbox, plugin reload with the `metaEditRun` ready sentinel, `data.json` disable/restore/enable/re-ready, failure-artifact capture, dev-vault symlink preflight, error-aggregating teardown - now comes from the package fixture. The local `evalJsonAsync` envelope is replaced by a thin adapter over the package's `obsidian.dev.evalJsonAsync` (which rethrows a `DevEvalError` carrying the remote message + stack). Env resolution (canonical `OBSIDIAN_E2E_*` + legacy `METAEDIT_E2E_*` fallback, per-client HOME injection) comes from `resolveObsidianEnvOptions`.

Net: **+42 / -271** on `tests/e2e/harness.ts`. Test bodies are untouched - every export the tests consume (`createMetaEditE2EHarness`, `evalJsonAsync`, `PLUGIN_ID`, `WAIT_OPTS`) is preserved.

## Why

metaedit, podnotes, and quickadd each hand-rolled a byte-similar suite lifecycle and an identical `evalJsonAsync`. The package now provides that plus env resolution, so the per-repo plumbing collapses. This is the canary consumer for the new fixtures.

## Live validation

Ran the full e2e suite (16 files) against an isolated Obsidian 1.13.0 instance. The harness lifecycle works: **86/103 tests pass**. The remaining failures are pre-existing modal/suggester UI flakiness (`DevEvalError: Timed out waiting for .suggestion-item` / `.metaEditPromptInput`) plus a plugin-logger `MetaEdit:` prefix polluting eval stdout - **verified identical under the old hand-rolled harness on the same instance** (e.g. `multi-value` fails 7/8 the same way both before and after). `native-properties` / `fluid-create` / `audit-repro` pass on a fresh instance; their full-run failures were instance degradation over the ~9-minute run, not the harness. Unit suite (355), lint, and typecheck are green.

## Dependency

Canary of the new `createPluginHarness`. It surfaced a bug in the published obsidian-e2e@0.8.0 (harness hooks bound to `vite-plus/test` instead of the consumer's `vitest`, so every e2e file died at collection); fixed in obsidian-e2e#14 and released as **0.8.1**. This PR pins `^0.8.1`, which is what all the validation above ran against.

No em-dashes.