### PR TITLE
ci(release): bump shared pipeline to v3

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -40,7 +40,7 @@ jobs:
         permissions:
             contents: write
             pull-requests: write
-        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@v2
+        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@v3
         with:
             plugin-name: metaedit
             package-manager: pnpm
@@ -49,7 +49,7 @@ jobs:
             target-sha: ${{ github.event.workflow_run.head_sha || inputs.targetSha }}
             release-bot-app-slug: metaedit-release-bot
             app-id: ${{ vars.RELEASE_APP_ID }}
-            workflows-ref: v2
+            workflows-ref: v3
             # dry-run: true   # plan only; skip opening the PR (smoke test)
         secrets:
             release-app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -28,7 +28,7 @@ jobs:
             actions: write
             contents: write
             pull-requests: read
-        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@v2
+        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@v3
         with:
             pr-number: ${{ github.event.pull_request.number }}
             plugin-name: metaedit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             contents: write
             id-token: write
             pull-requests: read
-        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@v2
+        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@v3
         with:
             release-pr: ${{ inputs.releasePr }}
             plugin-name: metaedit
@@ -43,7 +43,7 @@ jobs:
                 pnpm run lint
                 pnpm run typecheck
                 pnpm run test
-            workflows-ref: v2
+            workflows-ref: v3
         secrets:
             # Optional: unset secrets resolve to '' and the notify job skips them.
             slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## What

Bumps the shared release-pipeline pins in the three release caller stubs
(`release-prepare.yml`, `release-trigger.yml`, `release.yml`) from `v2` to the
new `v3` tag of
[`chhoumann/obsidian-plugin-workflows`](https://github.com/chhoumann/obsidian-plugin-workflows)
(v3 = `8471ad7827fcee306ac2b8c10e984e57aeefe7df`).

## Why - what v3 brings

- **feat!**: stop cutting releases for chore-only commits
- **fix**: handle bare release merge subjects
- **fix**: retry the tag-verify read after `createRef`, closing the tag-verify
  replication race that hit 2 of the first 3 production releases

## Behavior change

A commit range containing only `chore` commits will no longer produce a standing
release PR. This is intended - see
[chhoumann/obsidian-plugin-workflows#4](https://github.com/chhoumann/obsidian-plugin-workflows/issues/4).

## Validation

- YAML parses (PyYAML `safe_load`)
- `actionlint` clean on all three stubs

The `ci` / `codeql` / `dependency-review` / `pr-title` callers pin `@v1` (advanced
in place) and are intentionally left unchanged.